### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2029,7 +2029,7 @@
     },
     "packages/core": {
       "name": "@qulib/core",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "^4.9.0",
@@ -2049,11 +2049,11 @@
     },
     "packages/mcp": {
       "name": "@qulib/mcp",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@qulib/core": "0.1.1",
+        "@qulib/core": "0.2.0",
         "zod": "^3.23.0"
       },
       "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/core",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Qulib — analyze deployed web apps for honest quality gaps (CLI + programmatic API)",
   "license": "MIT",
   "author": "Tapesh Nagarwal",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/mcp",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "MCP server for Qulib — AI-callable QA gap analysis",
   "license": "MIT",
   "author": "Tapesh Nagarwal",
@@ -31,7 +31,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@qulib/core": "0.1.1",
+    "@qulib/core": "0.2.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^3.23.0"
   },


### PR DESCRIPTION
Bumps `@qulib/core` and `@qulib/mcp` to **0.2.0** after auth detection + MCP `detect_auth`, `qulib auth init`, etc.

Publish after merge (2FA):

```bash
git checkout main && git pull
cd packages/core && npm publish --otp=<code>
cd ../mcp && npm publish --otp=<code>
git tag v0.2.0 && git push origin v0.2.0
```


Made with [Cursor](https://cursor.com)