### PR TITLE
fix(explorer): same-site link discovery for www vs apex hostnames

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ qulib/
 
 If you want to help but aren't sure where to start:
 
-- Improve multi-page crawling (link extraction is shallow in v0.1.0 — see Known limitations in [packages/mcp/README.md](./packages/mcp/README.md))
+- Improve crawl coverage (e.g. sitemap seeds, deeper authenticated expansion — see Known limitations in [packages/mcp/README.md](./packages/mcp/README.md))
 - Add new gap detection rules (e.g., missing page titles, oversized images, missing meta tags)
 - Add integration with another scanner (Lighthouse, Pa11y, axe DevTools Pro)
 - Improve docs or add usage examples

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -92,7 +92,7 @@ Default file: **`qulib.config.ts`** in this package directory (or pass **`--conf
 
 Optional `auth` for authenticated scanning — see commented example in `qulib.config.ts`. For local credentials, use a separate file (e.g. `qulib.test-auth.config.ts`, gitignored at the repo root) and point `--config` at it.
 
-Use the same **origin** for `--url` as the app uses after login so same-origin links are discovered during the crawl.
+Use the same **hostname** for `--url` as your app’s canonical host when you can. The crawler treats **`www` and apex** (e.g. `example.com` and `www.example.com`) as the same site for internal link discovery, so hydration and redirects still queue in-site URLs.
 
 ## Scripts (from `packages/core`)
 

--- a/packages/core/src/tools/playwright-explorer.ts
+++ b/packages/core/src/tools/playwright-explorer.ts
@@ -5,6 +5,20 @@ import { createAuthenticatedContext } from './auth.js';
 import { RouteInventorySchema, type RouteInventory, type Route } from '../schemas/route-inventory.schema.js';
 import type { HarnessConfig } from '../schemas/config.schema.js';
 
+function crawlHostKey(hostname: string): string {
+  return hostname.replace(/^www\./i, '').toLowerCase();
+}
+
+function isInternalHref(href: string, baseUrlStr: string): boolean {
+  try {
+    const u = new URL(href);
+    const base = new URL(baseUrlStr);
+    return u.protocol === base.protocol && crawlHostKey(u.hostname) === crawlHostKey(base.hostname);
+  } catch {
+    return false;
+  }
+}
+
 export class PlaywrightExplorer implements AppExplorer {
   async explore(baseUrl: string, config: HarnessConfig): Promise<RouteInventory> {
     const browser = await chromium.launch({ headless: true });
@@ -69,16 +83,8 @@ export class PlaywrightExplorer implements AppExplorer {
               .filter(Boolean)
           );
 
-          const base = new URL(baseUrl);
           const internalLinks = hrefs
-            .filter((href) => {
-              try {
-                const u = new URL(href);
-                return u.origin === base.origin;
-              } catch {
-                return false;
-              }
-            })
+            .filter((href) => isInternalHref(href, baseUrl))
             .map((href) => href.split('?')[0].split('#')[0]);
 
           const uniqueInternal = [...new Set(internalLinks)];

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -53,7 +53,7 @@ Claude will pass auth credentials to the tool; Qulib signs in, then scans.
 
 ## Known limitations
 
-In **v0.1.0**, link discovery and route expansion from the entry URL are **shallow** compared to full multi-site crawling. Broader multi-page coverage is planned for **0.1.1**; treat low page counts in the output as a signal that the scan may not represent the whole app yet.
+Qulib discovers routes by following **same-site** links from pages it visits; it is not a full multi-site crawler (no sitemap-first mode, no unbounded domain expansion). Treat the route list as a sample of what was reachable within `maxPagesToScan` and `maxDepth`.
 
 ## Repository
 


### PR DESCRIPTION
## Summary
Restores multi-page crawling when the crawl seed uses the apex host (e.g. `notquality.com`) but resolved `<a href>` targets use `www` (or the reverse). Internal links are filtered by protocol plus hostname with a leading `www.` stripped.

## Test plan
- [ ] `cd packages/core && node bin/qulib.js analyze --url https://notquality.com --ephemeral` — expect multiple routes and non-empty `links` on `/`


Made with [Cursor](https://cursor.com)