### PR TITLE
chore: publish-readiness — README polish and dry-run verification

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,54 @@
 # @qulib/core
 
-**Qulib** core package on npm (`@qulib/core`): TypeScript-first QA harness for deployed apps and optional repo scans.
+**@qulib/core** is the TypeScript-first Qulib package for analyzing deployed web apps (and optionally a local repo) and surfacing honest quality gaps.
+
+## Install
+
+```bash
+npm install @qulib/core
+```
+
+## CLI (from npm)
+
+```bash
+npx @qulib/core analyze --url https://example.com
+```
+
+Use `npx playwright install chromium` the first time you scan (Playwright is a dependency).
+
+## Programmatic API
+
+```ts
+import { analyzeApp, type HarnessConfig } from '@qulib/core';
+
+const config: HarnessConfig = {
+  maxPagesToScan: 20,
+  maxDepth: 3,
+  minPagesForConfidence: 3,
+  timeoutMs: 30000,
+  retryCount: 2,
+  llmTokenBudget: 4000,
+  testGenerationLimit: 10,
+  readOnlyMode: true,
+  requireHumanReview: true,
+  failOnConsoleError: false,
+  explorer: 'playwright',
+  defaultAdapter: 'playwright',
+  adapters: ['playwright', 'cypress-e2e'],
+};
+
+const result = await analyzeApp({
+  url: 'https://example.com',
+  config,
+  writeArtifacts: false,
+});
+
+console.log(result.releaseConfidence, result.gapAnalysis);
+```
+
+## Repository
+
+Source and issues: **[github.com/TapeshN/qulib](https://github.com/TapeshN/qulib)**.
 
 ## Monorepo context
 
@@ -95,10 +143,4 @@ npx playwright install chromium
 - `.scan-state/discovered-routes.json`, `gap-analysis.json`, `decision-log.json`, and `repo-inventory.json` when `--repo` is set
 - `output/report.json`, `output/report.md`
 
-## Programmatic API
-
-```ts
-import { analyzeApp } from '@qulib/core';
-```
-
-Use `writeArtifacts: false` for stateless runs (same path as MCP). See `src/analyze.ts`.
+For more options (`repoPath`, loading config from disk), see `src/analyze.ts` in the repository.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # @qulib/mcp
 
-**Qulib** on npm as `@qulib/mcp`: MCP server so AI agents can analyze deployed web apps for quality gaps (CLI entry `qulib-mcp`).
+**@qulib/mcp** is an MCP server that exposes Qulib so AI clients can analyze a deployed URL for release confidence, accessibility, broken links, console noise, and prioritized gaps (CLI entry `qulib-mcp`).
 
 ## What it does
 
@@ -18,7 +18,13 @@ Supports optional form-login auth for scanning authenticated pages.
 
 ## Install for Claude Code
 
-Add to your MCP config:
+```bash
+claude mcp add qulib --scope user npx -y @qulib/mcp
+```
+
+## Install for Claude Desktop / Cursor
+
+Add this under `mcpServers` in `claude_desktop_config.json` (Claude Desktop) or your editor MCP settings (Cursor), adjusting paths if your client uses a different layout:
 
 ```json
 {
@@ -30,10 +36,6 @@ Add to your MCP config:
   }
 }
 ```
-
-## Install for Claude Desktop
-
-Same config, in `claude_desktop_config.json`.
 
 ## Example usage
 
@@ -48,6 +50,14 @@ Claude will call `analyze_app({ url: "https://example.com" })` and reason about 
 > "Use Qulib to scan my staging app at https://staging.example.com. Log in as user@example.com with password Test123, the login form is at /login with selectors [data-testid='email'], [data-testid='password'], and [data-testid='submit']."
 
 Claude will pass auth credentials to the tool; Qulib signs in, then scans.
+
+## Known limitations
+
+In **v0.1.0**, link discovery and route expansion from the entry URL are **shallow** compared to full multi-site crawling. Broader multi-page coverage is planned for **0.1.1**; treat low page counts in the output as a signal that the scan may not represent the whole app yet.
+
+## Repository
+
+Source and issues: **[github.com/TapeshN/qulib](https://github.com/TapeshN/qulib)**.
 
 ## License
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -18,6 +18,7 @@
   },
   "type": "module",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "bin": {
     "qulib-mcp": "./dist/index.js"
   },

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -9,7 +9,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "types": ["node"],
-    "isolatedModules": true
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["./dist", "./node_modules"]


### PR DESCRIPTION
Merges npm README updates for `@qulib/core` and `@qulib/mcp`, MCP declaration emit (`tsconfig` + `types` field), and dry-run verified publish tarballs.

Made with [Cursor](https://cursor.com)