### PR TITLE
chore: add files field to @qulib/core for clean npm publish

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,11 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": [
+    "dist",
+    "bin",
+    "README.md"
+  ],
   "bin": {
     "qulib": "./bin/qulib.js"
   },


### PR DESCRIPTION
Adds explicit `files` (`dist`, `bin`, `README.md`) so `npm publish` does not ship `src/`, `tsconfig.json`, or config samples.

Made with [Cursor](https://cursor.com)