### PR TITLE
chore: add root package repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
   "name": "qulib-monorepo",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TapeshN/qulib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/TapeshN/qulib/issues"
+  },
+  "homepage": "https://github.com/TapeshN/qulib#readme",
   "type": "module",
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Adds `repository`, `bugs`, and `homepage` to the root `package.json` with lowercase `TapeshN/qulib` URLs, matching workspace packages. Replaces the stale `chore/repo-url-casing` tip that predated recent merges.

Made with [Cursor](https://cursor.com)