### PR TITLE
feat: auth detection + qulib auth init

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,6 +8,55 @@
 npm install @qulib/core
 ```
 
+## Scanning authenticated apps
+
+Qulib supports three auth modes: anonymous (default), form-login, and storage-state.
+
+### Form login
+
+If your app uses a simple username/password form:
+
+```bash
+qulib analyze --url https://app.example.com \
+  --auth-form-login \
+  --login-url https://app.example.com/login \
+  --username you@example.com \
+  --password "..." \
+  --username-selector "input[name=email]" \
+  --password-selector "input[name=password]" \
+  --submit-selector "button[type=submit]"
+```
+
+### OAuth, magic link, SSO, or anything else
+
+These can't be automated. Qulib has a helper for this:
+
+```bash
+qulib auth init --base-url https://app.example.com
+```
+
+This opens a real browser. Log in normally (OAuth, magic link, password manager, whatever). Press ENTER in the terminal when you reach a logged-in page. Qulib saves your session to `qulib-storage-state.json`.
+
+Then scan with it:
+
+```bash
+qulib analyze --url https://app.example.com --auth-storage-state ./qulib-storage-state.json
+```
+
+The storage state is just a JSON file of cookies and localStorage — keep it private, treat it like a credential.
+
+### Auth detection
+
+To check what auth pattern a site uses before configuring anything:
+
+```bash
+qulib detect-auth --url https://app.example.com
+```
+
+Or via MCP:
+
+> "Use qulib's detect_auth tool on https://app.example.com — what's the recommended auth setup?"
+
 ## CLI (from npm)
 
 ```bash

--- a/packages/core/src/analyze.ts
+++ b/packages/core/src/analyze.ts
@@ -1,17 +1,19 @@
-import type { HarnessConfig } from './schemas/config.schema.js';
-import type { GapAnalysis } from './schemas/gap-analysis.schema.js';
+import type { HarnessConfig, DetectedAuth } from './schemas/config.schema.js';
+import { GapAnalysisSchema, type GapAnalysis } from './schemas/gap-analysis.schema.js';
 import type { RouteInventory } from './schemas/route-inventory.schema.js';
 import type { RepoAnalysis } from './schemas/repo-analysis.schema.js';
 import type { DecisionLogEntry } from './schemas/decision-log.schema.js';
 import { observe } from './phases/observe.js';
 import { think } from './phases/think.js';
 import { act } from './phases/act.js';
