### PR TITLE
fix: Chromium install hint + auth detector hydration wait

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,6 +8,16 @@
 npm install @qulib/core
 ```
 
+## One-time browser setup
+
+Qulib uses Playwright. Install Chromium once on the machine that runs scans:
+
+```bash
+npx playwright install chromium
+```
+
+If browsers are missing, commands fail with a short message pointing you here.
+
 ## Scanning authenticated apps
 
 Qulib supports three auth modes: anonymous (default), form-login, and storage-state.

--- a/packages/core/src/tools/auth-detector.ts
+++ b/packages/core/src/tools/auth-detector.ts
@@ -1,5 +1,14 @@
-import { chromium } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import type { DetectedAuth } from '../schemas/config.schema.js';
+import { launchBrowser } from './browser.js';
+
+async function waitNetworkIdleBestEffort(page: Page): Promise<void> {
+  try {
+    await page.waitForLoadState('networkidle', { timeout: 5000 });
+  } catch {
+    // best-effort — analytics or polling can prevent networkidle
+  }
+}
 
 const OAUTH_PROVIDERS: Array<{ provider: string; patterns: RegExp[] }> = [
   { provider: 'github', patterns: [/github/i, /sign in with github/i] },
@@ -51,12 +60,13 @@ async function firstTextInputNameForLogin(page: import('@playwright/test').Page)
 }
 
 export async function detectAuth(url: string, timeoutMs = 15000): Promise<DetectedAuth> {
-  const browser = await chromium.launch({ headless: true });
+  const browser = await launchBrowser();
   try {
     const context = await browser.newContext();
     const page = await context.newPage();
 
     await page.goto(url, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
+    await waitNetworkIdleBestEffort(page);
 
     let loginUrl = url;
     const looksLikeLoginPage =
@@ -70,6 +80,7 @@ export async function detectAuth(url: string, timeoutMs = 15000): Promise<Detect
         if (href) {
           loginUrl = new URL(href, url).toString();
           await page.goto(loginUrl, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
+          await waitNetworkIdleBestEffort(page);
         }
       }
     }

--- a/packages/core/src/tools/browser.ts
+++ b/packages/core/src/tools/browser.ts
@@ -1,0 +1,15 @@
+import { chromium, type Browser } from '@playwright/test';
+
+export async function launchBrowser(): Promise<Browser> {
+  try {
+    return await chromium.launch({ headless: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("Executable doesn't exist") || message.includes('chromium')) {
+      throw new Error(
+        `Playwright Chromium browser is not installed. Run:\n\n  npx playwright install chromium\n\nThen retry your qulib command. This is a one-time setup step.`
+      );
+    }
+    throw err;
+  }
+}

--- a/packages/core/src/tools/playwright-explorer.ts
+++ b/packages/core/src/tools/playwright-explorer.ts
@@ -1,4 +1,5 @@
-import { chromium, type BrowserContext } from '@playwright/test';
+import type { BrowserContext } from '@playwright/test';
+import { launchBrowser } from './browser.js';
 import { AxeBuilder } from '@axe-core/playwright';
 import type { AppExplorer } from './explorer.interface.js';
 import { createAuthenticatedContext } from './auth.js';
@@ -21,7 +22,7 @@ function isInternalHref(href: string, baseUrlStr: string): boolean {
 
 export class PlaywrightExplorer implements AppExplorer {
   async explore(baseUrl: string, config: HarnessConfig): Promise<RouteInventory> {
-    const browser = await chromium.launch({ headless: true });
+    const browser = await launchBrowser();
 
     let context: BrowserContext;
     try {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -40,6 +40,18 @@ Add this under `mcpServers` in `claude_desktop_config.json` (Claude Desktop) or 
 }
 ```
 
+## One-time browser setup
+
+qulib uses Playwright under the hood. After your MCP host first runs the qulib server, you'll need to install Chromium:
+
+```bash
+npx playwright install chromium
+```
+
+This is a one-time step. You'll only need to do it again if Playwright's browser version is bumped in a future qulib release.
+
+If you skip this step, the first tool call will return a clear error telling you to run the command.
+
 ## Example usage
 
 Ask Claude:


### PR DESCRIPTION
## Summary
- **Missing Playwright browsers:** `launchBrowser()` wraps `chromium.launch` in explorer + auth detector and throws an actionable install message (`npx playwright install chromium`).
- **Suspense / late hydration:** `detectAuth` waits `networkidle` (5s cap, best-effort) after each navigation before counting password fields / OAuth.

## Test plan
- [x] `detect-auth --url https://notquality.com/login` → `form-login`
- [x] `detect-auth --url https://example.com` → `none`
- [x] `analyze --url https://notquality.com --ephemeral` OK


Made with [Cursor](https://cursor.com)