### PR TITLE
feat: explore_auth tool with multi-provider detection + user-local registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ packages/*/dist
 .env
 qulib.test-auth.config.ts
 quilib.test-auth.config.ts
+qulib-storage-state.json
 .scan-state/*
 !.scan-state/.gitkeep
 output/*

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -55,6 +55,20 @@ qulib analyze --url https://app.example.com --auth-storage-state ./qulib-storage
 
 The storage state is just a JSON file of cookies and localStorage — keep it private, treat it like a credential.
 
+### Multi-path auth exploration (`explore-auth`)
+
+For unfamiliar apps (especially enterprise SSO with several buttons), run **`qulib explore-auth --url <url>`** before `analyze`. The JSON lists every detected path (built-in OAuth names like Google/Clever, **heuristic** unknown buttons such as tenant-specific SSO labels, password forms, and magic-link copy) plus **`suggestedAgentBehavior`** for the agent.
+
+Unknown SSO buttons include **`unrecognizedButtons`** with a hint. Teach this machine to recognize a label next time:
+
+```bash
+qulib auth providers add --id scholastic-sync --label "Scholastic Sync" --pattern "scholastic sync"
+qulib auth providers list
+qulib auth providers remove --id scholastic-sync
+```
+
+Patterns live in **`~/.qulib/providers.json`** (per user, not in the repo). Built-in public platforms stay in qulib’s curated list; tenant-specific names are never shipped as built-ins.
+
 ### Auth detection
 
 To check what auth pattern a site uses before configuring anything:

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { HarnessConfigSchema, type HarnessConfig } from '../schemas/config.schema.js';
 import { analyzeApp } from '../analyze.js';
 import { detectAuth } from '../tools/auth-detector.js';
+import { exploreAuth } from '../tools/auth-explorer.js';
 
 const program = new Command();
 const AnalyzeUrlSchema = z.string().url();
@@ -221,6 +222,16 @@ program
   });
 
 program
+  .command('explore-auth')
+  .description('Explore all sign-in paths (OAuth, forms, magic link) for agent-driven setup before analyze')
+  .requiredOption('--url <url>', 'URL of the app or login page')
+  .option('--timeout <ms>', 'Navigation timeout in ms', '20000')
+  .action(async (options) => {
+    const result = await exploreAuth(options.url, parseInt(options.timeout, 10));
+    console.log(JSON.stringify(result, null, 2));
+  });
+
+program
   .command('detect-auth')
   .description('Detect the authentication pattern used by a deployed web app')
   .requiredOption('--url <url>', 'URL of the app or login page')
@@ -231,6 +242,43 @@ program
   });
 
 const authCmd = program.command('auth').description('Authentication helpers for scans');
+const providersCmd = authCmd
+  .command('providers')
+  .description('User-local OAuth/SSO button patterns (~/.qulib/providers.json)');
+providersCmd
+  .command('list')
+  .description('List user-local providers registered on this machine')
+  .action(async () => {
+    const { listUserProviders } = await import('../tools/user-providers.js');
+    const providers = listUserProviders();
+    console.log(JSON.stringify(providers, null, 2));
+  });
+providersCmd
+  .command('add')
+  .description('Register a custom provider pattern (case-insensitive regex source)')
+  .requiredOption('--id <id>', 'Stable id (kebab-case), e.g. scholastic-sync')
+  .requiredOption('--label <label>', 'Human-readable label')
+  .requiredOption('--pattern <regex>', 'Regex source, e.g. scholastic sync')
+  .action(async (opts: { id: string; label: string; pattern: string }) => {
+    try {
+      new RegExp(opts.pattern, 'i');
+    } catch {
+      throw new Error(`Invalid regex pattern: ${opts.pattern}`);
+    }
+    const { addUserProvider } = await import('../tools/user-providers.js');
+    addUserProvider({ id: opts.id, label: opts.label, pattern: opts.pattern });
+    console.log(`[qulib] Added provider "${opts.label}" (id: ${opts.id}) to ~/.qulib/providers.json`);
+  });
+providersCmd
+  .command('remove')
+  .description('Remove a user-local provider by id')
+  .requiredOption('--id <id>', 'Provider id to remove')
+  .action(async (opts: { id: string }) => {
+    const { removeUserProvider } = await import('../tools/user-providers.js');
+    const removed = removeUserProvider(opts.id);
+    console.log(removed ? `[qulib] Removed "${opts.id}"` : `[qulib] No provider with id "${opts.id}" found`);
+  });
+
 authCmd
   .command('init')
   .description('Open a browser, let the user log in manually, save the storage state to a file for reuse')

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,7 @@
 export { analyzeApp } from './analyze.js';
 export { detectAuth } from './tools/auth-detector.js';
+export { exploreAuth } from './tools/auth-explorer.js';
+export { addUserProvider, removeUserProvider, listUserProviders } from './tools/user-providers.js';
 export type { AnalyzeOptions, AnalyzeResult } from './analyze.js';
 export type {
   HarnessConfig,
@@ -8,4 +10,7 @@ export type {
   GapAnalysis,
   RepoAnalysis,
   DetectedAuth,
+  AuthExploration,
+  AuthPath,
+  AuthPathRequirements,
 } from './schemas/index.js';

--- a/packages/core/src/schemas/config.schema.ts
+++ b/packages/core/src/schemas/config.schema.ts
@@ -73,3 +73,51 @@ export const DetectedAuthSchema = z.object({
 });
 
 export type DetectedAuth = z.infer<typeof DetectedAuthSchema>;
+
+export const AuthPathRequirementsSchema = z.discriminatedUnion('method', [
+  z.object({ method: z.literal('storage-state'), instruction: z.string() }),
+  z.object({
+    method: z.literal('credentials'),
+    fields: z.array(
+      z.object({
+        name: z.string(),
+        label: z.string(),
+        type: z.enum(['text', 'password', 'email', 'select', 'checkbox']),
+        observedOptions: z.array(z.string()).default([]),
+      })
+    ),
+  }),
+  z.object({ method: z.literal('unknown'), instruction: z.string() }),
+]);
+
+export const AuthPathSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  type: z.enum(['oauth', 'oauth-unknown', 'form-login', 'form-multi', 'magic-link', 'unknown']),
+  provider: z.string().nullable(),
+  source: z.enum(['built-in', 'user-local', 'heuristic']),
+  automatable: z.boolean(),
+  confidence: z.enum(['high', 'medium', 'low']),
+  requirements: AuthPathRequirementsSchema,
+});
+
+export const AuthExplorationSchema = z.object({
+  url: z.string(),
+  authRequired: z.boolean(),
+  authScope: z.enum(['site-wide', 'section-only', 'optional', 'none']),
+  authPaths: z.array(AuthPathSchema),
+  observedAt: z.string(),
+  suggestedAgentBehavior: z.string(),
+  unrecognizedButtons: z
+    .array(
+      z.object({
+        label: z.string(),
+        hint: z.string(),
+      })
+    )
+    .default([]),
+});
+
+export type AuthPathRequirements = z.infer<typeof AuthPathRequirementsSchema>;
+export type AuthPath = z.infer<typeof AuthPathSchema>;
+export type AuthExploration = z.infer<typeof AuthExplorationSchema>;

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -2,6 +2,9 @@ export {
   HarnessConfigSchema,
   AuthConfigSchema,
   DetectedAuthSchema,
+  AuthPathRequirementsSchema,
+  AuthPathSchema,
+  AuthExplorationSchema,
   type ExplorerType,
   type AdapterType,
   type FormLoginAuthConfig,
@@ -9,6 +12,9 @@ export {
   type AuthConfig,
   type HarnessConfig,
   type DetectedAuth,
+  type AuthPathRequirements,
+  type AuthPath,
+  type AuthExploration,
 } from './config.schema.js';
 export {
   DecisionLogEntrySchema,

--- a/packages/core/src/tools/auth-explorer.ts
+++ b/packages/core/src/tools/auth-explorer.ts
@@ -1,0 +1,367 @@
+import type { Page } from '@playwright/test';
+import {
+  AuthExplorationSchema,
+  type AuthExploration,
+  type AuthPath,
+  type AuthPathRequirements,
+} from '../schemas/config.schema.js';
+import { launchBrowser } from './browser.js';
+import { BUILT_IN_OAUTH_PROVIDERS, type OAuthProvider } from './oauth-providers.js';
+import { loadUserProviders } from './user-providers.js';
+
+type ProviderWithSource = OAuthProvider & { source: 'built-in' | 'user-local' };
+
+const MAGIC_LINK_PATTERNS = [
+  /email me a (sign[- ]?in )?link/i,
+  /sign in with email/i,
+  /passwordless/i,
+  /we'll send you a link/i,
+];
+
+async function waitNetworkIdleBestEffort(page: Page): Promise<void> {
+  try {
+    await page.waitForLoadState('networkidle', { timeout: 5000 });
+  } catch {
+    // best-effort
+  }
+}
+
+function textLooksLikeOAuthIdpButton(text: string): boolean {
+  const t = text.trim();
+  if (t.length === 0 || t.length > 120) {
+    return false;
+  }
+  return (
+    /\b(sign in with|log in with|continue with|sign up with)\b/i.test(t) ||
+    /^(github|google|microsoft|apple)$/i.test(t)
+  );
+}
+
+function slugifyLabel(text: string): string {
+  const s = text
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .slice(0, 48);
+  return s.length > 0 ? s : 'unknown';
+}
+
+function onLoginishPage(url: string): boolean {
+  return /login|sign[- ]?in|auth|sso|oauth/i.test(new URL(url).pathname + new URL(url).hostname);
+}
+
+function isHeuristicUnknownSso(text: string, loginish: boolean): boolean {
+  const t = text.trim();
+  if (!loginish || t.length < 3 || t.length > 80) {
+    return false;
+  }
+  if (/^(submit|cancel|back|close|next|skip|help|faq)$/i.test(t)) {
+    return false;
+  }
+  if (/\b(sign in with|log in with|continue with)\b/i.test(t)) {
+    return true;
+  }
+  if (/\b(sync|sso|portal|workspace|federation)\b/i.test(t)) {
+    return true;
+  }
+  return false;
+}
+
+function storageRequirement(): AuthPathRequirements {
+  return {
+    method: 'storage-state',
+    instruction:
+      'OAuth and most SSO flows cannot be scripted. Run `qulib auth init --base-url <app-url>` on this machine, then pass the saved storage state JSON to `analyze` or MCP `analyze_app` as `auth: { type: "storage-state", path: "..." }`.',
+  };
+}
+
+async function collectVisibleControlTexts(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    const nodes = document.querySelectorAll('button, a[href], [role="button"]');
+    for (const el of nodes) {
+      const t = (el.textContent ?? '').trim().replace(/\s+/g, ' ');
+      if (!t || t.length > 120) {
+        continue;
+      }
+      const style = window.getComputedStyle(el as HTMLElement);
+      if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
+        continue;
+      }
+      if (!seen.has(t)) {
+        seen.add(t);
+        out.push(t);
+      }
+    }
+    return out;
+  });
+}
+
+function buildAllProviders(): ProviderWithSource[] {
+  const builtIn = BUILT_IN_OAUTH_PROVIDERS.map((p) => ({ ...p, source: 'built-in' as const }));
+  const user = loadUserProviders().map((p) => ({ ...p, source: 'user-local' as const }));
+  return [...builtIn, ...user];
+}
+
+function matchProvider(text: string, p: OAuthProvider): boolean {
+  return p.patterns.some((re) => re.test(text));
+}
+
+function oauthConfidence(source: ProviderWithSource['source'], loginish: boolean): AuthPath['confidence'] {
+  if (source === 'user-local') {
+    return 'high';
+  }
+  if (source === 'built-in' && loginish) {
+    return 'high';
+  }
+  if (source === 'built-in') {
+    return 'medium';
+  }
+  return 'low';
+}
+
+async function buildFormPaths(page: Page): Promise<AuthPath[]> {
+  const passwordCount = await page.locator('input[type="password"]').count();
+  if (passwordCount === 0) {
+    return [];
+  }
+  const formType: AuthPath['type'] = passwordCount > 1 ? 'form-multi' : 'form-login';
+  const fields = await page.evaluate(() => {
+    const pwd = document.querySelector('input[type="password"]');
+    if (!pwd) {
+      return [];
+    }
+    const form = pwd.closest('form') ?? document.body;
+    const out: Array<{
+      name: string;
+      label: string;
+      type: 'text' | 'password' | 'email' | 'select' | 'checkbox';
+      observedOptions: string[];
+    }> = [];
+    const inputs = form.querySelectorAll('input, select, textarea');
+    for (const el of inputs) {
+      if (!(el instanceof HTMLElement)) {
+        continue;
+      }
+      const tag = el.tagName.toLowerCase();
+      if (tag === 'input') {
+        const inp = el as HTMLInputElement;
+        const t = (inp.type || 'text').toLowerCase();
+        if (['hidden', 'submit', 'button', 'image', 'reset'].includes(t)) {
+          continue;
+        }
+        let fieldType: 'text' | 'password' | 'email' | 'select' | 'checkbox' = 'text';
+        if (t === 'password') {
+          fieldType = 'password';
+        } else if (t === 'email') {
+          fieldType = 'email';
+        } else if (t === 'checkbox') {
+          fieldType = 'checkbox';
+        }
+        const id = inp.id;
+        let label = inp.getAttribute('aria-label') ?? inp.placeholder ?? inp.name ?? fieldType;
+        if (id) {
+          const lab = document.querySelector(`label[for="${CSS.escape(id)}"]`);
+          if (lab?.textContent) {
+            label = lab.textContent.trim();
+          }
+        }
+        out.push({
+          name: inp.name || inp.id || fieldType,
+          label: label.slice(0, 120),
+          type: fieldType,
+          observedOptions: [],
+        });
+      } else if (tag === 'select') {
+        const sel = el as HTMLSelectElement;
+        const opts = Array.from(sel.options).map((o) => o.text.trim()).filter(Boolean);
+        out.push({
+          name: sel.name || sel.id || 'select',
+          label: (sel.getAttribute('aria-label') ?? sel.name ?? 'select').slice(0, 120),
+          type: 'select',
+          observedOptions: opts.slice(0, 50),
+        });
+      }
+    }
+    return out;
+  });
+  const requirements: AuthPathRequirements =
+    fields.length > 0
+      ? { method: 'credentials', fields }
+      : {
+          method: 'unknown',
+          instruction:
+            'A password field exists but field metadata could not be read. Inspect the page in devtools and configure form-login selectors manually, or use `qulib auth init`.',
+        };
+  return [
+    {
+      id: formType === 'form-multi' ? 'form-multi' : 'form-login',
+      label: formType === 'form-multi' ? 'Multi-field sign-in form' : 'Username / password form',
+      type: formType,
+      provider: null,
+      source: 'heuristic',
+      automatable: requirements.method === 'credentials',
+      confidence: requirements.method === 'credentials' ? 'medium' : 'low',
+      requirements,
+    },
+  ];
+}
+
+export async function exploreAuth(url: string, timeoutMs = 20000): Promise<AuthExploration> {
+  const browser = await launchBrowser();
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto(url, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
+    await waitNetworkIdleBestEffort(page);
+
+    const loginishAfterFirst =
+      /login|sign[- ]?in|auth/i.test(page.url()) || (await page.locator('input[type="password"]').count()) > 0;
+
+    if (!loginishAfterFirst) {
+      const loginLink = page.locator('a').filter({ hasText: /^(log ?in|sign ?in|sign in)$/i }).first();
+      if ((await loginLink.count()) > 0) {
+        const href = await loginLink.getAttribute('href');
+        if (href) {
+          const next = new URL(href, url).toString();
+          await page.goto(next, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
+          await waitNetworkIdleBestEffort(page);
+        }
+      }
+    }
+
+    const finalUrl = page.url();
+    const loginish = onLoginishPage(finalUrl) || (await page.locator('input[type="password"]').count()) > 0;
+
+    const allProviders = buildAllProviders();
+    const texts = await collectVisibleControlTexts(page);
+    const consumed = new Set<string>();
+    const authPaths: AuthPath[] = [];
+    const unrecognizedButtons: Array<{ label: string; hint: string }> = [];
+
+    for (const rawText of texts) {
+      const text = rawText.trim();
+      if (!text) {
+        continue;
+      }
+      let matched: { p: ProviderWithSource; gate: boolean } | null = null;
+      for (const p of allProviders) {
+        if (!matchProvider(text, p)) {
+          continue;
+        }
+        if (p.source === 'built-in' && !(textLooksLikeOAuthIdpButton(text) || loginish)) {
+          continue;
+        }
+        matched = { p, gate: textLooksLikeOAuthIdpButton(text) || loginish };
+        break;
+      }
+      if (matched) {
+        const { p, gate } = matched;
+        const id = `oauth:${p.id}`;
+        if (consumed.has(id)) {
+          continue;
+        }
+        consumed.add(id);
+        authPaths.push({
+          id,
+          label: p.label,
+          type: 'oauth',
+          provider: p.id,
+          source: p.source,
+          automatable: false,
+          confidence: oauthConfidence(p.source, loginish || gate),
+          requirements: storageRequirement(),
+        });
+        continue;
+      }
+      if (isHeuristicUnknownSso(text, loginish)) {
+        const slug = slugifyLabel(text);
+        const id = `oauth-unknown:${slug}`;
+        if (consumed.has(id)) {
+          continue;
+        }
+        consumed.add(id);
+        authPaths.push({
+          id,
+          label: text.slice(0, 100),
+          type: 'oauth-unknown',
+          provider: null,
+          source: 'heuristic',
+          automatable: false,
+          confidence: 'low',
+          requirements: storageRequirement(),
+        });
+        const safePattern = text.slice(0, 48).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        unrecognizedButtons.push({
+          label: text.slice(0, 100),
+          hint: `If this is your org SSO, register it: qulib auth providers add --id "${slug}" --label "${text.replace(/"/g, '\\"').slice(0, 80)}" --pattern "${safePattern}"`,
+        });
+      }
+    }
+
+    const pageText = await page.locator('body').innerText().catch(() => '');
+    if (MAGIC_LINK_PATTERNS.some((re) => re.test(pageText))) {
+      authPaths.push({
+        id: 'magic-link',
+        label: 'Magic link / passwordless',
+        type: 'magic-link',
+        provider: null,
+        source: 'heuristic',
+        automatable: false,
+        confidence: 'medium',
+        requirements: {
+          method: 'storage-state',
+          instruction:
+            'Magic-link flows need a human in the loop. Use `qulib auth init --base-url <app-url>` and complete email or provider steps in the opened browser, then reuse the saved storage state for scans.',
+        },
+      });
+    }
+
+    authPaths.push(...(await buildFormPaths(page)));
+
+    const authRequired = authPaths.length > 0;
+    let authScope: AuthExploration['authScope'] = 'none';
+    if (authRequired) {
+      if (loginish) {
+        authScope = 'site-wide';
+      } else {
+        authScope = /login|signin|auth/i.test(new URL(finalUrl).pathname) ? 'site-wide' : 'optional';
+      }
+    }
+
+    const suggestedParts: string[] = [];
+    if (authPaths.some((p) => p.type === 'oauth' || p.type === 'oauth-unknown')) {
+      suggestedParts.push(
+        'For OAuth or unrecognized SSO buttons, collect a Playwright storage state with `qulib auth init` before calling `analyze_app`.'
+      );
+    }
+    if (authPaths.some((p) => p.type === 'form-login' || p.type === 'form-multi')) {
+      suggestedParts.push(
+        'For password forms, gather username/password and stable selectors (or use storage state if MFA applies).'
+      );
+    }
+    if (authPaths.some((p) => p.type === 'magic-link')) {
+      suggestedParts.push('For magic-link, use `qulib auth init` after the user completes email delivery.');
+    }
+    if (!authRequired) {
+      suggestedParts.push('No sign-in surface detected at this URL; you can run `analyze_app` without auth unless gated deeper in the app.');
+    }
+
+    const exploration: AuthExploration = {
+      url: finalUrl,
+      authRequired,
+      authScope,
+      authPaths,
+      observedAt: new Date().toISOString(),
+      suggestedAgentBehavior: suggestedParts.join(' '),
+      unrecognizedButtons,
+    };
+
+    return AuthExplorationSchema.parse(exploration);
+  } finally {
+    await browser.close();
+  }
+}

--- a/packages/core/src/tools/oauth-providers.ts
+++ b/packages/core/src/tools/oauth-providers.ts
@@ -1,0 +1,29 @@
+export interface OAuthProvider {
+  id: string;
+  label: string;
+  patterns: RegExp[];
+}
+
+export const BUILT_IN_OAUTH_PROVIDERS: OAuthProvider[] = [
+  { id: 'github', label: 'GitHub', patterns: [/\bgithub\b/i] },
+  { id: 'google', label: 'Google', patterns: [/\bgoogle\b/i, /accounts\.google\.com/i] },
+  { id: 'microsoft', label: 'Microsoft', patterns: [/microsoft/i, /login\.microsoftonline\.com/i] },
+  { id: 'apple', label: 'Apple', patterns: [/sign in with apple/i, /\bapple id\b/i] },
+  { id: 'facebook', label: 'Facebook', patterns: [/facebook/i] },
+  { id: 'twitter', label: 'Twitter/X', patterns: [/twitter\.com/i, /\bsign in with x\b/i] },
+  { id: 'linkedin', label: 'LinkedIn', patterns: [/linkedin/i] },
+
+  { id: 'auth0', label: 'Auth0', patterns: [/auth0/i] },
+  { id: 'okta', label: 'Okta', patterns: [/\bokta\b/i] },
+  { id: 'onelogin', label: 'OneLogin', patterns: [/onelogin/i] },
+  { id: 'duo', label: 'Duo Security', patterns: [/duo security/i] },
+  { id: 'ping', label: 'Ping Identity', patterns: [/pingidentity/i, /pingone/i] },
+  { id: 'workday', label: 'Workday', patterns: [/workday/i] },
+  { id: 'saml', label: 'SAML SSO', patterns: [/\bsaml\b/i] },
+
+  { id: 'clever', label: 'Clever', patterns: [/\bclever\b/i, /clever\.com/i] },
+  { id: 'classlink', label: 'ClassLink', patterns: [/classlink/i] },
+  { id: 'schoology', label: 'Schoology', patterns: [/schoology/i] },
+  { id: 'canvas', label: 'Canvas (Instructure)', patterns: [/\bcanvas lms\b/i, /instructure/i] },
+  { id: 'blackboard', label: 'Blackboard', patterns: [/blackboard/i] },
+];

--- a/packages/core/src/tools/user-providers.ts
+++ b/packages/core/src/tools/user-providers.ts
@@ -1,0 +1,74 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import type { OAuthProvider } from './oauth-providers.js';
+
+const USER_PROVIDERS_PATH = join(homedir(), '.qulib', 'providers.json');
+
+export interface SerializedProvider {
+  id: string;
+  label: string;
+  patterns: string[];
+}
+
+export function loadUserProviders(): OAuthProvider[] {
+  const raw = loadSerialized();
+  return raw.map((p) => ({
+    id: p.id,
+    label: p.label,
+    patterns: p.patterns.map((src) => new RegExp(src, 'i')),
+  }));
+}
+
+export function addUserProvider(input: { id: string; label: string; pattern: string }): void {
+  const existing = loadSerialized();
+  const idx = existing.findIndex((p) => p.id === input.id);
+  if (idx >= 0) {
+    const p = existing[idx];
+    if (!p.patterns.includes(input.pattern)) {
+      p.patterns.push(input.pattern);
+    }
+    p.label = input.label;
+  } else {
+    existing.push({ id: input.id, label: input.label, patterns: [input.pattern] });
+  }
+  ensureDir();
+  writeFileSync(USER_PROVIDERS_PATH, JSON.stringify(existing, null, 2), 'utf-8');
+}
+
+export function removeUserProvider(id: string): boolean {
+  const existing = loadSerialized();
+  const filtered = existing.filter((p) => p.id !== id);
+  if (filtered.length === existing.length) {
+    return false;
+  }
+  ensureDir();
+  writeFileSync(USER_PROVIDERS_PATH, JSON.stringify(filtered, null, 2), 'utf-8');
+  return true;
+}
+
+export function listUserProviders(): SerializedProvider[] {
+  return loadSerialized();
+}
+
+function loadSerialized(): SerializedProvider[] {
+  if (!existsSync(USER_PROVIDERS_PATH)) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(USER_PROVIDERS_PATH, 'utf-8')) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed as SerializedProvider[];
+  } catch {
+    return [];
+  }
+}
+
+function ensureDir(): void {
+  const dir = dirname(USER_PROVIDERS_PATH);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -6,8 +6,9 @@
 
 Tools:
 
-- **`analyze_app(url, auth?)`** — full quality scan (optional form-login auth).
-- **`detect_auth(url, timeoutMs?)`** — detect whether the site uses form login, OAuth, magic link, etc., and get a plain-language recommendation (including when to use manual `qulib auth init` and storage state).
+- **`explore_auth(url, timeoutMs?)`** — list all sign-in paths (OAuth, unknown SSO heuristics, forms, magic link) and what the agent must collect before `analyze_app`. Prefer this on unfamiliar apps.
+- **`analyze_app(url, auth?)`** — full quality scan (optional form-login or storage-state auth).
+- **`detect_auth(url, timeoutMs?)`** — single-pattern auth guess with a short recommendation (lighter than `explore_auth`).
 
 Returns from `analyze_app`:
 
@@ -51,6 +52,14 @@ npx playwright install chromium
 This is a one-time step. You'll only need to do it again if Playwright's browser version is bumped in a future qulib release.
 
 If you skip this step, the first tool call will return a clear error telling you to run the command.
+
+## Agentic auth exploration (`explore_auth`)
+
+On unfamiliar apps, call **`explore_auth`** before **`analyze_app`**. The response lists each sign-in path (curated public OAuth/SSO, password forms, magic-link wording, and **heuristic** unknown buttons such as tenant-specific SSO). Each path includes **`requirements`** (e.g. storage-state vs credentials) and **`suggestedAgentBehavior`**.
+
+When the model sees **`unrecognizedButtons`**, it can ask the user to register a label on the **MCP host** with the CLI:
+
+`qulib auth providers add --id <kebab-id> --label "..." --pattern "..."` — patterns are saved under **`~/.qulib/providers.json`** and merged with the built-in list on the next `explore_auth` / `explore-auth`. Nothing is auto-written without an explicit `providers add`.
 
 ## Example usage
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,7 +2,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { analyzeApp, detectAuth } from '@qulib/core';
+import { analyzeApp, detectAuth, exploreAuth } from '@qulib/core';
 import { z } from 'zod';
 
 const FormLoginMcpAuthSchema = z.object({
@@ -42,6 +42,19 @@ const server = new Server(
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
+    {
+      name: 'explore_auth',
+      description:
+        'Use this BEFORE analyze_app when scanning unfamiliar apps. Returns all detected sign-in paths with per-path requirements describing what credentials or actions the agent must collect from the user before calling analyze_app. Combines built-in OAuth/SSO labels, user-local patterns from ~/.qulib/providers.json, and heuristic unknown buttons.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          url: { type: 'string', description: 'Full URL of the deployed app or login page' },
+          timeoutMs: { type: 'number', description: 'Navigation timeout in milliseconds (default 20000)' },
+        },
+        required: ['url'],
+      },
+    },
     {
       name: 'analyze_app',
       description:
@@ -108,6 +121,20 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 }));
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  if (request.params.name === 'explore_auth') {
+    const { url, timeoutMs } = z
+      .object({
+        url: z.string().url(),
+        timeoutMs: z.number().int().positive().optional(),
+      })
+      .parse(request.params.arguments ?? {});
+
+    const result = await exploreAuth(url, timeoutMs);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  }
+
   if (request.params.name === 'detect_auth') {
     const { url, timeoutMs } = z
       .object({


### PR DESCRIPTION
## Summary

Introduces the `explore_auth` MCP tool and `qulib explore-auth` CLI command — Stage 1 of the agentic auth handshake.

## What this adds

- `exploreAuth(url)` core function that returns a structured `AuthExploration` with all detected sign-in paths
- New MCP tool `explore_auth` for agentic auth discovery
- Built-in OAuth/SSO provider list (curated, public providers only)
- User-local provider registry at `~/.qulib/providers.json`
- New CLI subcommands: `qulib auth providers list | add | remove`
- Heuristic detection for unknown sign-in buttons (`oauth-unknown` type)

## What this does NOT change

- `analyze_app` behavior is unchanged in this PR
- The existing `detectAuth` function remains for backward compatibility
- No version bump in this PR — release commit comes after merge

## Smoke tests passed

- Open site (example.com) → no auth required
- Form login (notquality.com/login) → detected
- Multi-provider (platform.scholastic.com) → Google + Clever + ClassLink as built-in, Scholastic Sync as unknown
- User-local round-trip: register Scholastic Sync, re-scan, detected as user-local high-confidence

## Future stages (not in this PR)

- Stage 2: multi-field auth handler (form-login-multi with select/checkbox fields)
- Stage 3: `analyze_app` accepts the structured `{ pathId, credentials }` shape — ships as 0.3.0