+import { detectAuth } from './tools/auth-detector.js';
 
 export interface AnalyzeOptions {
   url: string;
   repoPath?: string;
   config: HarnessConfig;
   writeArtifacts?: boolean;
+  skipAuthDetection?: boolean;
 }
 
 export interface AnalyzeResult {
@@ -20,6 +22,7 @@ export interface AnalyzeResult {
   routeInventory: RouteInventory;
   repoInventory: RepoAnalysis | null;
   decisionLog: DecisionLogEntry[];
+  detectedAuth?: DetectedAuth;
 }
 
 export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult> {
@@ -29,6 +32,45 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
     writeArtifacts,
     decisionMemory: decisionLog,
   };
+
+  if (!options.config.auth && !options.skipAuthDetection) {
+    const detection = await detectAuth(options.url, options.config.timeoutMs);
+    if (detection.hasAuth) {
+      const gapAnalysis = GapAnalysisSchema.parse({
+        analyzedAt: new Date().toISOString(),
+        mode: 'auth-required' as const,
+        releaseConfidence: 0,
+        coveragePagesScanned: 0,
+        coverageBudgetExceeded: false,
+        coverageWarning: 'auth-required' as const,
+        gaps: [],
+        scenarios: [],
+        generatedTests: [],
+      });
+      return {
+        releaseConfidence: 0,
+        gapAnalysis,
+        routeInventory: {
+          scannedAt: new Date().toISOString(),
+          baseUrl: options.url,
+          routes: [],
+          pagesSkipped: 0,
+          budgetExceeded: false,
+        },
+        repoInventory: null,
+        decisionLog: [
+          {
+            timestamp: new Date().toISOString(),
+            phase: 'observe' as const,
+            decision: 'auth-required',
+            reason: detection.recommendation,
+            metadata: { detection },
+          },
+        ],
+        detectedAuth: detection,
+      };
+    }
+  }
 
   const observed = await observe(options.url, options.repoPath, options.config, artifacts);
   const analysis = await think(observed, options.config, artifacts);

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -5,10 +5,20 @@ import { pathToFileURL } from 'node:url';
 import { z } from 'zod';
 import { HarnessConfigSchema, type HarnessConfig } from '../schemas/config.schema.js';
 import { analyzeApp } from '../analyze.js';
+import { detectAuth } from '../tools/auth-detector.js';
 
 const program = new Command();
 const AnalyzeUrlSchema = z.string().url();
 type AnalyzeMode = 'url-only' | 'url-repo';
+
+const FormLoginCliSchema = z.object({
+  loginUrl: z.string().url(),
+  username: z.string().min(1),
+  password: z.string(),
+  usernameSelector: z.string().min(1),
+  passwordSelector: z.string().min(1),
+  submitSelector: z.string().min(1),
+});
 
 async function loadConfigFile(relativePath: string): Promise<HarnessConfig> {
   const configPath = resolve(process.cwd(), relativePath);
@@ -30,15 +40,73 @@ function redactConfigForLog(config: HarnessConfig): Record<string, unknown> {
   return base;
 }
 
+function mergeAuthFromCli(
+  config: HarnessConfig,
+  options: {
+    authStorageState?: string;
+    authFormLogin?: boolean;
+    loginUrl?: string;
+    username?: string;
+    password?: string;
+    usernameSelector?: string;
+    passwordSelector?: string;
+    submitSelector?: string;
+  }
+): HarnessConfig {
+  if (options.authStorageState && options.authFormLogin) {
+    throw new Error('Use either --auth-storage-state or --auth-form-login, not both.');
+  }
+  if (options.authStorageState) {
+    return {
+      ...config,
+      auth: { type: 'storage-state', path: options.authStorageState },
+    };
+  }
+  if (options.authFormLogin) {
+    const parsed = FormLoginCliSchema.parse({
+      loginUrl: options.loginUrl,
+      username: options.username,
+      password: options.password,
+      usernameSelector: options.usernameSelector,
+      passwordSelector: options.passwordSelector,
+      submitSelector: options.submitSelector,
+    });
+    return {
+      ...config,
+      auth: {
+        type: 'form-login',
+        loginUrl: parsed.loginUrl,
+        credentials: { username: parsed.username, password: parsed.password },
+        selectors: {
+          username: parsed.usernameSelector,
+          password: parsed.passwordSelector,
+          submit: parsed.submitSelector,
+        },
+        successIndicator: {},
+      },
+    };
+  }
+  return config;
+}
+
 async function runAnalyze(options: {
   url: string;
   repo?: string;
   configFile?: string;
   ephemeral?: boolean;
+  authStorageState?: string;
+  authFormLogin?: boolean;
+  loginUrl?: string;
+  username?: string;
+  password?: string;
+  usernameSelector?: string;
+  passwordSelector?: string;
+  submitSelector?: string;
 }): Promise<void> {
   const validatedUrl = AnalyzeUrlSchema.parse(options.url);
   const mode: AnalyzeMode = options.repo ? 'url-repo' : 'url-only';
-  const config = await loadConfigFile(options.configFile ?? 'qulib.config.ts');
+  const baseConfig = await loadConfigFile(options.configFile ?? 'qulib.config.ts');
+  const config = mergeAuthFromCli(baseConfig, options);
   const ephemeral = options.ephemeral ?? false;
   const writeArtifacts = !ephemeral;
 
@@ -64,6 +132,7 @@ async function runAnalyze(options: {
           discoveredRoutes: result.routeInventory,
           repoInventory: result.repoInventory,
           decisionLog: result.decisionLog,
+          ...(result.detectedAuth !== undefined && { detectedAuth: result.detectedAuth }),
         },
         null,
         2
@@ -115,17 +184,101 @@ program
     'playwright'
   )
   .option('--ephemeral', 'Do not write to disk — return full report as JSON on stdout (use for MCP/CI)', false)
+  .option(
+    '--auth-storage-state <path>',
+    'Path to a storage state JSON file (use after `qulib auth init`)'
+  )
+  .option('--auth-form-login', 'Use form-login; requires --login-url, credentials, and selectors', false)
+  .option('--login-url <url>', 'Form login page URL (required with --auth-form-login)')
+  .option('--username <user>', 'Form login username')
+  .option('--password <secret>', 'Form login password')
+  .option('--username-selector <sel>', 'Selector for username field')
+  .option('--password-selector <sel>', 'Selector for password field')
+  .option('--submit-selector <sel>', 'Selector for submit control')
   .action(async (options) => {
+    const authFormLogin = Boolean(options.authFormLogin);
+    const loginUrl = options.loginUrl as string | undefined;
+    if (!authFormLogin && loginUrl !== undefined) {
+      throw new Error('--login-url is only valid with --auth-form-login');
+    }
+    if (authFormLogin && loginUrl === undefined) {
+      throw new Error('--auth-form-login requires --login-url');
+    }
     await runAnalyze({
       url: options.url,
       repo: options.repo,
       configFile: options.config,
       ephemeral: options.ephemeral,
+      authStorageState: options.authStorageState,
+      authFormLogin,
+      loginUrl,
+      username: options.username,
+      password: options.password,
+      usernameSelector: options.usernameSelector,
+      passwordSelector: options.passwordSelector,
+      submitSelector: options.submitSelector,
     });
+  });
+
+program
+  .command('detect-auth')
+  .description('Detect the authentication pattern used by a deployed web app')
+  .requiredOption('--url <url>', 'URL of the app or login page')
+  .option('--timeout <ms>', 'Page load timeout in ms', '15000')
+  .action(async (options) => {
+    const result = await detectAuth(options.url, parseInt(options.timeout, 10));
+    console.log(JSON.stringify(result, null, 2));
+  });
+
+const authCmd = program.command('auth').description('Authentication helpers for scans');
+authCmd
+  .command('init')
+  .description('Open a browser, let the user log in manually, save the storage state to a file for reuse')
+  .requiredOption('--base-url <url>', 'The base URL of the app to log into')
+  .option('--out <path>', 'Output file path for the storage state JSON', './qulib-storage-state.json')
+  .option('--timeout <ms>', 'Maximum time to wait for the user to finish logging in (default 5 min)', '300000')
+  .action(async (options) => {
+    const { chromium } = await import('@playwright/test');
+    const browser = await chromium.launch({ headless: false });
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    const timeoutMs = parseInt(options.timeout, 10);
+    console.log(`\n[qulib] Opening ${options.baseUrl}`);
+    console.log('[qulib] Log in normally in the browser window that just opened.');
+    console.log('[qulib] After you reach a logged-in state, return to this terminal and press ENTER.');
+    console.log(`[qulib] You have ${timeoutMs / 1000}s before timeout.\n`);
+
+    await page.goto(options.baseUrl);
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('Timed out waiting for user')),
+        timeoutMs
+      );
+      process.stdin.once('data', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      process.stdin.resume();
+    });
+
+    const fs = await import('node:fs/promises');
+    const pathMod = await import('node:path');
+    const outPath = pathMod.resolve(options.out);
+    await context.storageState({ path: outPath });
+
+    console.log(`\n[qulib] Saved storage state to ${outPath}`);
+    console.log('[qulib] To use it, pass to qulib like:');
+    console.log(`        qulib analyze --url ${options.baseUrl} --auth-storage-state ${outPath}`);
+    console.log(`[qulib] Or in MCP, pass auth: { type: 'storage-state', path: '${outPath}' }`);
+
+    await browser.close();
+    process.exit(0);
   });
 
 program.parseAsync().catch((error: unknown) => {
   const message = error instanceof Error ? error.message : String(error);
-  console.error('[qulib] Analyze failed:', message);
+  console.error('[qulib] Failed:', message);
   process.exit(1);
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { analyzeApp } from './analyze.js';
+export { detectAuth } from './tools/auth-detector.js';
 export type { AnalyzeOptions, AnalyzeResult } from './analyze.js';
 export type {
   HarnessConfig,
@@ -6,4 +7,5 @@ export type {
   RouteInventory,
   GapAnalysis,
   RepoAnalysis,
+  DetectedAuth,
 } from './schemas/index.js';

--- a/packages/core/src/schemas/config.schema.ts
+++ b/packages/core/src/schemas/config.schema.ts
@@ -50,3 +50,26 @@ export const HarnessConfigSchema = z.object({
 });
 
 export type HarnessConfig = z.infer<typeof HarnessConfigSchema>;
+
+export const DetectedAuthSchema = z.object({
+  hasAuth: z.boolean(),
+  type: z.enum(['none', 'form-login', 'oauth', 'magic-link', 'unknown']),
+  provider: z.string().nullable(),
+  loginUrl: z.string().nullable(),
+  observedSelectors: z
+    .object({
+      usernameSelector: z.string().nullable(),
+      passwordSelector: z.string().nullable(),
+      submitSelector: z.string().nullable(),
+    })
+    .nullable(),
+  oauthButtons: z.array(
+    z.object({
+      provider: z.string(),
+      text: z.string(),
+    })
+  ),
+  recommendation: z.string(),
+});
+
+export type DetectedAuth = z.infer<typeof DetectedAuthSchema>;

--- a/packages/core/src/schemas/gap-analysis.schema.ts
+++ b/packages/core/src/schemas/gap-analysis.schema.ts
@@ -55,11 +55,13 @@ export const GeneratedTestSchema = z.object({
 
 export const GapAnalysisSchema = z.object({
   analyzedAt: z.string().datetime(),
-  mode: z.enum(['url-only', 'url-repo']),
+  mode: z.enum(['url-only', 'url-repo', 'auth-required']),
   releaseConfidence: z.number().min(0).max(100),
   coveragePagesScanned: z.number().int().min(0),
   coverageBudgetExceeded: z.boolean(),
-  coverageWarning: z.enum(['budget-exceeded', 'low-coverage', 'navigation-failures']).optional(),
+  coverageWarning: z
+    .enum(['budget-exceeded', 'low-coverage', 'navigation-failures', 'auth-required'])
+    .optional(),
   gaps: z.array(GapSchema),
   scenarios: z.array(NeutralScenarioSchema),
   generatedTests: z.array(GeneratedTestSchema),

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -1,12 +1,14 @@
 export {
   HarnessConfigSchema,
   AuthConfigSchema,
+  DetectedAuthSchema,
   type ExplorerType,
   type AdapterType,
   type FormLoginAuthConfig,
   type StorageStateAuthConfig,
   type AuthConfig,
   type HarnessConfig,
+  type DetectedAuth,
 } from './config.schema.js';
 export {
   DecisionLogEntrySchema,

--- a/packages/core/src/tools/auth-detector.ts
+++ b/packages/core/src/tools/auth-detector.ts
@@ -1,0 +1,149 @@
+import { chromium } from '@playwright/test';
+import type { DetectedAuth } from '../schemas/config.schema.js';
+
+const OAUTH_PROVIDERS: Array<{ provider: string; patterns: RegExp[] }> = [
+  { provider: 'github', patterns: [/github/i, /sign in with github/i] },
+  {
+    provider: 'google',
+    patterns: [/google/i, /sign in with google/i, /accounts\.google\.com/i],
+  },
+  {
+    provider: 'microsoft',
+    patterns: [/microsoft/i, /sign in with microsoft/i, /login\.microsoftonline\.com/i],
+  },
+  { provider: 'apple', patterns: [/apple/i, /sign in with apple/i] },
+  { provider: 'auth0', patterns: [/auth0/i] },
+  { provider: 'okta', patterns: [/okta/i] },
+];
+
+function textLooksLikeOAuthIdpButton(text: string): boolean {
+  const t = text.trim();
+  if (t.length === 0 || t.length > 120) {
+    return false;
+  }
+  return (
+    /\b(sign in with|log in with|continue with|sign up with)\b/i.test(t) ||
+    /^(github|google|microsoft|apple)$/i.test(t)
+  );
+}
+
+const MAGIC_LINK_PATTERNS = [
+  /email me a (sign[- ]?in )?link/i,
+  /sign in with email/i,
+  /passwordless/i,
+  /we'll send you a link/i,
+];
+
+async function firstTextInputNameForLogin(page: import('@playwright/test').Page): Promise<string | null> {
+  const emailName = await page.locator('input[type="email"]').first().getAttribute('name').catch(() => null);
+  if (emailName) {
+    return emailName;
+  }
+  const textInputs = page.locator('input[type="text"]');
+  const count = await textInputs.count();
+  for (let i = 0; i < count; i++) {
+    const name = await textInputs.nth(i).getAttribute('name');
+    if (name && /user|email|login/i.test(name)) {
+      return name;
+    }
+  }
+  return null;
+}
+
+export async function detectAuth(url: string, timeoutMs = 15000): Promise<DetectedAuth> {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto(url, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
+
+    let loginUrl = url;
+    const looksLikeLoginPage =
+      /login|sign[- ]?in|auth/i.test(page.url()) ||
+      (await page.locator('input[type="password"]').count()) > 0;
+
+    if (!looksLikeLoginPage) {
+      const loginLink = page.locator('a').filter({ hasText: /^(log ?in|sign ?in|sign in)$/i }).first();
+      if ((await loginLink.count()) > 0) {
+        const href = await loginLink.getAttribute('href');
+        if (href) {
+          loginUrl = new URL(href, url).toString();
+          await page.goto(loginUrl, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
+        }
+      }
+    }
+
+    const passwordInputs = page.locator('input[type="password"]');
+    const passwordCount = await passwordInputs.count();
+    const hasFormLogin = passwordCount > 0;
+
+    const oauthButtons: { provider: string; text: string }[] = [];
+    const buttonTexts = await page.locator('button, a').allInnerTexts();
+
+    for (const text of buttonTexts) {
+      const trimmed = text.trim();
+      if (!textLooksLikeOAuthIdpButton(trimmed)) {
+        continue;
+      }
+      for (const { provider, patterns } of OAUTH_PROVIDERS) {
+        if (patterns.some((p) => p.test(trimmed))) {
+          if (!oauthButtons.find((b) => b.provider === provider)) {
+            oauthButtons.push({ provider, text: trimmed.slice(0, 100) });
+          }
+        }
+      }
+    }
+
+    const pageText = await page.locator('body').innerText().catch(() => '');
+    const hasMagicLink = MAGIC_LINK_PATTERNS.some((p) => p.test(pageText));
+
+    let type: DetectedAuth['type'] = 'none';
+    let provider: string | null = null;
+    let observedSelectors: DetectedAuth['observedSelectors'] = null;
+    let recommendation = '';
+
+    if (oauthButtons.length > 0) {
+      type = 'oauth';
+      provider = oauthButtons[0].provider;
+      recommendation = `OAuth detected (${oauthButtons.map((b) => b.provider).join(', ')}). OAuth cannot be automated. Run "qulib auth init --base-url ${url}" to log in manually once and save a reusable storage state file.`;
+    } else if (hasFormLogin) {
+      type = 'form-login';
+      const usernameName = await firstTextInputNameForLogin(page);
+      const passwordName = await passwordInputs.first().getAttribute('name').catch(() => null);
+      const submitName = await page
+        .locator('button[type="submit"], input[type="submit"]')
+        .first()
+        .getAttribute('name')
+        .catch(() => null);
+
+      observedSelectors = {
+        usernameSelector: usernameName ? `input[name="${usernameName}"]` : null,
+        passwordSelector: passwordName ? `input[name="${passwordName}"]` : null,
+        submitSelector: submitName ? `button[name="${submitName}"]` : 'button[type="submit"]',
+      };
+      recommendation = `Form login detected. Configure auth with type="form-login", credentials, and the selectors above. Test selectors in your browser dev tools to confirm.`;
+    } else if (hasMagicLink) {
+      type = 'magic-link';
+      recommendation = `Magic link / passwordless auth detected. Qulib cannot complete email-link flows. Run "qulib auth init --base-url ${url}" to log in manually once and save a storage state file.`;
+    } else if (looksLikeLoginPage) {
+      type = 'unknown';
+      recommendation = `Authentication required but the pattern is unrecognized. Use "qulib auth init --base-url ${url}" to capture a storage state by logging in manually.`;
+    } else {
+      type = 'none';
+      recommendation = `No authentication required for the entry URL. Qulib can scan anonymously.`;
+    }
+
+    return {
+      hasAuth: type !== 'none',
+      type,
+      provider,
+      loginUrl: type === 'none' ? null : loginUrl,
+      observedSelectors,
+      oauthButtons,
+      recommendation,
+    };
+  } finally {
+    await browser.close();
+  }
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,9 +4,12 @@
 
 ## What it does
 
-One tool: `analyze_app(url, auth?)`
+Tools:
 
-Returns:
+- **`analyze_app(url, auth?)`** — full quality scan (optional form-login auth).
+- **`detect_auth(url, timeoutMs?)`** — detect whether the site uses form login, OAuth, magic link, etc., and get a plain-language recommendation (including when to use manual `qulib auth init` and storage state).
+
+Returns from `analyze_app`:
 
 - Release confidence score (0-100)
 - Accessibility violations (axe-core, WCAG 2 A/AA)
@@ -14,7 +17,7 @@ Returns:
 - Console errors and coverage warnings
 - Prioritized gaps with severity
 
-Supports optional form-login auth for scanning authenticated pages.
+Supports optional form-login auth for scanning authenticated pages. If auth is required but not configured, the scan can stop early with `mode: auth-required` and guidance in `detectedAuth` / the decision log.
 
 ## Install for Claude Code
 
@@ -47,9 +50,33 @@ Claude will call `analyze_app({ url: "https://example.com" })` and reason about 
 
 ## Authenticated scanning
 
+### Form login (automated)
+
 > "Use Qulib to scan my staging app at https://staging.example.com. Log in as user@example.com with password Test123, the login form is at /login with selectors [data-testid='email'], [data-testid='password'], and [data-testid='submit']."
 
-Claude will pass auth credentials to the tool; Qulib signs in, then scans.
+Claude will pass auth credentials to `analyze_app`; Qulib signs in, then scans.
+
+### OAuth, SSO, magic link, or anything that cannot be scripted
+
+OAuth and similar flows need human consent on the provider domain; Qulib does not automate them. Use the **CLI** (same machine as the browser):
+
+```bash
+qulib auth init --base-url https://app.example.com
+```
+
+Log in manually in the opened window, press ENTER in the terminal, then reuse the saved JSON with:
+
+```bash
+qulib analyze --url https://app.example.com --auth-storage-state ./qulib-storage-state.json
+```
+
+For MCP-driven workflows, run `auth init` on the machine where the MCP server runs, then pass `auth: { type: 'storage-state', path: '/absolute/path/to/qulib-storage-state.json' }` to `analyze_app`.
+
+### Detecting auth before you configure anything
+
+> "Use qulib's `detect_auth` tool on https://app.example.com — what auth pattern does it use and what should I do next?"
+
+The tool returns `type`, `oauthButtons`, `recommendation`, and related fields so the agent can explain options honestly.
 
 ## Known limitations
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,25 +2,30 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { analyzeApp } from '@qulib/core';
+import { analyzeApp, detectAuth } from '@qulib/core';
 import { z } from 'zod';
+
+const FormLoginMcpAuthSchema = z.object({
+  type: z.literal('form-login'),
+  loginUrl: z.string().url(),
+  username: z.string(),
+  password: z.string(),
+  usernameSelector: z.string(),
+  passwordSelector: z.string(),
+  submitSelector: z.string(),
+  successUrlContains: z.string().optional(),
+});
+
+const StorageStateMcpAuthSchema = z.object({
+  type: z.literal('storage-state'),
+  path: z.string().min(1),
+});
 
 const AnalyzeInputSchema = z.object({
   url: z.string().url(),
   maxPagesToScan: z.number().int().min(1).max(50).optional(),
   timeoutMs: z.number().int().positive().optional(),
-  auth: z
-    .object({
-      type: z.literal('form-login'),
-      loginUrl: z.string().url(),
-      username: z.string(),
-      password: z.string(),
-      usernameSelector: z.string(),
-      passwordSelector: z.string(),
-      submitSelector: z.string(),
-      successUrlContains: z.string().optional(),
-    })
-    .optional(),
+  auth: z.discriminatedUnion('type', [FormLoginMcpAuthSchema, StorageStateMcpAuthSchema]).optional(),
 });
 
 const server = new Server(
@@ -40,7 +45,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'analyze_app',
       description:
-        'Analyze a deployed web app for quality gaps. Returns a release confidence score (0-100), accessibility violations, broken links, and prioritized risks. Supports optional form-login authentication.',
+        'Analyze a deployed web app for quality gaps. Returns a release confidence score (0-100), accessibility violations, broken links, and prioritized risks. Supports optional form-login or storage-state (Playwright) authentication.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -48,28 +53,53 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           maxPagesToScan: { type: 'number', description: 'Max pages to crawl (default 10)' },
           timeoutMs: { type: 'number', description: 'Per-page timeout in milliseconds (default 30000)' },
           auth: {
-            type: 'object',
-            description: 'Optional form-login auth',
-            properties: {
-              type: { type: 'string', enum: ['form-login'] },
-              loginUrl: { type: 'string' },
-              username: { type: 'string' },
-              password: { type: 'string' },
-              usernameSelector: { type: 'string' },
-              passwordSelector: { type: 'string' },
-              submitSelector: { type: 'string' },
-              successUrlContains: { type: 'string' },
-            },
-            required: [
-              'type',
-              'loginUrl',
-              'username',
-              'password',
-              'usernameSelector',
-              'passwordSelector',
-              'submitSelector',
+            description: 'Optional auth: form-login credentials or path to a storage state JSON from `qulib auth init`',
+            oneOf: [
+              {
+                type: 'object',
+                properties: {
+                  type: { type: 'string', enum: ['form-login'] },
+                  loginUrl: { type: 'string' },
+                  username: { type: 'string' },
+                  password: { type: 'string' },
+                  usernameSelector: { type: 'string' },
+                  passwordSelector: { type: 'string' },
+                  submitSelector: { type: 'string' },
+                  successUrlContains: { type: 'string' },
+                },
+                required: [
+                  'type',
+                  'loginUrl',
+                  'username',
+                  'password',
+                  'usernameSelector',
+                  'passwordSelector',
+                  'submitSelector',
+                ],
+              },
+              {
+                type: 'object',
+                properties: {
+                  type: { type: 'string', enum: ['storage-state'] },
+                  path: { type: 'string', description: 'Absolute path to storage state JSON on the MCP host' },
+                },
+                required: ['type', 'path'],
+              },
             ],
           },
+        },
+        required: ['url'],
+      },
+    },
+    {
+      name: 'detect_auth',
+      description:
+        'Detect the authentication pattern used by a deployed web app. Returns the auth type (form-login, oauth, magic-link, none, or unknown) and a recommendation for how to configure qulib to scan past it.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          url: { type: 'string', description: 'Full URL of the deployed app or login page' },
+          timeoutMs: { type: 'number', description: 'Page load timeout in milliseconds (default 15000)' },
         },
         required: ['url'],
       },
@@ -78,6 +108,20 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 }));
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  if (request.params.name === 'detect_auth') {
+    const { url, timeoutMs } = z
+      .object({
+        url: z.string().url(),
+        timeoutMs: z.number().int().positive().optional(),
+      })
+      .parse(request.params.arguments ?? {});
+
+    const result = await detectAuth(url, timeoutMs);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  }
+
   if (request.params.name !== 'analyze_app') {
     throw new Error(`Unknown tool: ${request.params.name}`);
   }
@@ -85,9 +129,28 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const input = AnalyzeInputSchema.parse(request.params.arguments ?? {});
 
   const successIndicator =
-    input.auth?.successUrlContains !== undefined && input.auth.successUrlContains !== ''
+    input.auth?.type === 'form-login' &&
+    input.auth.successUrlContains !== undefined &&
+    input.auth.successUrlContains !== ''
       ? { urlContains: input.auth.successUrlContains }
       : {};
+
+  const authConfig =
+    input.auth?.type === 'form-login'
+      ? {
+          type: 'form-login' as const,
+          loginUrl: input.auth.loginUrl,
+          credentials: { username: input.auth.username, password: input.auth.password },
+          selectors: {
+            username: input.auth.usernameSelector,
+            password: input.auth.passwordSelector,
+            submit: input.auth.submitSelector,
+          },
+          successIndicator,
+        }
+      : input.auth?.type === 'storage-state'
+        ? { type: 'storage-state' as const, path: input.auth.path }
+        : undefined;
 
   const result = await analyzeApp({
     url: input.url,
@@ -106,19 +169,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       explorer: 'playwright',
       defaultAdapter: 'playwright',
       adapters: ['playwright'],
-      ...(input.auth && {
-        auth: {
-          type: 'form-login' as const,
-          loginUrl: input.auth.loginUrl,
-          credentials: { username: input.auth.username, password: input.auth.password },
-          selectors: {
-            username: input.auth.usernameSelector,
-            password: input.auth.passwordSelector,
-            submit: input.auth.submitSelector,
-          },
-          successIndicator,
-        },
-      }),
+      ...(authConfig && { auth: authConfig }),
     },
   });
 


### PR DESCRIPTION
## Summary
Auth pattern detection (`detect_auth` / `detect-auth`), early `analyze_app` exit when auth is required but unset, `qulib auth init` for manual OAuth/session capture, CLI/MCP wiring, and related README updates.

**Note:** May need a merge/rebase from `main` after link-extraction lands if GitHub reports conflicts.

## Test plan
- [ ] `npm run build`
- [ ] `detect-auth` + analyze flows per checklist


Made with [Cursor](https://cursor.com)