### PR TITLE
feat: Cost Intelligence, OAuth public-surface scans, and MCP progress logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,39 @@
 # Qulib
 
-**Qulib** is an opinionated QA harness that analyzes deployed web apps and reports honest quality gaps. Built to answer one question: **is this app ready to ship?**
+**Honest QA gap analysis for deployed web apps.**
 
-On npm the packages stay lowercase: **`@qulib/core`** (library + CLI) and **`@qulib/mcp`** (MCP server). The CLI binary is **`qulib`**.
+Qulib is an opinionated harness that answers one question: **is this app ready to ship?** It prefers **honest uncertainty** over fake confidence: if auth blocks the crawl, coverage is thin, or data is incomplete, the report says so.
+
+**Design line:** AI should explore unknown gaps; **deterministic checks** (crawl, axe, links, console) should scale. Cost Intelligence tracks LLM usage so repeated reasoning can graduate into checks you own in CI.
+
+On npm: **`@qulib/core`** (engine + CLI `qulib`) and **`@qulib/mcp`** (MCP server for AI agents).
 
 [![npm @qulib/core](https://img.shields.io/npm/v/@qulib/core?label=%40qulib%2Fcore)](https://www.npmjs.com/package/@qulib/core)
 [![npm @qulib/mcp](https://img.shields.io/npm/v/@qulib/mcp?label=%40qulib%2Fmcp)](https://www.npmjs.com/package/@qulib/mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
+---
+
 ## What Qulib does
 
-- Crawls deployed web apps (anonymous or authenticated)
-- Runs real accessibility scans (axe-core, WCAG 2 A/AA)
+- Crawls deployed apps (anonymous or authenticated via Playwright)
+- Runs **axe-core** accessibility checks (WCAG 2 A/AA)
 - Detects broken links, console errors, navigation failures
-- Computes a release confidence score with an explicit coverage floor
-- Returns structured reports (JSON, Markdown) — or runs ephemeral with no disk writes
-- Ships as **`@qulib/core`** (engine + CLI) and **`@qulib/mcp`** (AI-facing MCP server)
+- Computes **release confidence** (0–100) with a **coverage floor** when too few pages were scanned
+- Emits **JSON** and **Markdown** reports (or **ephemeral** JSON on stdout)
+- **Auth-aware:** optional `detect-auth`, `explore-auth`, form-login, and storage-state flows
+- **Cost Intelligence** (optional block on gap analysis): token usage, budget warnings vs per-call output ceiling, prompt fingerprints, maturity hints, conversion recommendations
+
+---
 
 ## Packages
 
 | Package | Purpose |
 |---------|---------|
-| [`@qulib/core`](./packages/core) | The analyzer engine and CLI (`qulib`) |
-| [`@qulib/mcp`](./packages/mcp) | MCP server exposing Qulib to AI agents (e.g. Claude Code) |
+| [`@qulib/core`](./packages/core) | Analyzer engine and CLI (`qulib`) |
+| [`@qulib/mcp`](./packages/mcp) | MCP server exposing Qulib to AI clients |
+
+---
 
 ## Quick start (CLI)
 
@@ -30,11 +41,29 @@ On npm the packages stay lowercase: **`@qulib/core`** (library + CLI) and **`@qu
 npx @qulib/core analyze --url https://example.com
 ```
 
-For local development from a clone, use `npm run analyze -w @qulib/core -- --url https://example.com` from the repo root, or `cd packages/core` and `npm run analyze -- --url https://example.com`.
+From a clone (repo root):
+
+```bash
+npm run analyze -w @qulib/core -- --url https://example.com
+```
+
+Or `cd packages/core` and `npm run analyze -- --url https://example.com`.
+
+**Smoke (no disk writes):**
+
+```bash
+npm run smoke
+```
+
+**Cost doctor** (after a normal analyze that wrote `output/report.json`):
+
+```bash
+cd packages/core && npx tsx src/cli/index.ts cost doctor
+```
+
+---
 
 ## Quick start (MCP)
-
-Add to your Claude Code or Claude Desktop MCP config:
 
 ```json
 {
@@ -47,21 +76,40 @@ Add to your Claude Code or Claude Desktop MCP config:
 }
 ```
 
-Then ask Claude:
+Ask your agent:
 
-> "Use Qulib to analyze https://example.com and tell me if it's ready to ship."
+> Use Qulib to analyze https://example.com and tell me if it's ready to ship.
+
+Default **`analyze_app`** responses are **summary-first** (top gaps, cost summary, next deterministic checks). Pass **`includeFullReport: true`** for the full `gapAnalysis` including all scenarios.
+
+---
+
+## Release confidence (short)
+
+- Score starts from **100** and is reduced by **high / medium / low** gaps (see [`gap-engine`](./packages/core/src/tools/gap-engine.ts)).
+- If **fewer than `minPagesForConfidence`** pages were scanned, confidence is **capped at 40** and a **`low-coverage`** warning is set—thin coverage must not read as “ready”.
+- **`auth-required`** early exit sets confidence **0** with no gap inventory: the deployment was not actually exercised.
+
+Details: [packages/core/README.md](./packages/core/README.md).
+
+---
 
 ## Documentation
 
-- [Core package (CLI & API)](./packages/core/README.md)
+- [Core (CLI, API, Cost Intelligence)](./packages/core/README.md)
 - [MCP server](./packages/mcp/README.md)
 - [Contributing](./CONTRIBUTING.md)
-- [Security policy](./SECURITY.md)
+- [Security](./SECURITY.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [Manual testing checklist](./docs/manual-testing-checklist.md)
+
+---
 
 ## Contributing
 
-We welcome issues and pull requests. Start with [CONTRIBUTING.md](./CONTRIBUTING.md) for a fast local setup and conventions. Optional release smoke steps (CLI, auth detection when present, MCP) live in the [manual testing checklist](./docs/manual-testing-checklist.md). Everyone participating in the project is expected to follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
+Issues and PRs are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md). Follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+---
 
 ## License
 

--- a/docs/manual-testing-checklist.md
+++ b/docs/manual-testing-checklist.md
@@ -6,11 +6,14 @@ Use this before releases or after changes to crawling, auth, MCP tools, or repor
 
 - [ ] Repo root: `npm install`
 - [ ] `npm run build`
+- [ ] `npm run test` (core + MCP unit tests)
 - [ ] Playwright browsers (first machine / after Playwright upgrade): `cd packages/core && npx playwright install chromium`
 
 ## Core CLI (any branch with CLI changes)
 
 - [ ] `cd packages/core && npm run analyze -- --url https://notquality.com --ephemeral` (or another stable public URL): exits 0, JSON on stdout in ephemeral mode
+- [ ] `gapAnalysis.costIntelligence` present with `maxOutputTokensPerLlmCall`, `usageSummary`, `deterministicMaturity`
+- [ ] After a non-ephemeral analyze: `cd packages/core && npm run cost-doctor` prints Cost Intelligence from `output/report.json`
 - [ ] `npm run clean` (from `packages/core`): resets `output/` and `.scan-state/` without errors
 
 ## Auth detection and helpers
@@ -41,7 +44,8 @@ node packages/core/bin/qulib.js detect-auth --url "<URL>" --timeout 30000
 
 - [ ] Server starts: `node packages/mcp/dist/index.js` (or workspace equivalent) without startup errors
 - [ ] **`detect_auth`:** call with `{ "url": "https://github.com/login" }` → JSON matches CLI `detect-auth` for the same URL
-- [ ] **`analyze_app`:** `{ "url": "https://notquality.com" }` → structured result, exit 0 through client
+- [ ] **`analyze_app`:** `{ "url": "https://notquality.com" }` → summary-first JSON (`topGaps`, `costIntelligenceSummary`, `includeFullReport: false`)
+- [ ] **`analyze_app`:** `{ "url": "https://notquality.com", "includeFullReport": true }` → full payload including all scenarios
 - [ ] **`analyze_app` + storage-state** (if supported in your version): path to a file from `auth init` on the **same host** as the MCP process
 
 ## Known tricky URLs (regression notes)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
+    "smoke": "npm run smoke -w @qulib/core",
     "clean": "npm run clean -w @qulib/core --if-present"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
+    "test:integration": "npm run test:integration -w @qulib/core",
     "smoke": "npm run smoke -w @qulib/core",
     "clean": "npm run clean -w @qulib/core --if-present"
   }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -81,6 +81,29 @@ Or via MCP:
 
 > "Use qulib's detect_auth tool on https://app.example.com — what's the recommended auth setup?"
 
+## Release confidence
+
+The score (0–100) is derived from **deterministic gaps** (untested routes vs repo, console errors, broken links, axe violations). High-severity items subtract more than low-severity ones. If **`coveragePagesScanned` is below `minPagesForConfidence`**, the score is **capped at 40** and `coverageWarning` is set to **`low-coverage`** so a shallow crawl cannot masquerade as high confidence.
+
+When **`mode` is `auth-required`**, the scan never reached real app pages behind login: **release confidence is 0**, gaps are empty, and Cost Intelligence reflects the blocked state (L0 maturity).
+
+## LLM scenario budget (naming)
+
+- **`llmTokenBudget`** (legacy name, still required in config files): **max output tokens for a single** scenario-generation LLM completion. It maps to the provider’s **per-request completion cap**, not a multi-call or “whole run” token budget.
+- **`llmMaxOutputTokensPerCall`** (optional): when set, **overrides** `llmTokenBudget` for the same purpose—clearer naming.
+- **`enableLlmScenarios`**: when **`false`**, Qulib never calls an LLM for scenarios (templates only).
+
+## Cost Intelligence and `qulib cost doctor`
+
+After a normal **`analyze`**, `output/report.json` includes **`gapAnalysis.costIntelligence`**: usage records (**`actual`** vs **`estimated`** vs **`none`**), per-completion ceiling, budget warnings, repeated prompt fingerprints (when the same hash appears twice in one run), deterministic maturity (L0–L3 with an explicit ceiling for L4/L5), and conversion recommendations.
+
+Re-print that block from disk:
+
+```bash
+npx tsx src/cli/index.ts cost doctor
+# or: npx tsx src/cli/index.ts cost doctor --report output/report.json
+```
+
 ## CLI (from npm)
 
 ```bash
@@ -101,6 +124,8 @@ const config: HarnessConfig = {
   timeoutMs: 30000,
   retryCount: 2,
   llmTokenBudget: 4000,
+  llmMaxOutputTokensPerCall: undefined,
+  enableLlmScenarios: true,
   testGenerationLimit: 10,
   readOnlyMode: true,
   requireHumanReview: true,
@@ -116,7 +141,7 @@ const result = await analyzeApp({
   writeArtifacts: false,
 });
 
-console.log(result.releaseConfidence, result.gapAnalysis);
+console.log(result.releaseConfidence, result.gapAnalysis.costIntelligence);
 ```
 
 ## Repository
@@ -134,7 +159,7 @@ This package is part of **[Qulib](https://github.com/TapeshN/qulib)** ([repo REA
 - Optional **authenticated** crawling via `auth` in config (`form-login` or Playwright `storage-state`).
 - Repo scanner: routes, tests, Cypress structure.
 - Gap engine: deterministic gaps, **release confidence** with a low-page coverage floor, coverage warnings.
-- Reports: `output/report.json` and `output/report.md` when not using **`--ephemeral`**.
+- Reports: `output/report.json` and `output/report.md` when not using **`--ephemeral`** (both include **Cost Intelligence** when present on `gapAnalysis`).
 - State under `.scan-state/` unless **`--ephemeral`** (no disk writes; full JSON on stdout).
 - **`npm run clean`** removes generated `output/` and `.scan-state/` and restores `.gitkeep` placeholders.
 
@@ -172,6 +197,9 @@ Use the same **hostname** for `--url` as your app’s canonical host when you ca
 - `npm run dev` — CLI via `tsx` (append subcommands, e.g. `npm run dev -- clean`)
 - `npm run analyze -- --url <url> [--repo <path>] [--config <file>] [--ephemeral]`
 - `npm run clean` — reset `output/` and `.scan-state/` here
+- `npm run test` — unit tests (cost intelligence + hashing)
+- `npm run smoke` — ephemeral analyze of `https://example.com` (uses this package’s `qulib.config.ts`)
+- `npm run cost-doctor` — print Cost Intelligence from `output/report.json` (run a non-ephemeral `analyze` first)
 - `npm run build` — compile to `dist/`
 
 From the **repository root**:
@@ -209,7 +237,7 @@ npx playwright install chromium
 
 ## Output and state (cwd = `packages/core` when you `cd` here)
 
-**Ephemeral:** stdout prints one JSON object: `gapAnalysis`, `discoveredRoutes`, `repoInventory`, `decisionLog`.
+**Ephemeral:** stdout prints one JSON object: `gapAnalysis` (including **`costIntelligence`** when populated), `discoveredRoutes`, `repoInventory`, `decisionLog`.
 
 **Persistent:**
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "analyze": "tsx src/cli/index.ts analyze",
     "clean": "tsx src/cli/index.ts clean",
     "build": "tsc",
-    "test": "node --import tsx/esm --test src/llm/cost-intelligence.test.ts",
+    "test": "node --import tsx/esm --test src/llm/cost-intelligence.test.ts src/tools/gap-engine.test.ts src/tools/auth-block-gap.test.ts",
     "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral",
     "cost-doctor": "tsx src/cli/index.ts cost doctor"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,7 @@
     "clean": "tsx src/cli/index.ts clean",
     "build": "tsc",
     "test": "node --import tsx/esm --test src/llm/cost-intelligence.test.ts src/tools/gap-engine.test.ts src/tools/auth-block-gap.test.ts",
+    "test:integration": "node --import tsx/esm --test src/analyze.integration.test.ts",
     "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral",
     "cost-doctor": "tsx src/cli/index.ts cost doctor"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,8 @@
     "dev": "tsx src/cli/index.ts",
     "analyze": "tsx src/cli/index.ts analyze",
     "clean": "tsx src/cli/index.ts clean",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "node --import tsx/esm --test src/llm/cost-intelligence.test.ts"
   },
   "dependencies": {
     "@axe-core/playwright": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,8 @@
     "analyze": "tsx src/cli/index.ts analyze",
     "clean": "tsx src/cli/index.ts clean",
     "build": "tsc",
-    "test": "node --import tsx/esm --test src/llm/cost-intelligence.test.ts"
+    "test": "node --import tsx/esm --test src/llm/cost-intelligence.test.ts",
+    "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral"
   },
   "dependencies": {
     "@axe-core/playwright": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,8 @@
     "clean": "tsx src/cli/index.ts clean",
     "build": "tsc",
     "test": "node --import tsx/esm --test src/llm/cost-intelligence.test.ts",
-    "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral"
+    "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral",
+    "cost-doctor": "tsx src/cli/index.ts cost doctor"
   },
   "dependencies": {
     "@axe-core/playwright": "^4.9.0",

--- a/packages/core/qulib.config.ts
+++ b/packages/core/qulib.config.ts
@@ -7,6 +7,8 @@ const config: HarnessConfig = {
   timeoutMs: 30000,
   retryCount: 2,
   llmTokenBudget: 4000,
+  // llmMaxOutputTokensPerCall: 2048,
+  // enableLlmScenarios: true,
   testGenerationLimit: 10,
   readOnlyMode: true,
   requireHumanReview: true,

--- a/packages/core/src/analyze.integration.test.ts
+++ b/packages/core/src/analyze.integration.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Live-network validation for analyzeApp response shapes (node:test).
+ *
+ * - In CI, set RUN_NETWORK_INTEGRATION=1 to run; otherwise these tests skip so default pipelines stay offline.
+ * - platform.scholastic.com typically yields status "partial" (one pre-auth page crawled), not "blocked"
+ *   (zero routes). Case 2 covers both blocked and partial OAuth-wall outcomes.
+ * - For a strict status "blocked" check only, set QULIB_STRICT_BLOCKED_SCAN_URL to a URL that produces zero public routes.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { analyzeApp } from './analyze.js';
+import { HarnessConfigSchema, type HarnessConfig } from './schemas/config.schema.js';
+
+function integrationHarness(): HarnessConfig {
+  return HarnessConfigSchema.parse({
+    maxPagesToScan: 6,
+    maxDepth: 2,
+    minPagesForConfidence: 3,
+    timeoutMs: 45000,
+    retryCount: 0,
+    llmTokenBudget: 4096,
+    testGenerationLimit: 4,
+    enableLlmScenarios: false,
+    readOnlyMode: true,
+    requireHumanReview: false,
+    failOnConsoleError: false,
+    explorer: 'playwright',
+    defaultAdapter: 'playwright',
+    adapters: ['playwright'],
+  });
+}
+
+async function isUrlReachable(url: string, timeoutMs = 15000): Promise<boolean> {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: ac.signal,
+      headers: { 'User-Agent': 'qulib-analyze-integration/1.0' },
+    });
+    return res.status >= 200 && res.status < 600;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function allowNetworkIntegration(): boolean {
+  if (process.env.CI === 'true' && process.env.RUN_NETWORK_INTEGRATION !== 'true') {
+    return false;
+  }
+  return true;
+}
+
+test('Case 1 — complete scan (public site, no auth wall)', async (t) => {
+  if (!allowNetworkIntegration()) {
+    t.skip('CI without RUN_NETWORK_INTEGRATION=1: skipping live URL integration');
+    return;
+  }
+  const url = 'https://example.com';
+  if (!(await isUrlReachable(url))) {
+    t.skip(`${url} unreachable from this environment`);
+    return;
+  }
+
+  const result = await analyzeApp({ url, config: integrationHarness(), writeArtifacts: false });
+  console.log('[Case 1] full analyzeApp result:\n', JSON.stringify(result, null, 2));
+
+  assert.equal(result.status, 'complete');
+  assert.ok(result.releaseConfidence !== null && result.releaseConfidence !== undefined);
+  assert.ok(result.releaseConfidence >= 0 && result.releaseConfidence <= 100);
+  assert.ok(result.coverageScore !== null);
+  assert.ok(result.coverageScore >= 0 && result.coverageScore <= 100);
+  assert.ok(result.publicSurface !== null);
+  assert.ok(result.publicSurface.pages.length >= 1);
+  assert.ok(Array.isArray(result.gaps));
+  assert.ok(!result.gaps.some((g) => g.id === 'auth-block'));
+});
+
+test('Case 2 — OAuth-gated without storage (platform.scholastic.com)', async (t) => {
+  if (!allowNetworkIntegration()) {
+    t.skip('CI without RUN_NETWORK_INTEGRATION=1: skipping live URL integration');
+    return;
+  }
+  const url = 'https://platform.scholastic.com';
+  if (!(await isUrlReachable(url))) {
+    t.skip(`${url} unreachable from this environment`);
+    return;
+  }
+
+  const result = await analyzeApp({ url, config: integrationHarness(), writeArtifacts: false });
+  console.log('[Case 2] full analyzeApp result:\n', JSON.stringify(result, null, 2));
+
+  assert.ok(result.detectedAuth?.hasAuth, 'expected auth detection on OAuth-gated property');
+  assert.ok(result.publicSurface !== null && result.publicSurface.pages.length >= 1);
+  assert.ok(Array.isArray(result.gaps));
+  assert.ok(result.gaps.some((g) => g.id === 'auth-block'), 'expected auth-block gap in flat gaps');
+  assert.ok(result.gaps.some((g) => g.category === 'auth-surface'), 'expected auth-surface gap(s)');
+  assert.equal(result.routeInventory.routes.length, 0, 'authenticated route inventory stays empty without credentials');
+
+  if (result.status === 'blocked') {
+    assert.equal(result.releaseConfidence, null);
+    assert.equal(result.coverageScore, 0);
+  } else if (result.status === 'partial') {
+    assert.ok(typeof result.releaseConfidence === 'number');
+    assert.ok(result.releaseConfidence >= 0 && result.releaseConfidence <= 100);
+    assert.ok(result.coverageScore !== null);
+    assert.ok(result.coverageScore >= 0 && result.coverageScore <= 100);
+  } else {
+    assert.fail(`unexpected status ${result.status} for OAuth wall without storage`);
+  }
+});
+
+test('Case 2b — strictly blocked (0 public routes), optional QULIB_STRICT_BLOCKED_SCAN_URL', async (t) => {
+  const url = process.env.QULIB_STRICT_BLOCKED_SCAN_URL;
+  if (!url) {
+    t.skip('Set QULIB_STRICT_BLOCKED_SCAN_URL to assert status=blocked (0-route) OAuth wall behavior');
+    return;
+  }
+  if (!allowNetworkIntegration()) {
+    t.skip('CI without RUN_NETWORK_INTEGRATION=1: skipping live URL integration');
+    return;
+  }
+  if (!(await isUrlReachable(url))) {
+    t.skip(`${url} unreachable from this environment`);
+    return;
+  }
+
+  const result = await analyzeApp({ url, config: integrationHarness(), writeArtifacts: false });
+  console.log('[Case 2b] full analyzeApp result:\n', JSON.stringify(result, null, 2));
+
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.releaseConfidence, null);
+  assert.equal(result.coverageScore, 0);
+  assert.ok(result.gaps.some((g) => g.id === 'auth-block'));
+  assert.ok(result.gaps.some((g) => g.category === 'auth-surface'));
+});
+
+test.skip('Case 3 — partial scan — requires storage state', async () => undefined);

--- a/packages/core/src/analyze.ts
+++ b/packages/core/src/analyze.ts
@@ -7,6 +7,7 @@ import { observe } from './phases/observe.js';
 import { think } from './phases/think.js';
 import { act } from './phases/act.js';
 import { detectAuth } from './tools/auth-detector.js';
+import { costIntelligenceForAuthBlocked } from './llm/cost-intelligence.js';
 
 export interface AnalyzeOptions {
   url: string;
@@ -46,6 +47,7 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
         gaps: [],
         scenarios: [],
         generatedTests: [],
+        costIntelligence: costIntelligenceForAuthBlocked(options.config.llmTokenBudget),
       });
       return {
         releaseConfidence: 0,

--- a/packages/core/src/analyze.ts
+++ b/packages/core/src/analyze.ts
@@ -1,13 +1,20 @@
-import { resolveMaxOutputTokensPerLlmCall, type HarnessConfig, type DetectedAuth } from './schemas/config.schema.js';
-import { GapAnalysisSchema, type GapAnalysis } from './schemas/gap-analysis.schema.js';
-import type { RouteInventory } from './schemas/route-inventory.schema.js';
+import { type HarnessConfig, type DetectedAuth } from './schemas/config.schema.js';
+import type { Gap, GapAnalysis } from './schemas/gap-analysis.schema.js';
+import { RouteInventorySchema, type RouteInventory } from './schemas/route-inventory.schema.js';
 import type { RepoAnalysis } from './schemas/repo-analysis.schema.js';
 import type { DecisionLogEntry } from './schemas/decision-log.schema.js';
+import { PublicSurfaceSchema, type PublicSurface } from './schemas/public-surface.schema.js';
 import { observe } from './phases/observe.js';
 import { think } from './phases/think.js';
 import { act } from './phases/act.js';
 import { detectAuth } from './tools/auth-detector.js';
-import { costIntelligenceForAuthBlocked } from './llm/cost-intelligence.js';
+import { analyzeGaps, computeCoverageScore, computeQualityScoreFromGaps } from './tools/gap-engine.js';
+import { analyzeAuthSurfaceGaps } from './tools/auth-surface-analyzer.js';
+import { buildPublicSurface } from './tools/public-surface.js';
+import { buildAuthBlockGap } from './tools/auth-block-gap.js';
+import { finalizeGapAnalysisFromDraft, type GapAnalysisDraft } from './phases/think-finalize.js';
+
+export type AnalyzeStatus = 'complete' | 'blocked' | 'partial';
 
 export interface AnalyzeOptions {
   url: string;
@@ -18,12 +25,20 @@ export interface AnalyzeOptions {
 }
 
 export interface AnalyzeResult {
-  releaseConfidence: number;
+  status: AnalyzeStatus;
+  coverageScore: number | null;
+  /** Quality of evaluated pages only; `null` when no evaluable surface produced a score (fully blocked). */
+  releaseConfidence: number | null;
+  /** Same entries as `gapAnalysis.gaps` for consumers that read a flat `gaps` field. */
+  gaps: Gap[];
   gapAnalysis: GapAnalysis;
+  /** Authenticated crawl scope only; empty routes when the scan stopped at an auth wall without credentials. */
   routeInventory: RouteInventory;
   repoInventory: RepoAnalysis | null;
   decisionLog: DecisionLogEntry[];
   detectedAuth?: DetectedAuth;
+  /** Public pre-auth crawl; `null` when there was no auth wall or the flow matched a normal authenticated scan. */
+  publicSurface: PublicSurface | null;
 }
 
 export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult> {
@@ -34,55 +49,101 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
     decisionMemory: decisionLog,
   };
 
+  let detectedAuth: DetectedAuth | undefined;
+  let authWall = false;
   if (!options.config.auth && !options.skipAuthDetection) {
-    const detection = await detectAuth(options.url, options.config.timeoutMs);
-    if (detection.hasAuth) {
-      const gapAnalysis = GapAnalysisSchema.parse({
-        analyzedAt: new Date().toISOString(),
-        mode: 'auth-required' as const,
-        releaseConfidence: 0,
-        coveragePagesScanned: 0,
-        coverageBudgetExceeded: false,
-        coverageWarning: 'auth-required' as const,
-        gaps: [],
-        scenarios: [],
-        generatedTests: [],
-        costIntelligence: costIntelligenceForAuthBlocked(resolveMaxOutputTokensPerLlmCall(options.config)),
-      });
-      return {
-        releaseConfidence: 0,
-        gapAnalysis,
-        routeInventory: {
-          scannedAt: new Date().toISOString(),
-          baseUrl: options.url,
-          routes: [],
-          pagesSkipped: 0,
-          budgetExceeded: false,
-        },
-        repoInventory: null,
-        decisionLog: [
-          {
-            timestamp: new Date().toISOString(),
-            phase: 'observe' as const,
-            decision: 'auth-required',
-            reason: detection.recommendation,
-            metadata: { detection },
-          },
-        ],
-        detectedAuth: detection,
-      };
-    }
+    detectedAuth = await detectAuth(options.url, options.config.timeoutMs);
+    authWall = Boolean(detectedAuth.hasAuth);
   }
 
   const observed = await observe(options.url, options.repoPath, options.config, artifacts);
+
+  if (authWall && !options.config.auth && detectedAuth) {
+    decisionLog.push({
+      timestamp: new Date().toISOString(),
+      phase: 'observe',
+      decision: 'auth-required',
+      reason: detectedAuth.recommendation,
+      metadata: { detection: detectedAuth },
+    });
+
+    const mode = observed.repo ? 'url-repo' : 'url-only';
+    const publicAnalysis = analyzeGaps(observed.routes, observed.repo, mode, options.config);
+    const publicSurface = PublicSurfaceSchema.parse(
+      buildPublicSurface(observed.routes.routes, publicAnalysis.gaps)
+    );
+    const authSurfaceGaps = await analyzeAuthSurfaceGaps(
+      options.url,
+      detectedAuth,
+      options.config.timeoutMs
+    );
+    const authBlockGap = buildAuthBlockGap(options.url);
+    const status: AnalyzeStatus = observed.routes.routes.length === 0 ? 'blocked' : 'partial';
+    const qualityInputGaps = [...publicAnalysis.gaps, ...authSurfaceGaps];
+    const qualityScore = computeQualityScoreFromGaps(qualityInputGaps);
+    const draftRelease = status === 'blocked' ? null : qualityScore;
+
+    const draft: GapAnalysisDraft = {
+      analyzedAt: new Date().toISOString(),
+      mode: 'auth-required',
+      releaseConfidence: draftRelease,
+      coveragePagesScanned: 0,
+      coverageBudgetExceeded: false,
+      coverageWarning: 'auth-required',
+      gaps: [...authSurfaceGaps, authBlockGap],
+    };
+
+    const costContext: Pick<GapAnalysis, 'mode' | 'coveragePagesScanned' | 'releaseConfidence' | 'gaps'> = {
+      mode: publicAnalysis.mode,
+      coveragePagesScanned: observed.routes.routes.length,
+      releaseConfidence: qualityScore,
+      gaps: publicAnalysis.gaps,
+    };
+
+    const gapAnalysis = await finalizeGapAnalysisFromDraft(
+      draft,
+      options.config,
+      artifacts,
+      costContext
+    );
+
+    const emptyAuthRoutes = RouteInventorySchema.parse({
+      scannedAt: new Date().toISOString(),
+      baseUrl: options.url,
+      routes: [],
+      pagesSkipped: 0,
+      budgetExceeded: false,
+    });
+
+    await act(gapAnalysis, options.config, artifacts);
+
+    return {
+      status,
+      coverageScore: computeCoverageScore(observed.routes),
+      releaseConfidence: draftRelease,
+      gaps: gapAnalysis.gaps,
+      gapAnalysis,
+      routeInventory: emptyAuthRoutes,
+      repoInventory: observed.repo,
+      decisionLog,
+      detectedAuth,
+      publicSurface,
+    };
+  }
+
   const analysis = await think(observed, options.config, artifacts);
   await act(analysis, options.config, artifacts);
 
   return {
+    status: 'complete',
+    coverageScore: computeCoverageScore(observed.routes),
     releaseConfidence: analysis.releaseConfidence,
+    gaps: analysis.gaps,
     gapAnalysis: analysis,
     routeInventory: observed.routes,
     repoInventory: observed.repo,
     decisionLog,
+    ...(detectedAuth !== undefined && { detectedAuth }),
+    publicSurface: null,
   };
 }

--- a/packages/core/src/analyze.ts
+++ b/packages/core/src/analyze.ts
@@ -1,4 +1,4 @@
-import type { HarnessConfig, DetectedAuth } from './schemas/config.schema.js';
+import { resolveMaxOutputTokensPerLlmCall, type HarnessConfig, type DetectedAuth } from './schemas/config.schema.js';
 import { GapAnalysisSchema, type GapAnalysis } from './schemas/gap-analysis.schema.js';
 import type { RouteInventory } from './schemas/route-inventory.schema.js';
 import type { RepoAnalysis } from './schemas/repo-analysis.schema.js';
@@ -47,7 +47,7 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
         gaps: [],
         scenarios: [],
         generatedTests: [],
-        costIntelligence: costIntelligenceForAuthBlocked(options.config.llmTokenBudget),
+        costIntelligence: costIntelligenceForAuthBlocked(resolveMaxOutputTokensPerLlmCall(options.config)),
       });
       return {
         releaseConfidence: 0,

--- a/packages/core/src/analyze.ts
+++ b/packages/core/src/analyze.ts
@@ -37,7 +37,7 @@ export interface AnalyzeResult {
   repoInventory: RepoAnalysis | null;
   decisionLog: DecisionLogEntry[];
   detectedAuth?: DetectedAuth;
-  /** Public pre-auth crawl; `null` when there was no auth wall or the flow matched a normal authenticated scan. */
+  /** Crawled public routes and their gap-derived surface (complete scans); OAuth-wall scans use the pre-auth crawl only. */
   publicSurface: PublicSurface | null;
 }
 
@@ -134,6 +134,10 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
   const analysis = await think(observed, options.config, artifacts);
   await act(analysis, options.config, artifacts);
 
+  const publicSurface = PublicSurfaceSchema.parse(
+    buildPublicSurface(observed.routes.routes, analysis.gaps)
+  );
+
   return {
     status: 'complete',
     coverageScore: computeCoverageScore(observed.routes),
@@ -144,6 +148,6 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
     repoInventory: observed.repo,
     decisionLog,
     ...(detectedAuth !== undefined && { detectedAuth }),
-    publicSurface: null,
+    publicSurface,
   };
 }

--- a/packages/core/src/analyze.ts
+++ b/packages/core/src/analyze.ts
@@ -13,6 +13,7 @@ import { analyzeAuthSurfaceGaps } from './tools/auth-surface-analyzer.js';
 import { buildPublicSurface } from './tools/public-surface.js';
 import { buildAuthBlockGap } from './tools/auth-block-gap.js';
 import { finalizeGapAnalysisFromDraft, type GapAnalysisDraft } from './phases/think-finalize.js';
+import type { AnalyzeProgressSink } from './harness/progress-log.js';
 
 export type AnalyzeStatus = 'complete' | 'blocked' | 'partial';
 
@@ -22,6 +23,7 @@ export interface AnalyzeOptions {
   config: HarnessConfig;
   writeArtifacts?: boolean;
   skipAuthDetection?: boolean;
+  progressLog?: AnalyzeProgressSink;
 }
 
 export interface AnalyzeResult {
@@ -41,18 +43,34 @@ export interface AnalyzeResult {
   publicSurface: PublicSurface | null;
 }
 
+function logScanEnd(progress: AnalyzeProgressSink | undefined, result: AnalyzeResult): void {
+  const rc = result.releaseConfidence === null ? 'null' : String(result.releaseConfidence);
+  const cs = result.coverageScore === null ? 'null' : String(result.coverageScore);
+  progress?.info(`status=${result.status} | coverageScore=${cs} | releaseConfidence=${rc} | gaps=${result.gaps.length}`);
+  for (const g of result.gaps) {
+    progress?.debug(`gap id=${g.id} severity=${g.severity} category=${g.category}`);
+  }
+  if (process.env.QULIB_DEBUG === '1') {
+    progress?.debug(`gaps json=${JSON.stringify(result.gaps)}`);
+  }
+}
+
 export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult> {
   const writeArtifacts = options.writeArtifacts ?? false;
   const decisionLog: DecisionLogEntry[] = [];
+  const progress = options.progressLog;
   const artifacts = {
     writeArtifacts,
     decisionMemory: decisionLog,
+    ...(progress !== undefined && { progressLog: progress }),
   };
+
+  progress?.info(`Starting scan → ${options.url} maxPagesToScan=${options.config.maxPagesToScan}`);
 
   let detectedAuth: DetectedAuth | undefined;
   let authWall = false;
   if (!options.config.auth && !options.skipAuthDetection) {
-    detectedAuth = await detectAuth(options.url, options.config.timeoutMs);
+    detectedAuth = await detectAuth(options.url, options.config.timeoutMs, progress);
     authWall = Boolean(detectedAuth.hasAuth);
   }
 
@@ -67,18 +85,26 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
       metadata: { detection: detectedAuth },
     });
 
+    const status: AnalyzeStatus = observed.routes.routes.length === 0 ? 'blocked' : 'partial';
+    if (status === 'blocked') {
+      progress?.warn('Scan blocked by auth wall');
+    } else {
+      progress?.warn('Auth wall: continuing with public surface only (partial)');
+    }
+
     const mode = observed.repo ? 'url-repo' : 'url-only';
     const publicAnalysis = analyzeGaps(observed.routes, observed.repo, mode, options.config);
     const publicSurface = PublicSurfaceSchema.parse(
       buildPublicSurface(observed.routes.routes, publicAnalysis.gaps)
     );
+    progress?.info(`Public surface crawl: ${publicSurface.pages.length} page(s) reachable pre-auth`);
+
     const authSurfaceGaps = await analyzeAuthSurfaceGaps(
       options.url,
       detectedAuth,
       options.config.timeoutMs
     );
     const authBlockGap = buildAuthBlockGap(options.url);
-    const status: AnalyzeStatus = observed.routes.routes.length === 0 ? 'blocked' : 'partial';
     const qualityInputGaps = [...publicAnalysis.gaps, ...authSurfaceGaps];
     const qualityScore = computeQualityScoreFromGaps(qualityInputGaps);
     const draftRelease = status === 'blocked' ? null : qualityScore;
@@ -117,7 +143,7 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
 
     await act(gapAnalysis, options.config, artifacts);
 
-    return {
+    const result: AnalyzeResult = {
       status,
       coverageScore: computeCoverageScore(observed.routes),
       releaseConfidence: draftRelease,
@@ -129,6 +155,8 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
       detectedAuth,
       publicSurface,
     };
+    logScanEnd(progress, result);
+    return result;
   }
 
   const analysis = await think(observed, options.config, artifacts);
@@ -137,8 +165,9 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
   const publicSurface = PublicSurfaceSchema.parse(
     buildPublicSurface(observed.routes.routes, analysis.gaps)
   );
+  progress?.info(`Public surface crawl: ${publicSurface.pages.length} page(s) reachable pre-auth`);
 
-  return {
+  const result: AnalyzeResult = {
     status: 'complete',
     coverageScore: computeCoverageScore(observed.routes),
     releaseConfidence: analysis.releaseConfidence,
@@ -150,4 +179,6 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
     ...(detectedAuth !== undefined && { detectedAuth }),
     publicSurface,
   };
+  logScanEnd(progress, result);
+  return result;
 }

--- a/packages/core/src/cli/cost-doctor.ts
+++ b/packages/core/src/cli/cost-doctor.ts
@@ -64,7 +64,7 @@ export async function runCostDoctor(reportPath: string): Promise<void> {
     console.log(`- ${c}`);
   }
   const topGap = [...parsed.data.gaps].sort((a, b) => {
-    const o = { high: 0, medium: 1, low: 2 };
+    const o = { critical: 0, high: 1, medium: 2, low: 3 };
     return o[a.severity] - o[b.severity];
   })[0];
   console.log('\n## Next best deterministic check\n');

--- a/packages/core/src/cli/cost-doctor.ts
+++ b/packages/core/src/cli/cost-doctor.ts
@@ -1,0 +1,82 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { GapAnalysisSchema } from '../schemas/gap-analysis.schema.js';
+
+export async function runCostDoctor(reportPath: string): Promise<void> {
+  const abs = resolve(process.cwd(), reportPath);
+  let raw: string;
+  try {
+    raw = await readFile(abs, 'utf8');
+  } catch {
+    throw new Error(
+      `Could not read ${abs}. Run \`qulib analyze --url <url>\` (without --ephemeral) from this directory first.`
+    );
+  }
+
+  const parsed = GapAnalysisSchema.safeParse(JSON.parse(raw) as unknown);
+  if (!parsed.success) {
+    throw new Error('File is not a valid gap analysis report (report.json schema mismatch).');
+  }
+
+  const ci = parsed.data.costIntelligence;
+  if (!ci) {
+    console.log(
+      '[qulib] No costIntelligence in this report (older scan). Re-run analyze with the current qulib version to populate Cost Intelligence.'
+    );
+    return;
+  }
+
+  console.log('# Qulib cost doctor\n');
+  console.log(`Report: ${abs}`);
+  console.log(`Analyzed at: ${parsed.data.analyzedAt}\n`);
+  console.log('## Token ceiling (per LLM completion)\n');
+  console.log(`- maxOutputTokensPerLlmCall: ${ci.maxOutputTokensPerLlmCall}`);
+  console.log(`- budgetRole: ${ci.budgetRole}\n`);
+  console.log('## Usage (this scan)\n');
+  console.log(
+    `- Input / output tokens: ${ci.usageSummary.totalInputTokens} / ${ci.usageSummary.totalOutputTokens} (${ci.usageSummary.dataQuality})`
+  );
+  if (ci.budgetWarnings.length) {
+    console.log('\n## Budget warnings\n');
+    for (const w of ci.budgetWarnings) {
+      console.log(`- ${w}`);
+    }
+  } else {
+    console.log('\n## Budget warnings\n\n- (none)\n');
+  }
+  if (ci.repeatedOperations.length) {
+    console.log('\n## Repeated AI patterns\n');
+    for (const r of ci.repeatedOperations) {
+      console.log(`- ${r.promptHash} ×${r.count}`);
+      console.log(`  ${r.recommendation}`);
+    }
+  } else {
+    console.log('\n## Repeated AI patterns\n\n- (none in this run)\n');
+  }
+  console.log('\n## Deterministic maturity\n');
+  console.log(`- ${ci.deterministicMaturity.label}`);
+  console.log(`- ${ci.deterministicMaturity.rationale}`);
+  if (ci.deterministicMaturity.ceilingNote) {
+    console.log(`- _${ci.deterministicMaturity.ceilingNote}_`);
+  }
+  console.log('\n## Conversion recommendations\n');
+  for (const c of ci.conversionRecommendations) {
+    console.log(`- ${c}`);
+  }
+  const topGap = [...parsed.data.gaps].sort((a, b) => {
+    const o = { high: 0, medium: 1, low: 2 };
+    return o[a.severity] - o[b.severity];
+  })[0];
+  console.log('\n## Next best deterministic check\n');
+  if (topGap) {
+    console.log(
+      `- Prioritize **${topGap.category}** on \`${topGap.path}\` (${topGap.severity}): ${topGap.reason}`
+    );
+  } else {
+    console.log('- No gaps in this report; extend crawl coverage or add auth before chasing new checks.');
+  }
+  console.log('\n---\n');
+  console.log(
+    'TODO: correlate multiple historical reports and CI adapters for cross-run “cost doctor” diffing (not implemented yet).'
+  );
+}

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -129,8 +129,13 @@ async function runAnalyze(options: {
     console.log(
       JSON.stringify(
         {
+          status: result.status,
+          coverageScore: result.coverageScore,
+          releaseConfidence: result.releaseConfidence,
+          gaps: result.gaps,
           gapAnalysis: result.gapAnalysis,
           discoveredRoutes: result.routeInventory,
+          publicSurface: result.publicSurface,
           repoInventory: result.repoInventory,
           decisionLog: result.decisionLog,
           ...(result.detectedAuth !== undefined && { detectedAuth: result.detectedAuth }),

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -172,6 +172,16 @@ program
     console.log('[qulib] clean complete');
   });
 
+const costCmd = program.command('cost').description('Cost intelligence helpers');
+costCmd
+  .command('doctor')
+  .description('Print Cost Intelligence from output/report.json (run analyze without --ephemeral first)')
+  .option('--report <file>', 'Path to report.json relative to cwd', 'output/report.json')
+  .action(async (opts: { report: string }) => {
+    const { runCostDoctor } = await import('./cost-doctor.js');
+    await runCostDoctor(opts.report);
+  });
+
 program
   .command('analyze')
   .description('Analyze an app for quality gaps')

--- a/packages/core/src/harness/progress-log.ts
+++ b/packages/core/src/harness/progress-log.ts
@@ -1,0 +1,6 @@
+export interface AnalyzeProgressSink {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+  debug(message: string): void;
+}

--- a/packages/core/src/harness/run-options.ts
+++ b/packages/core/src/harness/run-options.ts
@@ -1,6 +1,8 @@
 import type { DecisionLogEntry } from '../schemas/decision-log.schema.js';
+import type { AnalyzeProgressSink } from './progress-log.js';
 
 export type RunArtifactsOptions = {
   writeArtifacts: boolean;
   decisionMemory?: DecisionLogEntry[];
+  progressLog?: AnalyzeProgressSink;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export { exploreAuth } from './tools/auth-explorer.js';
 export { addUserProvider, removeUserProvider, listUserProviders } from './tools/user-providers.js';
 export { resolveMaxOutputTokensPerLlmCall } from './schemas/config.schema.js';
 export type { AnalyzeOptions, AnalyzeResult, AnalyzeStatus } from './analyze.js';
+export type { AnalyzeProgressSink } from './harness/progress-log.js';
 export type {
   HarnessConfig,
   AuthConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,4 +13,6 @@ export type {
   AuthExploration,
   AuthPath,
   AuthPathRequirements,
+  CostIntelligence,
+  LlmUsageRecord,
 } from './schemas/index.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export { analyzeApp } from './analyze.js';
 export { detectAuth } from './tools/auth-detector.js';
 export { exploreAuth } from './tools/auth-explorer.js';
 export { addUserProvider, removeUserProvider, listUserProviders } from './tools/user-providers.js';
+export { resolveMaxOutputTokensPerLlmCall } from './schemas/config.schema.js';
 export type { AnalyzeOptions, AnalyzeResult } from './analyze.js';
 export type {
   HarnessConfig,
@@ -15,4 +16,6 @@ export type {
   AuthPathRequirements,
   CostIntelligence,
   LlmUsageRecord,
+  RepeatedAiPattern,
+  DeterministicMaturity,
 } from './schemas/index.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@ export { detectAuth } from './tools/auth-detector.js';
 export { exploreAuth } from './tools/auth-explorer.js';
 export { addUserProvider, removeUserProvider, listUserProviders } from './tools/user-providers.js';
 export { resolveMaxOutputTokensPerLlmCall } from './schemas/config.schema.js';
-export type { AnalyzeOptions, AnalyzeResult } from './analyze.js';
+export type { AnalyzeOptions, AnalyzeResult, AnalyzeStatus } from './analyze.js';
 export type {
   HarnessConfig,
   AuthConfig,
@@ -18,4 +18,5 @@ export type {
   LlmUsageRecord,
   RepeatedAiPattern,
   DeterministicMaturity,
+  PublicSurface,
 } from './schemas/index.js';

--- a/packages/core/src/llm/content-hash.ts
+++ b/packages/core/src/llm/content-hash.ts
@@ -1,0 +1,5 @@
+import { createHash } from 'node:crypto';
+
+export function hashForCostIntelligence(payload: string): string {
+  return createHash('sha256').update(payload, 'utf8').digest('hex').slice(0, 32);
+}

--- a/packages/core/src/llm/context-builder.ts
+++ b/packages/core/src/llm/context-builder.ts
@@ -3,7 +3,7 @@ import type { Gap } from '../schemas/gap-analysis.schema.js';
 export function buildGapPrompt(gaps: Gap[], limit: number): string {
   const topGaps = [...gaps]
     .sort((a, b) => {
-      const order = { high: 0, medium: 1, low: 2 };
+      const order = { critical: 0, high: 1, medium: 2, low: 3 };
       return order[a.severity] - order[b.severity];
     })
     .slice(0, limit);

--- a/packages/core/src/llm/cost-intelligence.test.ts
+++ b/packages/core/src/llm/cost-intelligence.test.ts
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { hashForCostIntelligence } from './content-hash.js';
+import {
+  buildBudgetWarnings,
+  findRepeatedPromptPatterns,
+  computeDeterministicMaturity,
+} from './cost-intelligence.js';
+
+test('hashForCostIntelligence is stable 32-char hex', () => {
+  const a = hashForCostIntelligence('hello');
+  const b = hashForCostIntelligence('hello');
+  assert.equal(a, b);
+  assert.match(a, /^[a-f0-9]{32}$/);
+  assert.notEqual(hashForCostIntelligence('a'), hashForCostIntelligence('b'));
+});
+
+test('buildBudgetWarnings flags 80% of max-output budget', () => {
+  const warnings = buildBudgetWarnings(
+    [
+      {
+        provider: 'x',
+        model: 'm',
+        inputTokens: 10,
+        outputTokens: 800,
+        operationType: 'scenario-generation',
+        timestamp: new Date().toISOString(),
+        dataQuality: 'actual',
+      },
+    ],
+    1000
+  );
+  assert.ok(warnings.some((w) => w.includes('80%')));
+});
+
+test('buildBudgetWarnings flags at or over budget', () => {
+  const w = buildBudgetWarnings(
+    [
+      {
+        provider: 'x',
+        model: 'm',
+        inputTokens: 1,
+        outputTokens: 50,
+        operationType: 'scenario-generation',
+        timestamp: new Date().toISOString(),
+        dataQuality: 'actual',
+      },
+    ],
+    50
+  );
+  assert.ok(w.some((w) => w.includes('reached or exceeded')));
+});
+
+test('findRepeatedPromptPatterns requires count >= 2', () => {
+  const ts = new Date().toISOString();
+  const base = {
+    provider: 'a',
+    model: 'b',
+    inputTokens: 1,
+    outputTokens: 1,
+    operationType: 'scenario-generation' as const,
+    timestamp: ts,
+    dataQuality: 'actual' as const,
+  };
+  assert.equal(findRepeatedPromptPatterns([{ ...base, promptHash: 'x' }]).length, 0);
+  const repeated = findRepeatedPromptPatterns([
+    { ...base, promptHash: 'abc' },
+    { ...base, promptHash: 'abc' },
+  ]);
+  assert.equal(repeated.length, 1);
+  assert.equal(repeated[0]!.count, 2);
+});
+
+test('computeDeterministicMaturity L2 when LLM scenarios used', () => {
+  const m = computeDeterministicMaturity({
+    mode: 'url-only',
+    coveragePagesScanned: 3,
+    gapCount: 2,
+    scenarioSource: 'llm',
+    repeatedOperations: [],
+    releaseConfidence: 60,
+    requireHumanReview: false,
+  });
+  assert.equal(m.level, 2);
+  assert.match(m.label, /L2/);
+});
+
+test('computeDeterministicMaturity L3 when repeated prompt patterns', () => {
+  const m = computeDeterministicMaturity({
+    mode: 'url-only',
+    coveragePagesScanned: 2,
+    gapCount: 1,
+    scenarioSource: 'template',
+    repeatedOperations: [
+      {
+        promptHash: 'ab',
+        count: 2,
+        recommendation: 'dedupe',
+      },
+    ],
+    releaseConfidence: 70,
+    requireHumanReview: false,
+  });
+  assert.equal(m.level, 3);
+  assert.match(m.label, /L3/);
+});
+
+test('computeDeterministicMaturity L0 for auth-required', () => {
+  const m = computeDeterministicMaturity({
+    mode: 'auth-required',
+    coveragePagesScanned: 0,
+    gapCount: 0,
+    scenarioSource: 'template',
+    repeatedOperations: [],
+    releaseConfidence: 0,
+    requireHumanReview: true,
+  });
+  assert.equal(m.level, 0);
+});

--- a/packages/core/src/llm/cost-intelligence.test.ts
+++ b/packages/core/src/llm/cost-intelligence.test.ts
@@ -5,7 +5,10 @@ import {
   buildBudgetWarnings,
   findRepeatedPromptPatterns,
   computeDeterministicMaturity,
+  costIntelligenceForAuthBlocked,
 } from './cost-intelligence.js';
+import { CostIntelligenceSchema } from '../schemas/cost-intelligence.schema.js';
+import { HarnessConfigSchema, resolveMaxOutputTokensPerLlmCall } from '../schemas/config.schema.js';
 
 test('hashForCostIntelligence is stable 32-char hex', () => {
   const a = hashForCostIntelligence('hello');
@@ -116,4 +119,27 @@ test('computeDeterministicMaturity L0 for auth-required', () => {
     requireHumanReview: true,
   });
   assert.equal(m.level, 0);
+});
+
+test('resolveMaxOutputTokensPerLlmCall prefers llmMaxOutputTokensPerCall', () => {
+  const c = HarnessConfigSchema.parse({
+    maxPagesToScan: 5,
+    maxDepth: 2,
+    minPagesForConfidence: 1,
+    timeoutMs: 10000,
+    retryCount: 0,
+    llmTokenBudget: 4000,
+    llmMaxOutputTokensPerCall: 512,
+    testGenerationLimit: 5,
+    readOnlyMode: true,
+    requireHumanReview: true,
+    failOnConsoleError: false,
+  });
+  assert.equal(resolveMaxOutputTokensPerLlmCall(c), 512);
+});
+
+test('costIntelligenceForAuthBlocked matches schema', () => {
+  const ci = costIntelligenceForAuthBlocked(2048);
+  CostIntelligenceSchema.parse(ci);
+  assert.equal(ci.maxOutputTokensPerLlmCall, 2048);
 });

--- a/packages/core/src/llm/cost-intelligence.ts
+++ b/packages/core/src/llm/cost-intelligence.ts
@@ -22,7 +22,7 @@ export function summarizeUsageQuality(records: LlmUsageRecord[]): CostIntelligen
 
 export function buildBudgetWarnings(
   records: LlmUsageRecord[],
-  llmTokenBudget: number
+  maxOutputTokensPerLlmCall: number
 ): string[] {
   const warnings: string[] = [];
   for (const r of records) {
@@ -30,13 +30,13 @@ export function buildBudgetWarnings(
       continue;
     }
     const out = r.outputTokens;
-    if (out >= llmTokenBudget) {
+    if (out >= maxOutputTokensPerLlmCall) {
       warnings.push(
-        `Output tokens (${out}) reached or exceeded configured max-output budget (${llmTokenBudget}). Completion may be truncated; consider raising llmTokenBudget or reducing testGenerationLimit.`
+        `Output tokens (${out}) reached or exceeded the configured per-completion max-output ceiling (${maxOutputTokensPerLlmCall}). Completion may be truncated; raise llmMaxOutputTokensPerCall (or legacy llmTokenBudget) or reduce testGenerationLimit.`
       );
-    } else if (out >= Math.floor(llmTokenBudget * 0.8)) {
+    } else if (out >= Math.floor(maxOutputTokensPerLlmCall * 0.8)) {
       warnings.push(
-        `Output tokens (${out}) are within 80% of max-output budget (${llmTokenBudget}). Truncation risk on heavier prompts.`
+        `Output tokens (${out}) are within 80% of the per-completion max-output ceiling (${maxOutputTokensPerLlmCall}). Truncation risk on heavier prompts.`
       );
     }
   }
@@ -86,7 +86,7 @@ export function buildConversionRecommendations(params: {
   }
   if (params.budgetWarnings.some((w) => w.includes('truncated') || w.includes('80%'))) {
     rec.push(
-      'Tune llmTokenBudget against real prompt sizes, or lower testGenerationLimit so each model call stays within a safe completion envelope.'
+      'Tune llmMaxOutputTokensPerCall (or legacy llmTokenBudget) against real prompt sizes, or lower testGenerationLimit so each completion stays within a safe envelope.'
     );
   }
   if (params.scenarioSource === 'template') {
@@ -155,7 +155,7 @@ export function computeDeterministicMaturity(params: {
 }
 
 export function assembleCostIntelligence(params: {
-  llmTokenBudget: number;
+  maxOutputTokensPerLlmCall: number;
   records: LlmUsageRecord[];
   partial: Pick<
     GapAnalysis,
@@ -165,7 +165,7 @@ export function assembleCostIntelligence(params: {
   requireHumanReview: boolean;
 }): CostIntelligence {
   const usageSummary = summarizeUsageQuality(params.records);
-  const budgetWarnings = buildBudgetWarnings(params.records, params.llmTokenBudget);
+  const budgetWarnings = buildBudgetWarnings(params.records, params.maxOutputTokensPerLlmCall);
   const repeatedOperations = findRepeatedPromptPatterns(params.records);
   const conversionRecommendations = buildConversionRecommendations({
     scenarioSource: params.scenarioSource,
@@ -184,7 +184,7 @@ export function assembleCostIntelligence(params: {
   });
 
   return {
-    llmTokenBudgetConfigured: params.llmTokenBudget,
+    maxOutputTokensPerLlmCall: params.maxOutputTokensPerLlmCall,
     budgetRole: 'max-output-tokens-per-llm-call',
     records: params.records,
     budgetWarnings,
@@ -195,9 +195,9 @@ export function assembleCostIntelligence(params: {
   };
 }
 
-export function costIntelligenceForAuthBlocked(llmTokenBudget: number): CostIntelligence {
+export function costIntelligenceForAuthBlocked(maxOutputTokensPerLlmCall: number): CostIntelligence {
   return {
-    llmTokenBudgetConfigured: llmTokenBudget,
+    maxOutputTokensPerLlmCall,
     budgetRole: 'max-output-tokens-per-llm-call',
     records: [],
     budgetWarnings: [],

--- a/packages/core/src/llm/cost-intelligence.ts
+++ b/packages/core/src/llm/cost-intelligence.ts
@@ -1,0 +1,218 @@
+import type { GapAnalysis } from '../schemas/gap-analysis.schema.js';
+import type {
+  CostIntelligence,
+  DeterministicMaturity,
+  LlmUsageRecord,
+  RepeatedAiPattern,
+} from '../schemas/cost-intelligence.schema.js';
+
+export function summarizeUsageQuality(records: LlmUsageRecord[]): CostIntelligence['usageSummary'] {
+  if (records.length === 0) {
+    return { totalInputTokens: 0, totalOutputTokens: 0, dataQuality: 'none' };
+  }
+  const totalInputTokens = records.reduce((s, r) => s + r.inputTokens, 0);
+  const totalOutputTokens = records.reduce((s, r) => s + r.outputTokens, 0);
+  const qualities = new Set(records.map((r) => r.dataQuality));
+  if (qualities.size > 1) {
+    return { totalInputTokens, totalOutputTokens, dataQuality: 'mixed' };
+  }
+  const only = records[0]!.dataQuality;
+  return { totalInputTokens, totalOutputTokens, dataQuality: only };
+}
+
+export function buildBudgetWarnings(
+  records: LlmUsageRecord[],
+  llmTokenBudget: number
+): string[] {
+  const warnings: string[] = [];
+  for (const r of records) {
+    if (r.dataQuality === 'none' && r.inputTokens === 0 && r.outputTokens === 0) {
+      continue;
+    }
+    const out = r.outputTokens;
+    if (out >= llmTokenBudget) {
+      warnings.push(
+        `Output tokens (${out}) reached or exceeded configured max-output budget (${llmTokenBudget}). Completion may be truncated; consider raising llmTokenBudget or reducing testGenerationLimit.`
+      );
+    } else if (out >= Math.floor(llmTokenBudget * 0.8)) {
+      warnings.push(
+        `Output tokens (${out}) are within 80% of max-output budget (${llmTokenBudget}). Truncation risk on heavier prompts.`
+      );
+    }
+  }
+  if (records.some((r) => r.dataQuality === 'estimated')) {
+    warnings.push(
+      'Some token counts are estimated (API usage missing or call failed). Treat totals as approximate until actual usage is available.'
+    );
+  }
+  return warnings;
+}
+
+export function findRepeatedPromptPatterns(records: LlmUsageRecord[]): RepeatedAiPattern[] {
+  const byHash = new Map<string, number>();
+  for (const r of records) {
+    if (!r.promptHash) continue;
+    byHash.set(r.promptHash, (byHash.get(r.promptHash) ?? 0) + 1);
+  }
+  const out: RepeatedAiPattern[] = [];
+  for (const [promptHash, count] of byHash) {
+    if (count < 2) continue;
+    out.push({
+      promptHash,
+      count,
+      recommendation:
+        'The same prompt fingerprint appeared multiple times in this run. Capture the intent as versioned Playwright/Cypress checks or shared scenario fixtures so repeat visits do not re-spend model tokens.',
+    });
+  }
+  return out;
+}
+
+export function buildConversionRecommendations(params: {
+  scenarioSource: 'llm' | 'template';
+  repeatedOperations: RepeatedAiPattern[];
+  budgetWarnings: string[];
+  gapCount: number;
+}): string[] {
+  const rec: string[] = [];
+  if (params.scenarioSource === 'llm' && params.gapCount > 0) {
+    rec.push(
+      'LLM-authored scenarios are suggestions only. Promote the highest-severity paths into deterministic checks (axe, link crawl, route smoke) checked on every deploy to shrink future LLM reliance.'
+    );
+  }
+  if (params.repeatedOperations.length > 0) {
+    rec.push(
+      'Deduplicate repeated AI work: key scenarios by gap ids or route templates and reuse stored outputs where the deployment hash is unchanged.'
+    );
+  }
+  if (params.budgetWarnings.some((w) => w.includes('truncated') || w.includes('80%'))) {
+    rec.push(
+      'Tune llmTokenBudget against real prompt sizes, or lower testGenerationLimit so each model call stays within a safe completion envelope.'
+    );
+  }
+  if (params.scenarioSource === 'template') {
+    rec.push(
+      'Scenarios were generated from built-in templates (no LLM). This is the lowest-cost path; keep expanding template coverage for recurring gap categories.'
+    );
+  }
+  return rec;
+}
+
+export function computeDeterministicMaturity(params: {
+  mode: GapAnalysis['mode'];
+  coveragePagesScanned: number;
+  gapCount: number;
+  scenarioSource: 'llm' | 'template';
+  repeatedOperations: RepeatedAiPattern[];
+  releaseConfidence: number;
+  requireHumanReview: boolean;
+}): DeterministicMaturity {
+  if (params.mode === 'auth-required') {
+    return {
+      level: 0,
+      label: 'L0 — unknown / blocked',
+      rationale:
+        'Authentication blocked the crawl. Release confidence and gap inventory are not representative until a deterministic auth path is configured.',
+      ceilingNote:
+        'L1+ require at least one authenticated or public crawl producing structured gaps.',
+    };
+  }
+
+  if (params.coveragePagesScanned === 0 && params.gapCount === 0) {
+    return {
+      level: 0,
+      label: 'L0 — insufficient deterministic signal',
+      rationale:
+        'No pages were scanned and no gaps were recorded. Treat maturity as unknown rather than high.',
+      ceilingNote: 'Re-run with reachable URLs, auth, or relaxed crawl limits.',
+    };
+  }
+
+  let level = 1;
+  let label = 'L1 — deterministic scan inventory';
+  let rationale =
+    'Structured gaps came from deterministic crawling and checks (links, console, a11y, coverage). This is the baseline Qulib release-confidence story.';
+
+  if (params.scenarioSource === 'llm') {
+    level = 2;
+    label = 'L2 — AI-assisted analysis layer';
+    rationale =
+      'An LLM expanded gaps into scenarios. Value is exploratory; it is not yet the same as enforced CI coverage.';
+  }
+
+  if (params.repeatedOperations.length > 0) {
+    level = Math.max(level, 3);
+    label = 'L3 — repeated AI surface';
+    rationale =
+      'Repeated prompt fingerprints suggest the same reasoning loop is firing more than once—strong candidates to replace with cached or deterministic checks.';
+  }
+
+  const ceilingNote =
+    params.releaseConfidence >= 85 && !params.requireHumanReview
+      ? 'High release confidence does not imply L4–L5. Reviewed self-healing (L4) and adaptive quality intelligence (L5) require organizational process and feedback loops outside this single scan.'
+      : 'L4 (reviewed self-healing) and L5 (adaptive quality intelligence) are not inferred from a snapshot scan. They require documented review, ownership, and sustained automation feedback.';
+
+  return { level, label, rationale, ceilingNote };
+}
+
+export function assembleCostIntelligence(params: {
+  llmTokenBudget: number;
+  records: LlmUsageRecord[];
+  partial: Pick<
+    GapAnalysis,
+    'mode' | 'coveragePagesScanned' | 'releaseConfidence' | 'gaps'
+  >;
+  scenarioSource: 'llm' | 'template';
+  requireHumanReview: boolean;
+}): CostIntelligence {
+  const usageSummary = summarizeUsageQuality(params.records);
+  const budgetWarnings = buildBudgetWarnings(params.records, params.llmTokenBudget);
+  const repeatedOperations = findRepeatedPromptPatterns(params.records);
+  const conversionRecommendations = buildConversionRecommendations({
+    scenarioSource: params.scenarioSource,
+    repeatedOperations,
+    budgetWarnings,
+    gapCount: params.partial.gaps.length,
+  });
+  const deterministicMaturity = computeDeterministicMaturity({
+    mode: params.partial.mode,
+    coveragePagesScanned: params.partial.coveragePagesScanned,
+    gapCount: params.partial.gaps.length,
+    scenarioSource: params.scenarioSource,
+    repeatedOperations,
+    releaseConfidence: params.partial.releaseConfidence,
+    requireHumanReview: params.requireHumanReview,
+  });
+
+  return {
+    llmTokenBudgetConfigured: params.llmTokenBudget,
+    budgetRole: 'max-output-tokens-per-llm-call',
+    records: params.records,
+    budgetWarnings,
+    usageSummary,
+    repeatedOperations,
+    deterministicMaturity,
+    conversionRecommendations,
+  };
+}
+
+export function costIntelligenceForAuthBlocked(llmTokenBudget: number): CostIntelligence {
+  return {
+    llmTokenBudgetConfigured: llmTokenBudget,
+    budgetRole: 'max-output-tokens-per-llm-call',
+    records: [],
+    budgetWarnings: [],
+    usageSummary: { totalInputTokens: 0, totalOutputTokens: 0, dataQuality: 'none' },
+    repeatedOperations: [],
+    deterministicMaturity: {
+      level: 0,
+      label: 'L0 — unknown / blocked',
+      rationale:
+        'Authentication blocked the crawl. No LLM usage was recorded; deterministic inventory is incomplete.',
+      ceilingNote:
+        'Configure auth, then re-run so gap analysis and any LLM scenario pass operate on real pages.',
+    },
+    conversionRecommendations: [
+      'Resolve authentication first (storage-state from `qulib auth init` or form-login flags). Cost intelligence for model-assisted work applies after the crawl succeeds.',
+    ],
+  };
+}

--- a/packages/core/src/llm/cost-intelligence.ts
+++ b/packages/core/src/llm/cost-intelligence.ts
@@ -103,7 +103,7 @@ export function computeDeterministicMaturity(params: {
   gapCount: number;
   scenarioSource: 'llm' | 'template';
   repeatedOperations: RepeatedAiPattern[];
-  releaseConfidence: number;
+  releaseConfidence: number | null;
   requireHumanReview: boolean;
 }): DeterministicMaturity {
   if (params.mode === 'auth-required') {
@@ -147,7 +147,7 @@ export function computeDeterministicMaturity(params: {
   }
 
   const ceilingNote =
-    params.releaseConfidence >= 85 && !params.requireHumanReview
+    (params.releaseConfidence ?? 0) >= 85 && !params.requireHumanReview
       ? 'High release confidence does not imply L4–L5. Reviewed self-healing (L4) and adaptive quality intelligence (L5) require organizational process and feedback loops outside this single scan.'
       : 'L4 (reviewed self-healing) and L5 (adaptive quality intelligence) are not inferred from a snapshot scan. They require documented review, ownership, and sustained automation feedback.';
 

--- a/packages/core/src/llm/provider.ts
+++ b/packages/core/src/llm/provider.ts
@@ -87,9 +87,20 @@ export function generateScenariosFromTemplate(gaps: Gap[]): NeutralScenario[] {
       steps.push({ action: 'assert-visible' as const, description: 'Run accessibility scan on page' });
     } else if (gap.category === 'broken-link') {
       steps.push({ action: 'assert-visible' as const, description: 'Assert all links resolve correctly' });
+    } else if (gap.category === 'auth-surface') {
+      steps.push({
+        action: 'assert-visible' as const,
+        description: 'Verify sign-in surface accessibility and SSO affordances',
+      });
+    } else if (gap.category === 'coverage') {
+      steps.push({
+        action: 'assert-visible' as const,
+        description: 'Resolve authentication and re-run full deployment scan',
+      });
     }
 
-    const adapter = gap.category === 'a11y' ? 'accessibility' : 'playwright';
+    const adapter =
+      gap.category === 'a11y' || gap.category === 'auth-surface' ? 'accessibility' : 'playwright';
 
     return NeutralScenarioSchema.parse({
       id: randomUUID(),

--- a/packages/core/src/llm/provider.ts
+++ b/packages/core/src/llm/provider.ts
@@ -1,12 +1,26 @@
 import { randomUUID } from 'node:crypto';
 import { NeutralScenarioSchema, type Gap, type NeutralScenario } from '../schemas/gap-analysis.schema.js';
 
-export async function callLLM(
-  prompt: string,
-  tokenBudget: number
-): Promise<string> {
+export interface LlmCallResult {
+  text: string;
+  usage: {
+    provider: string;
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    dataQuality: 'actual' | 'estimated';
+  } | null;
+}
+
+function estimateTokensFromChars(chars: number): number {
+  return Math.max(0, Math.ceil(chars / 4));
+}
+
+export async function callLLM(prompt: string, tokenBudget: number): Promise<LlmCallResult> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) throw new Error('ANTHROPIC_API_KEY is not set');
+
+  const model = 'claude-sonnet-4-20250514';
 
   const response = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
@@ -16,7 +30,7 @@ export async function callLLM(
       'content-type': 'application/json',
     },
     body: JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
+      model,
       max_tokens: tokenBudget,
       messages: [{ role: 'user', content: prompt }],
     }),
@@ -27,9 +41,37 @@ export async function callLLM(
     throw new Error(`LLM call failed: ${response.status} ${text}`);
   }
 
-  const data = await response.json() as { content: Array<{ type: string; text: string }> };
+  const data = (await response.json()) as {
+    content: Array<{ type: string; text?: string }>;
+    usage?: { input_tokens?: number; output_tokens?: number };
+    model?: string;
+  };
   const text = data.content.find((b) => b.type === 'text')?.text ?? '';
-  return text;
+  const inTok = data.usage?.input_tokens;
+  const outTok = data.usage?.output_tokens;
+  if (typeof inTok === 'number' && typeof outTok === 'number') {
+    return {
+      text,
+      usage: {
+        provider: 'anthropic',
+        model: data.model ?? model,
+        inputTokens: inTok,
+        outputTokens: outTok,
+        dataQuality: 'actual',
+      },
+    };
+  }
+
+  return {
+    text,
+    usage: {
+      provider: 'anthropic',
+      model: data.model ?? model,
+      inputTokens: estimateTokensFromChars(prompt.length),
+      outputTokens: estimateTokensFromChars(text.length),
+      dataQuality: 'estimated',
+    },
+  };
 }
 
 export function generateScenariosFromTemplate(gaps: Gap[]): NeutralScenario[] {

--- a/packages/core/src/phases/act.ts
+++ b/packages/core/src/phases/act.ts
@@ -42,6 +42,9 @@ export async function act(
   log(`  Gaps found:          ${analysis.gaps.length}`);
   log(`  Scenarios generated: ${analysis.scenarios.length}`);
   log(`  Release confidence:  ${analysis.releaseConfidence}/100`);
+  if (analysis.costIntelligence?.budgetWarnings.length) {
+    log(`  Cost warnings:       ${analysis.costIntelligence.budgetWarnings.length} (see report.md Cost Intelligence)`);
+  }
 
   if (config.requireHumanReview) {
     log('\n[qulib] Human review required before applying any generated output.');

--- a/packages/core/src/phases/act.ts
+++ b/packages/core/src/phases/act.ts
@@ -41,7 +41,9 @@ export async function act(
   log('\n[qulib] Analysis complete');
   log(`  Gaps found:          ${analysis.gaps.length}`);
   log(`  Scenarios generated: ${analysis.scenarios.length}`);
-  log(`  Release confidence:  ${analysis.releaseConfidence}/100`);
+  log(
+    `  Release confidence:  ${analysis.releaseConfidence === null ? '— (null)' : `${analysis.releaseConfidence}/100`}`
+  );
   if (analysis.costIntelligence?.budgetWarnings.length) {
     log(`  Cost warnings:       ${analysis.costIntelligence.budgetWarnings.length} (see report.md Cost Intelligence)`);
   }

--- a/packages/core/src/phases/observe.ts
+++ b/packages/core/src/phases/observe.ts
@@ -22,7 +22,7 @@ export async function observe(
   const stateManager = new StateManager();
   const logOpts = { persist: artifacts.writeArtifacts, memory: artifacts.decisionMemory };
 
-  const rawRoutes = await explorer.explore(baseUrl, config);
+  const rawRoutes = await explorer.explore(baseUrl, config, artifacts);
   const routes = RouteInventorySchema.parse(rawRoutes);
   if (artifacts.writeArtifacts) {
     await stateManager.writeState('discovered-routes.json', routes, RouteInventorySchema);

--- a/packages/core/src/phases/think-finalize.ts
+++ b/packages/core/src/phases/think-finalize.ts
@@ -1,0 +1,187 @@
+import { resolveMaxOutputTokensPerLlmCall, type HarnessConfig } from '../schemas/config.schema.js';
+import { GapAnalysisSchema, NeutralScenarioSchema, type GapAnalysis, type NeutralScenario } from '../schemas/gap-analysis.schema.js';
+import type { LlmUsageRecord } from '../schemas/cost-intelligence.schema.js';
+import { StateManager } from '../harness/state-manager.js';
+import { logDecision } from '../harness/decision-logger.js';
+import { callLLM, generateScenariosFromTemplate } from '../llm/provider.js';
+import { buildGapPrompt } from '../llm/context-builder.js';
+import { assembleCostIntelligence } from '../llm/cost-intelligence.js';
+import { hashForCostIntelligence } from '../llm/content-hash.js';
+import type { RunArtifactsOptions } from '../harness/run-options.js';
+
+export type GapAnalysisDraft = Omit<GapAnalysis, 'scenarios' | 'generatedTests' | 'costIntelligence'>;
+
+export async function finalizeGapAnalysisFromDraft(
+  draft: GapAnalysisDraft,
+  config: HarnessConfig,
+  artifacts: RunArtifactsOptions = { writeArtifacts: true },
+  costContext?: Pick<GapAnalysis, 'mode' | 'coveragePagesScanned' | 'releaseConfidence' | 'gaps'>
+): Promise<GapAnalysis> {
+  const stateManager = new StateManager();
+  const logOpts = { persist: artifacts.writeArtifacts, memory: artifacts.decisionMemory };
+  const partialAnalysis = GapAnalysisSchema.parse({
+    ...draft,
+    scenarios: [],
+    generatedTests: [],
+  });
+
+  let scenarioSource: 'llm' | 'template' = 'template';
+  let generatedScenarios: NeutralScenario[] = [];
+  const llmRecords: LlmUsageRecord[] = [];
+  const maxOut = resolveMaxOutputTokensPerLlmCall(config);
+
+  if (!config.enableLlmScenarios) {
+    await logDecision(
+      {
+        timestamp: new Date().toISOString(),
+        phase: 'think',
+        decision: 'llm-scenarios-disabled',
+        reason: 'enableLlmScenarios is false; using template scenarios only',
+      },
+      logOpts
+    );
+    generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
+    llmRecords.push({
+      provider: 'none',
+      model: 'none',
+      inputTokens: 0,
+      outputTokens: 0,
+      operationType: 'scenario-generation',
+      timestamp: new Date().toISOString(),
+      dataQuality: 'none',
+      notes: 'No LLM call: enableLlmScenarios is false in harness config.',
+    });
+  } else if (!process.env.ANTHROPIC_API_KEY) {
+    await logDecision(
+      {
+        timestamp: new Date().toISOString(),
+        phase: 'think',
+        decision: 'llm-scenarios-skipped',
+        reason: 'Skipped LLM scenario generation because ANTHROPIC_API_KEY is not set',
+      },
+      logOpts
+    );
+    generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
+    llmRecords.push({
+      provider: 'none',
+      model: 'none',
+      inputTokens: 0,
+      outputTokens: 0,
+      operationType: 'scenario-generation',
+      timestamp: new Date().toISOString(),
+      dataQuality: 'none',
+      notes: 'No LLM call: ANTHROPIC_API_KEY not set; template scenarios only.',
+    });
+  } else {
+    const prompt = buildGapPrompt(partialAnalysis.gaps, config.testGenerationLimit);
+    const promptHash = hashForCostIntelligence(prompt);
+    try {
+      const llmResult = await callLLM(prompt, maxOut);
+      const resultHash = hashForCostIntelligence(llmResult.text);
+      const usage = llmResult.usage;
+      llmRecords.push({
+        provider: usage?.provider ?? 'unknown',
+        model: usage?.model ?? 'unknown',
+        inputTokens: usage?.inputTokens ?? 0,
+        outputTokens: usage?.outputTokens ?? 0,
+        operationType: 'scenario-generation',
+        timestamp: new Date().toISOString(),
+        promptHash,
+        resultHash,
+        dataQuality: usage?.dataQuality ?? 'estimated',
+        notes:
+          usage?.dataQuality === 'estimated'
+            ? 'Token counts estimated (API usage block missing).'
+            : undefined,
+      });
+      try {
+        const parsed = JSON.parse(llmResult.text) as unknown;
+        const candidates = Array.isArray(parsed) ? parsed : [];
+
+        for (const item of candidates) {
+          const validated = NeutralScenarioSchema.safeParse(item);
+          if (validated.success) {
+            generatedScenarios.push(validated.data);
+          }
+        }
+
+        if (generatedScenarios.length === 0) {
+          generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
+          scenarioSource = 'template';
+          const last = llmRecords[llmRecords.length - 1];
+          if (last) {
+            last.notes = [last.notes, 'Model returned no valid scenarios; template scenarios used.']
+              .filter(Boolean)
+              .join(' ');
+          }
+        } else {
+          scenarioSource = 'llm';
+        }
+      } catch {
+        generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
+        scenarioSource = 'template';
+        const last = llmRecords[llmRecords.length - 1];
+        if (last) {
+          last.notes = [last.notes, 'Response was not valid JSON; template scenarios used.']
+            .filter(Boolean)
+            .join(' ');
+        }
+      }
+    } catch (err) {
+      generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
+      scenarioSource = 'template';
+      const msg = err instanceof Error ? err.message : String(err);
+      llmRecords.push({
+        provider: 'unavailable',
+        model: 'unknown',
+        inputTokens: Math.max(0, Math.ceil(prompt.length / 4)),
+        outputTokens: 0,
+        operationType: 'scenario-generation',
+        timestamp: new Date().toISOString(),
+        promptHash,
+        dataQuality: 'estimated',
+        notes: `LLM call failed; template scenarios used. ${msg.slice(0, 240)}`,
+      });
+    }
+  }
+
+  await logDecision(
+    {
+      timestamp: new Date().toISOString(),
+      phase: 'think',
+      decision: 'scenario-generation-complete',
+      reason: `Generated ${generatedScenarios.length} scenarios via ${scenarioSource}`,
+      metadata: {
+        source: scenarioSource,
+        scenarioCount: generatedScenarios.length,
+      },
+    },
+    logOpts
+  );
+
+  const costPartial = costContext ?? partialAnalysis;
+  const costIntelligence = assembleCostIntelligence({
+    maxOutputTokensPerLlmCall: maxOut,
+    records: llmRecords,
+    partial: {
+      mode: costPartial.mode,
+      coveragePagesScanned: costPartial.coveragePagesScanned,
+      releaseConfidence: costPartial.releaseConfidence ?? 0,
+      gaps: costPartial.gaps,
+    },
+    scenarioSource,
+    requireHumanReview: config.requireHumanReview,
+  });
+
+  const completeAnalysis = GapAnalysisSchema.parse({
+    ...partialAnalysis,
+    scenarios: generatedScenarios,
+    generatedTests: [],
+    costIntelligence,
+  });
+  if (artifacts.writeArtifacts) {
+    await stateManager.writeState('gap-analysis.json', completeAnalysis, GapAnalysisSchema);
+  }
+
+  return completeAnalysis;
+}

--- a/packages/core/src/phases/think.ts
+++ b/packages/core/src/phases/think.ts
@@ -1,15 +1,10 @@
-import { resolveMaxOutputTokensPerLlmCall, type HarnessConfig } from '../schemas/config.schema.js';
-import { GapAnalysisSchema, NeutralScenarioSchema, type GapAnalysis, type NeutralScenario } from '../schemas/gap-analysis.schema.js';
-import type { LlmUsageRecord } from '../schemas/cost-intelligence.schema.js';
+import type { HarnessConfig } from '../schemas/config.schema.js';
+import { GapAnalysisSchema, type GapAnalysis } from '../schemas/gap-analysis.schema.js';
 import type { ObserveResult } from './observe.js';
 import { analyzeGaps } from '../tools/gap-engine.js';
-import { StateManager } from '../harness/state-manager.js';
 import { logDecision } from '../harness/decision-logger.js';
-import { callLLM, generateScenariosFromTemplate } from '../llm/provider.js';
-import { buildGapPrompt } from '../llm/context-builder.js';
-import { assembleCostIntelligence } from '../llm/cost-intelligence.js';
-import { hashForCostIntelligence } from '../llm/content-hash.js';
 import type { RunArtifactsOptions } from '../harness/run-options.js';
+import { finalizeGapAnalysisFromDraft } from './think-finalize.js';
 
 export async function think(
   observed: ObserveResult,
@@ -17,24 +12,31 @@ export async function think(
   artifacts: RunArtifactsOptions = { writeArtifacts: true }
 ): Promise<GapAnalysis> {
   const mode = observed.repo ? 'url-repo' : 'url-only';
-  const stateManager = new StateManager();
   const logOpts = { persist: artifacts.writeArtifacts, memory: artifacts.decisionMemory };
 
+  const gapBlock = analyzeGaps(observed.routes, observed.repo, mode, config);
+  const draft = {
+    analyzedAt: gapBlock.analyzedAt,
+    mode: gapBlock.mode,
+    releaseConfidence: gapBlock.releaseConfidence,
+    coveragePagesScanned: gapBlock.coveragePagesScanned,
+    coverageBudgetExceeded: gapBlock.coverageBudgetExceeded,
+    coverageWarning: gapBlock.coverageWarning,
+    gaps: gapBlock.gaps,
+  };
+
   const partialAnalysis = GapAnalysisSchema.parse({
-    ...analyzeGaps(observed.routes, observed.repo, mode, config),
+    ...draft,
     scenarios: [],
     generatedTests: [],
   });
-  if (artifacts.writeArtifacts) {
-    await stateManager.writeState('gap-analysis.json', partialAnalysis, GapAnalysisSchema);
-  }
 
   await logDecision(
     {
       timestamp: new Date().toISOString(),
       phase: 'think',
       decision: 'gap-analysis-complete',
-      reason: `Computed ${partialAnalysis.gaps.length} gaps with release confidence ${partialAnalysis.releaseConfidence}`,
+      reason: `Computed ${partialAnalysis.gaps.length} gaps with release confidence ${String(partialAnalysis.releaseConfidence)}`,
       metadata: {
         mode,
         gapCount: partialAnalysis.gaps.length,
@@ -44,157 +46,8 @@ export async function think(
     logOpts
   );
 
-  let scenarioSource: 'llm' | 'template' = 'template';
-  let generatedScenarios: NeutralScenario[] = [];
-  const llmRecords: LlmUsageRecord[] = [];
-  const maxOut = resolveMaxOutputTokensPerLlmCall(config);
-
-  if (!config.enableLlmScenarios) {
-    await logDecision(
-      {
-        timestamp: new Date().toISOString(),
-        phase: 'think',
-        decision: 'llm-scenarios-disabled',
-        reason: 'enableLlmScenarios is false; using template scenarios only',
-      },
-      logOpts
-    );
-    generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
-    llmRecords.push({
-      provider: 'none',
-      model: 'none',
-      inputTokens: 0,
-      outputTokens: 0,
-      operationType: 'scenario-generation',
-      timestamp: new Date().toISOString(),
-      dataQuality: 'none',
-      notes: 'No LLM call: enableLlmScenarios is false in harness config.',
-    });
-  } else if (!process.env.ANTHROPIC_API_KEY) {
-    await logDecision(
-      {
-        timestamp: new Date().toISOString(),
-        phase: 'think',
-        decision: 'llm-scenarios-skipped',
-        reason: 'Skipped LLM scenario generation because ANTHROPIC_API_KEY is not set',
-      },
-      logOpts
-    );
-    generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
-    llmRecords.push({
-      provider: 'none',
-      model: 'none',
-      inputTokens: 0,
-      outputTokens: 0,
-      operationType: 'scenario-generation',
-      timestamp: new Date().toISOString(),
-      dataQuality: 'none',
-      notes: 'No LLM call: ANTHROPIC_API_KEY not set; template scenarios only.',
-    });
-  } else {
-    const prompt = buildGapPrompt(partialAnalysis.gaps, config.testGenerationLimit);
-    const promptHash = hashForCostIntelligence(prompt);
-    try {
-      const llmResult = await callLLM(prompt, maxOut);
-      const resultHash = hashForCostIntelligence(llmResult.text);
-      const usage = llmResult.usage;
-      llmRecords.push({
-        provider: usage?.provider ?? 'unknown',
-        model: usage?.model ?? 'unknown',
-        inputTokens: usage?.inputTokens ?? 0,
-        outputTokens: usage?.outputTokens ?? 0,
-        operationType: 'scenario-generation',
-        timestamp: new Date().toISOString(),
-        promptHash,
-        resultHash,
-        dataQuality: usage?.dataQuality ?? 'estimated',
-        notes:
-          usage?.dataQuality === 'estimated'
-            ? 'Token counts estimated (API usage block missing).'
-            : undefined,
-      });
-      try {
-        const parsed = JSON.parse(llmResult.text) as unknown;
-        const candidates = Array.isArray(parsed) ? parsed : [];
-
-        for (const item of candidates) {
-          const validated = NeutralScenarioSchema.safeParse(item);
-          if (validated.success) {
-            generatedScenarios.push(validated.data);
-          }
-        }
-
-        if (generatedScenarios.length === 0) {
-          generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
-          scenarioSource = 'template';
-          const last = llmRecords[llmRecords.length - 1];
-          if (last) {
-            last.notes = [last.notes, 'Model returned no valid scenarios; template scenarios used.']
-              .filter(Boolean)
-              .join(' ');
-          }
-        } else {
-          scenarioSource = 'llm';
-        }
-      } catch {
-        generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
-        scenarioSource = 'template';
-        const last = llmRecords[llmRecords.length - 1];
-        if (last) {
-          last.notes = [last.notes, 'Response was not valid JSON; template scenarios used.']
-            .filter(Boolean)
-            .join(' ');
-        }
-      }
-    } catch (err) {
-      generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
-      scenarioSource = 'template';
-      const msg = err instanceof Error ? err.message : String(err);
-      llmRecords.push({
-        provider: 'unavailable',
-        model: 'unknown',
-        inputTokens: Math.max(0, Math.ceil(prompt.length / 4)),
-        outputTokens: 0,
-        operationType: 'scenario-generation',
-        timestamp: new Date().toISOString(),
-        promptHash,
-        dataQuality: 'estimated',
-        notes: `LLM call failed; template scenarios used. ${msg.slice(0, 240)}`,
-      });
-    }
-  }
-
-  await logDecision(
-    {
-      timestamp: new Date().toISOString(),
-      phase: 'think',
-      decision: 'scenario-generation-complete',
-      reason: `Generated ${generatedScenarios.length} scenarios via ${scenarioSource}`,
-      metadata: {
-        source: scenarioSource,
-        scenarioCount: generatedScenarios.length,
-      },
-    },
-    logOpts
-  );
-
-  const costIntelligence = assembleCostIntelligence({
-    maxOutputTokensPerLlmCall: maxOut,
-    records: llmRecords,
-    partial: partialAnalysis,
-    scenarioSource,
-    requireHumanReview: config.requireHumanReview,
-  });
-
-  const completeAnalysis = GapAnalysisSchema.parse({
-    ...partialAnalysis,
-    scenarios: generatedScenarios,
-    generatedTests: [],
-    costIntelligence,
-  });
-  if (artifacts.writeArtifacts) {
-    await stateManager.writeState('gap-analysis.json', completeAnalysis, GapAnalysisSchema);
-  }
-
-  return completeAnalysis;
+  return finalizeGapAnalysisFromDraft(draft, config, artifacts);
 }
+
+export { finalizeGapAnalysisFromDraft } from './think-finalize.js';
+export type { GapAnalysisDraft } from './think-finalize.js';

--- a/packages/core/src/phases/think.ts
+++ b/packages/core/src/phases/think.ts
@@ -1,4 +1,4 @@
-import type { HarnessConfig } from '../schemas/config.schema.js';
+import { resolveMaxOutputTokensPerLlmCall, type HarnessConfig } from '../schemas/config.schema.js';
 import { GapAnalysisSchema, NeutralScenarioSchema, type GapAnalysis, type NeutralScenario } from '../schemas/gap-analysis.schema.js';
 import type { LlmUsageRecord } from '../schemas/cost-intelligence.schema.js';
 import type { ObserveResult } from './observe.js';
@@ -47,8 +47,30 @@ export async function think(
   let scenarioSource: 'llm' | 'template' = 'template';
   let generatedScenarios: NeutralScenario[] = [];
   const llmRecords: LlmUsageRecord[] = [];
+  const maxOut = resolveMaxOutputTokensPerLlmCall(config);
 
-  if (!process.env.ANTHROPIC_API_KEY) {
+  if (!config.enableLlmScenarios) {
+    await logDecision(
+      {
+        timestamp: new Date().toISOString(),
+        phase: 'think',
+        decision: 'llm-scenarios-disabled',
+        reason: 'enableLlmScenarios is false; using template scenarios only',
+      },
+      logOpts
+    );
+    generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
+    llmRecords.push({
+      provider: 'none',
+      model: 'none',
+      inputTokens: 0,
+      outputTokens: 0,
+      operationType: 'scenario-generation',
+      timestamp: new Date().toISOString(),
+      dataQuality: 'none',
+      notes: 'No LLM call: enableLlmScenarios is false in harness config.',
+    });
+  } else if (!process.env.ANTHROPIC_API_KEY) {
     await logDecision(
       {
         timestamp: new Date().toISOString(),
@@ -73,7 +95,7 @@ export async function think(
     const prompt = buildGapPrompt(partialAnalysis.gaps, config.testGenerationLimit);
     const promptHash = hashForCostIntelligence(prompt);
     try {
-      const llmResult = await callLLM(prompt, config.llmTokenBudget);
+      const llmResult = await callLLM(prompt, maxOut);
       const resultHash = hashForCostIntelligence(llmResult.text);
       const usage = llmResult.usage;
       llmRecords.push({
@@ -129,7 +151,7 @@ export async function think(
       scenarioSource = 'template';
       const msg = err instanceof Error ? err.message : String(err);
       llmRecords.push({
-        provider: 'anthropic',
+        provider: 'unavailable',
         model: 'unknown',
         inputTokens: Math.max(0, Math.ceil(prompt.length / 4)),
         outputTokens: 0,
@@ -157,7 +179,7 @@ export async function think(
   );
 
   const costIntelligence = assembleCostIntelligence({
-    llmTokenBudget: config.llmTokenBudget,
+    maxOutputTokensPerLlmCall: maxOut,
     records: llmRecords,
     partial: partialAnalysis,
     scenarioSource,

--- a/packages/core/src/phases/think.ts
+++ b/packages/core/src/phases/think.ts
@@ -1,11 +1,14 @@
 import type { HarnessConfig } from '../schemas/config.schema.js';
 import { GapAnalysisSchema, NeutralScenarioSchema, type GapAnalysis, type NeutralScenario } from '../schemas/gap-analysis.schema.js';
+import type { LlmUsageRecord } from '../schemas/cost-intelligence.schema.js';
 import type { ObserveResult } from './observe.js';
 import { analyzeGaps } from '../tools/gap-engine.js';
 import { StateManager } from '../harness/state-manager.js';
 import { logDecision } from '../harness/decision-logger.js';
 import { callLLM, generateScenariosFromTemplate } from '../llm/provider.js';
 import { buildGapPrompt } from '../llm/context-builder.js';
+import { assembleCostIntelligence } from '../llm/cost-intelligence.js';
+import { hashForCostIntelligence } from '../llm/content-hash.js';
 import type { RunArtifactsOptions } from '../harness/run-options.js';
 
 export async function think(
@@ -43,6 +46,7 @@ export async function think(
 
   let scenarioSource: 'llm' | 'template' = 'template';
   let generatedScenarios: NeutralScenario[] = [];
+  const llmRecords: LlmUsageRecord[] = [];
 
   if (!process.env.ANTHROPIC_API_KEY) {
     await logDecision(
@@ -55,29 +59,86 @@ export async function think(
       logOpts
     );
     generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
+    llmRecords.push({
+      provider: 'none',
+      model: 'none',
+      inputTokens: 0,
+      outputTokens: 0,
+      operationType: 'scenario-generation',
+      timestamp: new Date().toISOString(),
+      dataQuality: 'none',
+      notes: 'No LLM call: ANTHROPIC_API_KEY not set; template scenarios only.',
+    });
   } else {
+    const prompt = buildGapPrompt(partialAnalysis.gaps, config.testGenerationLimit);
+    const promptHash = hashForCostIntelligence(prompt);
     try {
-      const prompt = buildGapPrompt(partialAnalysis.gaps, config.testGenerationLimit);
-      const response = await callLLM(prompt, config.llmTokenBudget);
-      const parsed = JSON.parse(response) as unknown;
-      const candidates = Array.isArray(parsed) ? parsed : [];
+      const llmResult = await callLLM(prompt, config.llmTokenBudget);
+      const resultHash = hashForCostIntelligence(llmResult.text);
+      const usage = llmResult.usage;
+      llmRecords.push({
+        provider: usage?.provider ?? 'unknown',
+        model: usage?.model ?? 'unknown',
+        inputTokens: usage?.inputTokens ?? 0,
+        outputTokens: usage?.outputTokens ?? 0,
+        operationType: 'scenario-generation',
+        timestamp: new Date().toISOString(),
+        promptHash,
+        resultHash,
+        dataQuality: usage?.dataQuality ?? 'estimated',
+        notes:
+          usage?.dataQuality === 'estimated'
+            ? 'Token counts estimated (API usage block missing).'
+            : undefined,
+      });
+      try {
+        const parsed = JSON.parse(llmResult.text) as unknown;
+        const candidates = Array.isArray(parsed) ? parsed : [];
 
-      for (const item of candidates) {
-        const validated = NeutralScenarioSchema.safeParse(item);
-        if (validated.success) {
-          generatedScenarios.push(validated.data);
+        for (const item of candidates) {
+          const validated = NeutralScenarioSchema.safeParse(item);
+          if (validated.success) {
+            generatedScenarios.push(validated.data);
+          }
         }
-      }
 
-      if (generatedScenarios.length === 0) {
+        if (generatedScenarios.length === 0) {
+          generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
+          scenarioSource = 'template';
+          const last = llmRecords[llmRecords.length - 1];
+          if (last) {
+            last.notes = [last.notes, 'Model returned no valid scenarios; template scenarios used.']
+              .filter(Boolean)
+              .join(' ');
+          }
+        } else {
+          scenarioSource = 'llm';
+        }
+      } catch {
         generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
         scenarioSource = 'template';
-      } else {
-        scenarioSource = 'llm';
+        const last = llmRecords[llmRecords.length - 1];
+        if (last) {
+          last.notes = [last.notes, 'Response was not valid JSON; template scenarios used.']
+            .filter(Boolean)
+            .join(' ');
+        }
       }
-    } catch {
+    } catch (err) {
       generatedScenarios = generateScenariosFromTemplate(partialAnalysis.gaps);
       scenarioSource = 'template';
+      const msg = err instanceof Error ? err.message : String(err);
+      llmRecords.push({
+        provider: 'anthropic',
+        model: 'unknown',
+        inputTokens: Math.max(0, Math.ceil(prompt.length / 4)),
+        outputTokens: 0,
+        operationType: 'scenario-generation',
+        timestamp: new Date().toISOString(),
+        promptHash,
+        dataQuality: 'estimated',
+        notes: `LLM call failed; template scenarios used. ${msg.slice(0, 240)}`,
+      });
     }
   }
 
@@ -95,10 +156,19 @@ export async function think(
     logOpts
   );
 
+  const costIntelligence = assembleCostIntelligence({
+    llmTokenBudget: config.llmTokenBudget,
+    records: llmRecords,
+    partial: partialAnalysis,
+    scenarioSource,
+    requireHumanReview: config.requireHumanReview,
+  });
+
   const completeAnalysis = GapAnalysisSchema.parse({
     ...partialAnalysis,
     scenarios: generatedScenarios,
     generatedTests: [],
+    costIntelligence,
   });
   if (artifacts.writeArtifacts) {
     await stateManager.writeState('gap-analysis.json', completeAnalysis, GapAnalysisSchema);

--- a/packages/core/src/reporters/markdown-reporter.ts
+++ b/packages/core/src/reporters/markdown-reporter.ts
@@ -21,7 +21,8 @@ export async function writeMarkdownReport(analysis: GapAnalysis, outputDir: stri
   const costSection = ci
     ? `## Cost Intelligence
 
-- **LLM token budget (max output per call):** ${ci.llmTokenBudgetConfigured} (${ci.budgetRole.replace(/-/g, ' ')})
+- **Per-completion LLM output ceiling:** ${ci.maxOutputTokensPerLlmCall} (${ci.budgetRole.replace(/-/g, ' ')})
+- **Meaning:** this caps **one** model completion per scenario-generation call; it is **not** a multi-step or multi-run token budget.
 - **Usage (this run):** input ${ci.usageSummary.totalInputTokens}, output ${ci.usageSummary.totalOutputTokens} tokens — _${ci.usageSummary.dataQuality}_
 - **Budget warnings:** ${ci.budgetWarnings.length ? ci.budgetWarnings.map((w) => `\n  - ${w}`).join('') : '_none_'}
 - **Repeated AI patterns:** ${ci.repeatedOperations.length ? ci.repeatedOperations.map((r) => `\n  - \`${r.promptHash}\` ×${r.count}: ${r.recommendation}`).join('') : '_none detected in this run_'}

--- a/packages/core/src/reporters/markdown-reporter.ts
+++ b/packages/core/src/reporters/markdown-reporter.ts
@@ -17,6 +17,19 @@ export async function writeMarkdownReport(analysis: GapAnalysis, outputDir: stri
     .map((s) => `### ${s.title}\n${s.description}\n\nSteps:\n${s.steps.map((step) => `- ${step.description}`).join('\n')}\n\nRecommended adapters: ${s.recommendations.map((r) => r.adapter).join(', ')}`)
     .join('\n\n---\n\n');
 
+  const ci = analysis.costIntelligence;
+  const costSection = ci
+    ? `## Cost Intelligence
+
+- **LLM token budget (max output per call):** ${ci.llmTokenBudgetConfigured} (${ci.budgetRole.replace(/-/g, ' ')})
+- **Usage (this run):** input ${ci.usageSummary.totalInputTokens}, output ${ci.usageSummary.totalOutputTokens} tokens — _${ci.usageSummary.dataQuality}_
+- **Budget warnings:** ${ci.budgetWarnings.length ? ci.budgetWarnings.map((w) => `\n  - ${w}`).join('') : '_none_'}
+- **Repeated AI patterns:** ${ci.repeatedOperations.length ? ci.repeatedOperations.map((r) => `\n  - \`${r.promptHash}\` ×${r.count}: ${r.recommendation}`).join('') : '_none detected in this run_'}
+- **Deterministic maturity:** **${ci.deterministicMaturity.label}** (level ${ci.deterministicMaturity.level}/5) — ${ci.deterministicMaturity.rationale}${ci.deterministicMaturity.ceilingNote ? `\n  - _${ci.deterministicMaturity.ceilingNote}_` : ''}
+- **Conversion recommendations:**${ci.conversionRecommendations.length ? ci.conversionRecommendations.map((c) => `\n  - ${c}`).join('') : '\n  - _none_'}
+`
+    : '';
+
   const md = `# Qulib Quality Gap Report
 
 **Generated:** ${analysis.analyzedAt}
@@ -29,6 +42,7 @@ export async function writeMarkdownReport(analysis: GapAnalysis, outputDir: stri
 - Scan budget exhausted (unfinished queue): ${analysis.coverageBudgetExceeded ? 'yes' : 'no'}
 ${analysis.coverageWarning ? `- Warning: **${analysis.coverageWarning}**` : '- Warning: none'}
 
+${costSection}
 ## Coverage gaps (${analysis.gaps.length})
 
 | Path | Category | Severity | Reason |

--- a/packages/core/src/reporters/markdown-reporter.ts
+++ b/packages/core/src/reporters/markdown-reporter.ts
@@ -5,9 +5,15 @@ import type { GapAnalysis } from '../schemas/gap-analysis.schema.js';
 export async function writeMarkdownReport(analysis: GapAnalysis, outputDir: string): Promise<void> {
   await mkdir(outputDir, { recursive: true });
 
+  const rc = analysis.releaseConfidence;
   const recommendation =
-    analysis.releaseConfidence >= 80 ? 'READY' :
-    analysis.releaseConfidence >= 50 ? 'CONDITIONAL' : 'NOT READY';
+    rc === null
+      ? 'NOT SCORED (blocked or insufficient surface)'
+      : rc >= 80
+        ? 'READY'
+        : rc >= 50
+          ? 'CONDITIONAL'
+          : 'NOT READY';
 
   const gapRows = analysis.gaps
     .map((g) => `| ${g.path} | ${g.category} | ${g.severity} | ${g.reason} |`)
@@ -35,7 +41,7 @@ export async function writeMarkdownReport(analysis: GapAnalysis, outputDir: stri
 
 **Generated:** ${analysis.analyzedAt}
 **Mode:** ${analysis.mode}
-**Release confidence:** ${analysis.releaseConfidence}/100 — ${recommendation}
+**Release confidence:** ${rc === null ? '—' : `${rc}/100`} — ${recommendation}
 
 ## Coverage
 

--- a/packages/core/src/schemas/config.schema.ts
+++ b/packages/core/src/schemas/config.schema.ts
@@ -38,8 +38,24 @@ export const HarnessConfigSchema = z.object({
   minPagesForConfidence: z.number().int().min(1).default(3),
   timeoutMs: z.number().int().positive(),
   retryCount: z.number().int().min(0),
-  llmTokenBudget: z.number().int().positive(),
+  llmTokenBudget: z
+    .number()
+    .int()
+    .positive()
+    .describe(
+      'Legacy name: max output tokens for a single LLM completion request. Prefer llmMaxOutputTokensPerCall when set.'
+    ),
+  llmMaxOutputTokensPerCall: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('When set, overrides llmTokenBudget (same semantics: per-completion output cap, not a multi-call total).'),
   testGenerationLimit: z.number().int().positive(),
+  enableLlmScenarios: z
+    .boolean()
+    .default(true)
+    .describe('When false, scenario generation uses templates only (no LLM calls).'),
   readOnlyMode: z.boolean(),
   requireHumanReview: z.boolean(),
   failOnConsoleError: z.boolean(),
@@ -50,6 +66,10 @@ export const HarnessConfigSchema = z.object({
 });
 
 export type HarnessConfig = z.infer<typeof HarnessConfigSchema>;
+
+export function resolveMaxOutputTokensPerLlmCall(config: HarnessConfig): number {
+  return config.llmMaxOutputTokensPerCall ?? config.llmTokenBudget;
+}
 
 export const DetectedAuthSchema = z.object({
   hasAuth: z.boolean(),

--- a/packages/core/src/schemas/cost-intelligence.schema.ts
+++ b/packages/core/src/schemas/cost-intelligence.schema.ts
@@ -32,7 +32,7 @@ export const DeterministicMaturitySchema = z.object({
 });
 
 export const CostIntelligenceSchema = z.object({
-  llmTokenBudgetConfigured: z.number().int().positive(),
+  maxOutputTokensPerLlmCall: z.number().int().positive(),
   budgetRole: z.literal('max-output-tokens-per-llm-call'),
   records: z.array(LlmUsageRecordSchema),
   budgetWarnings: z.array(z.string()),

--- a/packages/core/src/schemas/cost-intelligence.schema.ts
+++ b/packages/core/src/schemas/cost-intelligence.schema.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+export const LlmDataQualitySchema = z.enum(['actual', 'estimated', 'mixed', 'none']);
+
+export const LlmOperationTypeSchema = z.enum(['scenario-generation']);
+
+export const LlmUsageRecordSchema = z.object({
+  provider: z.string(),
+  model: z.string(),
+  inputTokens: z.number().int().min(0),
+  outputTokens: z.number().int().min(0),
+  estimatedCostUsd: z.number().optional(),
+  operationType: LlmOperationTypeSchema,
+  timestamp: z.string().datetime(),
+  promptHash: z.string().optional(),
+  resultHash: z.string().optional(),
+  dataQuality: LlmDataQualitySchema,
+  notes: z.string().optional(),
+});
+
+export const RepeatedAiPatternSchema = z.object({
+  promptHash: z.string(),
+  count: z.number().int().min(2),
+  recommendation: z.string(),
+});
+
+export const DeterministicMaturitySchema = z.object({
+  level: z.number().int().min(0).max(5),
+  label: z.string(),
+  rationale: z.string(),
+  ceilingNote: z.string().optional(),
+});
+
+export const CostIntelligenceSchema = z.object({
+  llmTokenBudgetConfigured: z.number().int().positive(),
+  budgetRole: z.literal('max-output-tokens-per-llm-call'),
+  records: z.array(LlmUsageRecordSchema),
+  budgetWarnings: z.array(z.string()),
+  usageSummary: z.object({
+    totalInputTokens: z.number().int().min(0),
+    totalOutputTokens: z.number().int().min(0),
+    dataQuality: LlmDataQualitySchema,
+  }),
+  repeatedOperations: z.array(RepeatedAiPatternSchema),
+  deterministicMaturity: DeterministicMaturitySchema,
+  conversionRecommendations: z.array(z.string()),
+});
+
+export type LlmDataQuality = z.infer<typeof LlmDataQualitySchema>;
+export type LlmOperationType = z.infer<typeof LlmOperationTypeSchema>;
+export type LlmUsageRecord = z.infer<typeof LlmUsageRecordSchema>;
+export type RepeatedAiPattern = z.infer<typeof RepeatedAiPatternSchema>;
+export type DeterministicMaturity = z.infer<typeof DeterministicMaturitySchema>;
+export type CostIntelligence = z.infer<typeof CostIntelligenceSchema>;

--- a/packages/core/src/schemas/gap-analysis.schema.ts
+++ b/packages/core/src/schemas/gap-analysis.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { CostIntelligenceSchema } from './cost-intelligence.schema.js';
 
 export const GapSchema = z.object({
   id: z.string(),
@@ -65,6 +66,7 @@ export const GapAnalysisSchema = z.object({
   gaps: z.array(GapSchema),
   scenarios: z.array(NeutralScenarioSchema),
   generatedTests: z.array(GeneratedTestSchema),
+  costIntelligence: CostIntelligenceSchema.optional(),
 });
 
 export type GapAnalysis = z.infer<typeof GapAnalysisSchema>;

--- a/packages/core/src/schemas/gap-analysis.schema.ts
+++ b/packages/core/src/schemas/gap-analysis.schema.ts
@@ -4,9 +4,11 @@ import { CostIntelligenceSchema } from './cost-intelligence.schema.js';
 export const GapSchema = z.object({
   id: z.string(),
   path: z.string(),
-  severity: z.enum(['high', 'medium', 'low']),
+  severity: z.enum(['critical', 'high', 'medium', 'low']),
   reason: z.string(),
-  category: z.enum(['untested-route', 'a11y', 'console-error', 'broken-link']),
+  category: z.enum(['untested-route', 'a11y', 'console-error', 'broken-link', 'auth-surface', 'coverage']),
+  description: z.string().optional(),
+  recommendation: z.string().optional(),
 });
 
 export const FrameworkRecommendationSchema = z.object({
@@ -57,7 +59,7 @@ export const GeneratedTestSchema = z.object({
 export const GapAnalysisSchema = z.object({
   analyzedAt: z.string().datetime(),
   mode: z.enum(['url-only', 'url-repo', 'auth-required']),
-  releaseConfidence: z.number().min(0).max(100),
+  releaseConfidence: z.union([z.number().min(0).max(100), z.null()]),
   coveragePagesScanned: z.number().int().min(0),
   coverageBudgetExceeded: z.boolean(),
   coverageWarning: z

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -1,5 +1,6 @@
 export {
   HarnessConfigSchema,
+  resolveMaxOutputTokensPerLlmCall,
   AuthConfigSchema,
   DetectedAuthSchema,
   AuthPathRequirementsSchema,

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -43,6 +43,20 @@ export {
   type FrameworkRecommendation,
 } from './gap-analysis.schema.js';
 export {
+  CostIntelligenceSchema,
+  LlmUsageRecordSchema,
+  LlmDataQualitySchema,
+  LlmOperationTypeSchema,
+  RepeatedAiPatternSchema,
+  DeterministicMaturitySchema,
+  type CostIntelligence,
+  type LlmUsageRecord,
+  type LlmDataQuality,
+  type LlmOperationType,
+  type RepeatedAiPattern,
+  type DeterministicMaturity,
+} from './cost-intelligence.schema.js';
+export {
   RepoAnalysisSchema,
   type RepoAnalysis,
 } from './repo-analysis.schema.js';

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -61,3 +61,11 @@ export {
   RepoAnalysisSchema,
   type RepoAnalysis,
 } from './repo-analysis.schema.js';
+export {
+  PublicSurfaceSchema,
+  PublicSurfaceViolationSchema,
+  PublicSurfaceBrokenLinkSchema,
+  type PublicSurface,
+  type PublicSurfaceViolation,
+  type PublicSurfaceBrokenLink,
+} from './public-surface.schema.js';

--- a/packages/core/src/schemas/public-surface.schema.ts
+++ b/packages/core/src/schemas/public-surface.schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { GapSchema } from './gap-analysis.schema.js';
+import { A11yViolationSchema, BrokenLinkSchema, RouteSchema } from './route-inventory.schema.js';
+
+export const PublicSurfaceViolationSchema = A11yViolationSchema.extend({
+  path: z.string(),
+});
+
+export const PublicSurfaceBrokenLinkSchema = BrokenLinkSchema.extend({
+  path: z.string(),
+});
+
+export const PublicSurfaceSchema = z.object({
+  pages: z.array(RouteSchema),
+  gaps: z.array(GapSchema),
+  accessibilityViolations: z.array(PublicSurfaceViolationSchema),
+  brokenLinks: z.array(PublicSurfaceBrokenLinkSchema),
+});
+
+export type PublicSurface = z.infer<typeof PublicSurfaceSchema>;
+export type PublicSurfaceViolation = z.infer<typeof PublicSurfaceViolationSchema>;
+export type PublicSurfaceBrokenLink = z.infer<typeof PublicSurfaceBrokenLinkSchema>;

--- a/packages/core/src/tools/auth-block-gap.test.ts
+++ b/packages/core/src/tools/auth-block-gap.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAuthBlockGap } from './auth-block-gap.js';
+
+test('buildAuthBlockGap matches coverage auth-block contract', () => {
+  const g = buildAuthBlockGap('https://platform.example.com/login');
+  assert.equal(g.id, 'auth-block');
+  assert.equal(g.category, 'coverage');
+  assert.equal(g.severity, 'critical');
+  assert.equal(g.description, 'Scan blocked by authentication. 0 authenticated pages were evaluated.');
+  assert.match(g.recommendation, /qulib auth init/);
+  assert.match(g.recommendation, /https:\/\/platform\.example\.com\/login/);
+});

--- a/packages/core/src/tools/auth-block-gap.ts
+++ b/packages/core/src/tools/auth-block-gap.ts
@@ -1,0 +1,20 @@
+import type { Gap } from '../schemas/gap-analysis.schema.js';
+
+export function buildAuthBlockGap(url: string): Gap {
+  const host = (() => {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return url;
+    }
+  })();
+  return {
+    id: 'auth-block',
+    path: '/',
+    severity: 'critical',
+    category: 'coverage',
+    reason: `Scan blocked by authentication. No authenticated pages were evaluated for ${host}.`,
+    description: 'Scan blocked by authentication. 0 authenticated pages were evaluated.',
+    recommendation: `Run \`qulib auth init --base-url ${url}\` to capture a storage state, then re-run with --auth storage-state.`,
+  };
+}

--- a/packages/core/src/tools/auth-detector.ts
+++ b/packages/core/src/tools/auth-detector.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test';
 import type { DetectedAuth } from '../schemas/config.schema.js';
+import type { AnalyzeProgressSink } from '../harness/progress-log.js';
 import { launchBrowser } from './browser.js';
 
 async function waitNetworkIdleBestEffort(page: Page): Promise<void> {
@@ -59,14 +60,29 @@ async function firstTextInputNameForLogin(page: import('@playwright/test').Page)
   return null;
 }
 
-export async function detectAuth(url: string, timeoutMs = 15000): Promise<DetectedAuth> {
+function debugAuth(): boolean {
+  return process.env.QULIB_DEBUG === '1';
+}
+
+export async function detectAuth(
+  url: string,
+  timeoutMs = 15000,
+  progress?: AnalyzeProgressSink
+): Promise<DetectedAuth> {
   const browser = await launchBrowser();
   try {
     const context = await browser.newContext();
     const page = await context.newPage();
 
+    progress?.info(`detect_auth URL=${url}`);
+
     await page.goto(url, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
     await waitNetworkIdleBestEffort(page);
+
+    if (debugAuth()) {
+      const html = await page.content();
+      progress?.debug(`detect_auth HTML byteLength=${Buffer.byteLength(html, 'utf8')}`);
+    }
 
     let loginUrl = url;
     const looksLikeLoginPage =
@@ -75,8 +91,11 @@ export async function detectAuth(url: string, timeoutMs = 15000): Promise<Detect
 
     if (!looksLikeLoginPage) {
       const loginLink = page.locator('a').filter({ hasText: /^(log ?in|sign ?in|sign in)$/i }).first();
-      if ((await loginLink.count()) > 0) {
+      const loginLinkCount = await loginLink.count();
+      progress?.debug(`detect_auth selector loginLink count=${loginLinkCount}`);
+      if (loginLinkCount > 0) {
         const href = await loginLink.getAttribute('href');
+        progress?.debug(`detect_auth selector loginLink href matched=${Boolean(href)}`);
         if (href) {
           loginUrl = new URL(href, url).toString();
           await page.goto(loginUrl, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
@@ -87,6 +106,7 @@ export async function detectAuth(url: string, timeoutMs = 15000): Promise<Detect
 
     const passwordInputs = page.locator('input[type="password"]');
     const passwordCount = await passwordInputs.count();
+    progress?.debug(`detect_auth selector input[type=password] count=${passwordCount}`);
     const hasFormLogin = passwordCount > 0;
 
     const oauthButtons: { provider: string; text: string }[] = [];
@@ -95,10 +115,17 @@ export async function detectAuth(url: string, timeoutMs = 15000): Promise<Detect
     for (const text of buttonTexts) {
       const trimmed = text.trim();
       if (!textLooksLikeOAuthIdpButton(trimmed)) {
+        if (debugAuth() && trimmed.length > 0 && trimmed.length <= 120) {
+          progress?.debug(`detect_auth oauth text skipped (not Idp-shaped) sample="${trimmed.slice(0, 80)}"`);
+        }
         continue;
       }
       for (const { provider, patterns } of OAUTH_PROVIDERS) {
-        if (patterns.some((p) => p.test(trimmed))) {
+        const matched = patterns.some((p) => p.test(trimmed));
+        if (debugAuth()) {
+          progress?.debug(`detect_auth oauth pattern try provider=${provider} matched=${matched}`);
+        }
+        if (matched) {
           if (!oauthButtons.find((b) => b.provider === provider)) {
             oauthButtons.push({ provider, text: trimmed.slice(0, 100) });
           }
@@ -133,6 +160,11 @@ export async function detectAuth(url: string, timeoutMs = 15000): Promise<Detect
         passwordSelector: passwordName ? `input[name="${passwordName}"]` : null,
         submitSelector: submitName ? `button[name="${submitName}"]` : 'button[type="submit"]',
       };
+      if (debugAuth()) {
+        progress?.debug(
+          `detect_auth resolved selectors username=${observedSelectors.usernameSelector ?? 'null'} password=${observedSelectors.passwordSelector ?? 'null'} submit=${observedSelectors.submitSelector}`
+        );
+      }
       recommendation = `Form login detected. Configure auth with type="form-login", credentials, and the selectors above. Test selectors in your browser dev tools to confirm.`;
     } else if (hasMagicLink) {
       type = 'magic-link';
@@ -144,6 +176,11 @@ export async function detectAuth(url: string, timeoutMs = 15000): Promise<Detect
       type = 'none';
       recommendation = `No authentication required for the entry URL. Qulib can scan anonymously.`;
     }
+
+    const providerList =
+      oauthButtons.length > 0 ? oauthButtons.map((b) => b.provider).join(', ') : provider ?? 'none';
+    const automatable = type === 'form-login';
+    progress?.info(`Auth detected: ${type} (${providerList}) automatable=${automatable}`);
 
     return {
       hasAuth: type !== 'none',

--- a/packages/core/src/tools/auth-explorer.ts
+++ b/packages/core/src/tools/auth-explorer.ts
@@ -5,6 +5,7 @@ import {
   type AuthPath,
   type AuthPathRequirements,
 } from '../schemas/config.schema.js';
+import type { AnalyzeProgressSink } from '../harness/progress-log.js';
 import { launchBrowser } from './browser.js';
 import { BUILT_IN_OAUTH_PROVIDERS, type OAuthProvider } from './oauth-providers.js';
 import { loadUserProviders } from './user-providers.js';
@@ -49,6 +50,10 @@ function slugifyLabel(text: string): string {
 
 function onLoginishPage(url: string): boolean {
   return /login|sign[- ]?in|auth|sso|oauth/i.test(new URL(url).pathname + new URL(url).hostname);
+}
+
+function debugExplore(): boolean {
+  return process.env.QULIB_DEBUG === '1';
 }
 
 function isHeuristicUnknownSso(text: string, loginish: boolean): boolean {
@@ -209,22 +214,36 @@ async function buildFormPaths(page: Page): Promise<AuthPath[]> {
   ];
 }
 
-export async function exploreAuth(url: string, timeoutMs = 20000): Promise<AuthExploration> {
+export async function exploreAuth(
+  url: string,
+  timeoutMs = 20000,
+  progress?: AnalyzeProgressSink
+): Promise<AuthExploration> {
   const browser = await launchBrowser();
   try {
     const context = await browser.newContext();
     const page = await context.newPage();
 
+    progress?.info(`explore_auth URL=${url}`);
+
     await page.goto(url, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
     await waitNetworkIdleBestEffort(page);
+
+    if (debugExplore()) {
+      const html = await page.content();
+      progress?.debug(`explore_auth HTML byteLength=${Buffer.byteLength(html, 'utf8')}`);
+    }
 
     const loginishAfterFirst =
       /login|sign[- ]?in|auth/i.test(page.url()) || (await page.locator('input[type="password"]').count()) > 0;
 
     if (!loginishAfterFirst) {
       const loginLink = page.locator('a').filter({ hasText: /^(log ?in|sign ?in|sign in)$/i }).first();
-      if ((await loginLink.count()) > 0) {
+      const cnt = await loginLink.count();
+      progress?.debug(`explore_auth selector loginLink count=${cnt}`);
+      if (cnt > 0) {
         const href = await loginLink.getAttribute('href');
+        progress?.debug(`explore_auth selector loginLink href matched=${Boolean(href)}`);
         if (href) {
           const next = new URL(href, url).toString();
           await page.goto(next, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
@@ -247,19 +266,23 @@ export async function exploreAuth(url: string, timeoutMs = 20000): Promise<AuthE
       if (!text) {
         continue;
       }
-      let matched: { p: ProviderWithSource; gate: boolean } | null = null;
+      let providerMatch: { p: ProviderWithSource; gate: boolean } | null = null;
       for (const p of allProviders) {
-        if (!matchProvider(text, p)) {
+        const hit = matchProvider(text, p);
+        if (debugExplore()) {
+          progress?.debug(`explore_auth provider try id=${p.id} matched=${hit}`);
+        }
+        if (!hit) {
           continue;
         }
         if (p.source === 'built-in' && !(textLooksLikeOAuthIdpButton(text) || loginish)) {
           continue;
         }
-        matched = { p, gate: textLooksLikeOAuthIdpButton(text) || loginish };
+        providerMatch = { p, gate: textLooksLikeOAuthIdpButton(text) || loginish };
         break;
       }
-      if (matched) {
-        const { p, gate } = matched;
+      if (providerMatch) {
+        const { p, gate } = providerMatch;
         const id = `oauth:${p.id}`;
         if (consumed.has(id)) {
           continue;
@@ -275,6 +298,7 @@ export async function exploreAuth(url: string, timeoutMs = 20000): Promise<AuthE
           confidence: oauthConfidence(p.source, loginish || gate),
           requirements: storageRequirement(),
         });
+        progress?.info(`explore_auth path id=${id} type=oauth provider=${p.id} automatable=false`);
         continue;
       }
       if (isHeuristicUnknownSso(text, loginish)) {
@@ -294,6 +318,7 @@ export async function exploreAuth(url: string, timeoutMs = 20000): Promise<AuthE
           confidence: 'low',
           requirements: storageRequirement(),
         });
+        progress?.info(`explore_auth path id=${id} type=oauth-unknown automatable=false`);
         const safePattern = text.slice(0, 48).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         unrecognizedButtons.push({
           label: text.slice(0, 100),
@@ -318,9 +343,14 @@ export async function exploreAuth(url: string, timeoutMs = 20000): Promise<AuthE
             'Magic-link flows need a human in the loop. Use `qulib auth init --base-url <app-url>` and complete email or provider steps in the opened browser, then reuse the saved storage state for scans.',
         },
       });
+      progress?.info('explore_auth path id=magic-link type=magic-link automatable=false');
     }
 
-    authPaths.push(...(await buildFormPaths(page)));
+    const formPaths = await buildFormPaths(page);
+    for (const fp of formPaths) {
+      authPaths.push(fp);
+      progress?.info(`explore_auth path id=${fp.id} type=${fp.type} automatable=${fp.automatable}`);
+    }
 
     const authRequired = authPaths.length > 0;
     let authScope: AuthExploration['authScope'] = 'none';

--- a/packages/core/src/tools/auth-surface-analyzer.ts
+++ b/packages/core/src/tools/auth-surface-analyzer.ts
@@ -1,0 +1,170 @@
+import type { Page } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import type { DetectedAuth } from '../schemas/config.schema.js';
+import type { Gap } from '../schemas/gap-analysis.schema.js';
+import { launchBrowser } from './browser.js';
+
+async function waitNetworkIdleBestEffort(page: Page): Promise<void> {
+  try {
+    await page.waitForLoadState('networkidle', { timeout: 5000 });
+  } catch {
+    /* best-effort */
+  }
+}
+
+export async function analyzeAuthSurfaceGaps(
+  url: string,
+  detection: DetectedAuth,
+  timeoutMs: number
+): Promise<Gap[]> {
+  if (!detection.hasAuth) {
+    return [];
+  }
+
+  const gaps: Gap[] = [];
+  const browser = await launchBrowser();
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const resp = await page.goto(url, { timeout: timeoutMs, waitUntil: 'domcontentloaded' }).catch(() => null);
+    if (!resp || !resp.ok()) {
+      gaps.push({
+        id: randomUUID(),
+        path: new URL(url).pathname || '/',
+        severity: 'critical',
+        category: 'auth-surface',
+        reason: 'Sign-in surface did not load successfully for evaluation.',
+        description: 'The auth entry URL failed to load or returned a non-OK status before DOM checks could run.',
+        recommendation: 'Verify DNS, TLS, and that the URL is reachable from the scan environment.',
+      });
+      return gaps;
+    }
+    await waitNetworkIdleBestEffort(page);
+
+    const title = await page.title().catch(() => '');
+    if (!title || title.trim().length < 3) {
+      gaps.push({
+        id: randomUUID(),
+        path: '/',
+        severity: 'medium',
+        category: 'auth-surface',
+        reason: 'Missing or trivial document title on the sign-in surface.',
+        description: 'Users and assistive tech rely on a meaningful window title.',
+        recommendation: 'Set a concise, unique <title> for the login experience.',
+      });
+    }
+
+    const metaDesc = await page.locator('meta[name="description"]').getAttribute('content').catch(() => null);
+    if (!metaDesc || metaDesc.trim().length < 8) {
+      gaps.push({
+        id: randomUUID(),
+        path: '/',
+        severity: 'low',
+        category: 'auth-surface',
+        reason: 'No meta description on the sign-in surface.',
+        description: 'Search and sharing previews benefit from meta description on public entry pages.',
+        recommendation: 'Add <meta name="description" content="..."> with a short summary of the product.',
+      });
+    }
+
+    const h1Count = await page.locator('h1').count();
+    if (h1Count === 0) {
+      gaps.push({
+        id: randomUUID(),
+        path: '/',
+        severity: 'medium',
+        category: 'auth-surface',
+        reason: 'No visible primary heading (h1) on the sign-in surface.',
+        description: 'A primary heading helps users orient on the login page.',
+        recommendation: 'Add a single descriptive <h1> for the sign-in view.',
+      });
+    }
+
+    const oauthButtons = page.locator('button, a[href], [role="button"]');
+    const n = await oauthButtons.count();
+    for (let i = 0; i < Math.min(n, 25); i++) {
+      const el = oauthButtons.nth(i);
+      const text = ((await el.textContent()) ?? '').trim();
+      if (!text || text.length > 120) continue;
+      const isOAuthish =
+        /google|microsoft|github|apple|sso|sign in with|log in with|continue with|oauth/i.test(text);
+      if (!isOAuthish) continue;
+
+      const role = await el.getAttribute('role');
+      const tag = await el.evaluate((node) => node.tagName.toLowerCase());
+      const tabIndex = await el.getAttribute('tabindex');
+      const aria = await el.getAttribute('aria-label');
+      const keyboardable = tag === 'button' || tag === 'a' || role === 'button';
+      const labeled = Boolean(aria && aria.trim().length > 0) || text.length > 0;
+      if (!keyboardable || tabIndex === '-1') {
+        gaps.push({
+          id: randomUUID(),
+          path: '/',
+          severity: 'high',
+          category: 'auth-surface',
+          reason: `OAuth control "${text.slice(0, 60)}" may not be keyboard-accessible.`,
+          description: 'SSO entry points should be real buttons or links with focus support.',
+          recommendation: 'Use <button> or <a href> with visible label; avoid tabindex=-1 on the only sign-in path.',
+        });
+      } else if (!labeled) {
+        gaps.push({
+          id: randomUUID(),
+          path: '/',
+          severity: 'medium',
+          category: 'auth-surface',
+          reason: `OAuth control "${text.slice(0, 60)}" lacks aria-label and has weak visible text.`,
+          description: 'Assistive technologies need a clear accessible name for IdP buttons.',
+          recommendation: 'Add aria-label or visible text that names the provider and action.',
+        });
+      }
+    }
+
+    const hasPassword = (await page.locator('input[type="password"]').count()) > 0;
+    const hasEmailLink = await page.getByText(/magic link|email.*link|passwordless/i).count();
+    const hasOAuthUi =
+      detection.oauthButtons.length > 0 ||
+      (await page.getByText(/sign in with|continue with google|microsoft|github/i).count()) > 0;
+    if (hasOAuthUi && !hasPassword && !hasEmailLink) {
+      gaps.push({
+        id: randomUUID(),
+        path: '/',
+        severity: 'medium',
+        category: 'auth-surface',
+        reason: 'OAuth-only entry with no visible password or magic-link fallback.',
+        description: 'Users who cannot use a social IdP need another path (email/password, help, or support).',
+        recommendation: 'Add a documented fallback (email/password, help desk link, or alternate IdP).',
+      });
+    }
+
+    const errorSelectors = '[role="alert"], [data-testid*="error" i], .error, .alert-danger, [class*="error" i]';
+    const errCount = await page.locator(errorSelectors).count();
+    if (errCount === 0 && hasOAuthUi) {
+      gaps.push({
+        id: randomUUID(),
+        path: '/',
+        severity: 'low',
+        category: 'auth-surface',
+        reason: 'No obvious in-DOM error container found for OAuth sign-in failures.',
+        description: 'IdP failures should surface recoverable feedback in the page.',
+        recommendation: 'Reserve a live region or inline alert for OAuth errors returned from the provider.',
+      });
+    }
+
+    const help = await page.getByText(/forgot password|need help|contact support|get help/i).count();
+    if (help === 0 && hasOAuthUi) {
+      gaps.push({
+        id: randomUUID(),
+        path: '/',
+        severity: 'low',
+        category: 'auth-surface',
+        reason: 'No visible “forgot password” or help path detected near OAuth controls.',
+        description: 'Users locked out of an IdP need a support or recovery affordance.',
+        recommendation: 'Link to account recovery, IT help, or a support URL near the sign-in actions.',
+      });
+    }
+  } finally {
+    await browser.close();
+  }
+
+  return gaps;
+}

--- a/packages/core/src/tools/cypress-explorer.ts
+++ b/packages/core/src/tools/cypress-explorer.ts
@@ -1,9 +1,10 @@
 import type { AppExplorer } from './explorer.interface.js';
 import type { HarnessConfig } from '../schemas/config.schema.js';
 import type { RouteInventory } from '../schemas/route-inventory.schema.js';
+import type { RunArtifactsOptions } from '../harness/run-options.js';
 
 export class CypressExplorer implements AppExplorer {
-  async explore(baseUrl: string, config: HarnessConfig): Promise<RouteInventory> {
+  async explore(_baseUrl: string, _config: HarnessConfig, _artifacts?: RunArtifactsOptions): Promise<RouteInventory> {
     throw new Error('Not implemented');
   }
 }

--- a/packages/core/src/tools/explorer.interface.ts
+++ b/packages/core/src/tools/explorer.interface.ts
@@ -1,6 +1,7 @@
 import type { HarnessConfig } from '../schemas/config.schema.js';
 import type { RouteInventory } from '../schemas/route-inventory.schema.js';
+import type { RunArtifactsOptions } from '../harness/run-options.js';
 
 export interface AppExplorer {
-  explore(baseUrl: string, config: HarnessConfig): Promise<RouteInventory>;
+  explore(baseUrl: string, config: HarnessConfig, artifacts?: RunArtifactsOptions): Promise<RouteInventory>;
 }

--- a/packages/core/src/tools/gap-engine.test.ts
+++ b/packages/core/src/tools/gap-engine.test.ts
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeCoverageScore, computeQualityScoreFromGaps } from './gap-engine.js';
+import type { RouteInventory, Route } from '../schemas/route-inventory.schema.js';
+import type { Gap } from '../schemas/gap-analysis.schema.js';
+
+function routesInv(partial: Partial<RouteInventory> & Pick<RouteInventory, 'routes'>): RouteInventory {
+  return {
+    scannedAt: new Date().toISOString(),
+    baseUrl: 'https://example.com',
+    pagesSkipped: 0,
+    budgetExceeded: false,
+    ...partial,
+  };
+}
+
+test('computeCoverageScore is 100 when all discovered routes were scanned', () => {
+  assert.equal(computeCoverageScore(routesInv({ routes: [{ path: '/' } as Route], pagesSkipped: 0 })), 100);
+});
+
+test('computeCoverageScore is proportional when some routes were skipped', () => {
+  assert.equal(
+    computeCoverageScore(
+      routesInv({
+        routes: [{ path: '/a' } as Route, { path: '/b' } as Route, { path: '/c' } as Route],
+        pagesSkipped: 7,
+      })
+    ),
+    30
+  );
+});
+
+test('computeCoverageScore is 0 when nothing was scanned and nothing skipped', () => {
+  assert.equal(computeCoverageScore(routesInv({ routes: [], pagesSkipped: 0 })), 0);
+});
+
+test('computeQualityScoreFromGaps is 100 for no gaps', () => {
+  assert.equal(computeQualityScoreFromGaps([]), 100);
+});
+
+test('computeQualityScoreFromGaps reflects high-severity weighting', () => {
+  const g: Gap[] = [{ id: '1', path: '/', severity: 'high', reason: 'x', category: 'console-error' }];
+  assert.equal(computeQualityScoreFromGaps(g), 80);
+});
+
+test('computeQualityScoreFromGaps penalizes critical findings', () => {
+  const g: Gap[] = [{ id: '1', path: '/', severity: 'critical', reason: 'c', category: 'a11y' }];
+  assert.equal(computeQualityScoreFromGaps(g), 75);
+});

--- a/packages/core/src/tools/gap-engine.ts
+++ b/packages/core/src/tools/gap-engine.ts
@@ -22,6 +22,8 @@ export function computeCoverageScore(routes: RouteInventory): number | null {
   const scanned = routes.routes.length;
   const skipped = routes.pagesSkipped;
   const denom = scanned + skipped;
+  // TODO: return null here once the explorer exposes an explicit "discovered-but-unknown" signal
+  //       (i.e. routes were found but the full set couldn't be confirmed — a low score is misleading)
   if (denom === 0) {
     if (routes.budgetExceeded) {
       return 0;

--- a/packages/core/src/tools/gap-engine.ts
+++ b/packages/core/src/tools/gap-engine.ts
@@ -4,6 +4,33 @@ import type { RouteInventory } from '../schemas/route-inventory.schema.js';
 import type { RepoAnalysis } from '../schemas/repo-analysis.schema.js';
 import type { HarnessConfig } from '../schemas/config.schema.js';
 
+export function computeQualityScoreFromGaps(gaps: Gap[]): number {
+  let critical = 0;
+  let high = 0;
+  let medium = 0;
+  let low = 0;
+  for (const g of gaps) {
+    if (g.severity === 'critical') critical++;
+    else if (g.severity === 'high') high++;
+    else if (g.severity === 'medium') medium++;
+    else low++;
+  }
+  return Math.max(0, 100 - critical * 25 - high * 20 - medium * 8 - low * 3);
+}
+
+export function computeCoverageScore(routes: RouteInventory): number | null {
+  const scanned = routes.routes.length;
+  const skipped = routes.pagesSkipped;
+  const denom = scanned + skipped;
+  if (denom === 0) {
+    if (routes.budgetExceeded) {
+      return 0;
+    }
+    return scanned === 0 ? 0 : 100;
+  }
+  return Math.round((100 * scanned) / denom);
+}
+
 export function analyzeGaps(
   routes: RouteInventory,
   repo: RepoAnalysis | null,
@@ -72,11 +99,13 @@ export function analyzeGaps(
     for (const violation of route.a11yViolations) {
       const impact = violation.impact.toLowerCase();
       const severity: Gap['severity'] =
-        impact === 'critical' || impact === 'serious'
-          ? 'high'
-          : impact === 'moderate'
-            ? 'medium'
-            : 'low';
+        impact === 'critical'
+          ? 'critical'
+          : impact === 'serious'
+            ? 'high'
+            : impact === 'moderate'
+              ? 'medium'
+              : 'low';
       addGap({
         id: randomUUID(),
         path: route.path,
@@ -87,16 +116,9 @@ export function analyzeGaps(
     }
   }
 
-  const highCount = gaps.filter((g) => g.severity === 'high').length;
-  const mediumCount = gaps.filter((g) => g.severity === 'medium').length;
-  const lowCount = gaps.filter((g) => g.severity === 'low').length;
-  let releaseConfidence = Math.max(0, 100 - highCount * 20 - mediumCount * 8 - lowCount * 3);
+  const releaseConfidence = computeQualityScoreFromGaps(gaps);
 
   const pagesScanned = routes.routes.length;
-  if (pagesScanned < config.minPagesForConfidence) {
-    releaseConfidence = Math.min(releaseConfidence, 40);
-  }
-
   let coverageWarning: GapAnalysis['coverageWarning'];
   if (routes.budgetExceeded) {
     coverageWarning = 'budget-exceeded';

--- a/packages/core/src/tools/playwright-explorer.ts
+++ b/packages/core/src/tools/playwright-explorer.ts
@@ -5,6 +5,7 @@ import type { AppExplorer } from './explorer.interface.js';
 import { createAuthenticatedContext } from './auth.js';
 import { RouteInventorySchema, type RouteInventory, type Route } from '../schemas/route-inventory.schema.js';
 import type { HarnessConfig } from '../schemas/config.schema.js';
+import type { RunArtifactsOptions } from '../harness/run-options.js';
 
 function crawlHostKey(hostname: string): string {
   return hostname.replace(/^www\./i, '').toLowerCase();
@@ -20,8 +21,13 @@ function isInternalHref(href: string, baseUrlStr: string): boolean {
   }
 }
 
+function debugMode(): boolean {
+  return process.env.QULIB_DEBUG === '1';
+}
+
 export class PlaywrightExplorer implements AppExplorer {
-  async explore(baseUrl: string, config: HarnessConfig): Promise<RouteInventory> {
+  async explore(baseUrl: string, config: HarnessConfig, artifacts?: RunArtifactsOptions): Promise<RouteInventory> {
+    const progress = artifacts?.progressLog;
     const browser = await launchBrowser();
 
     let context: BrowserContext;
@@ -35,7 +41,10 @@ export class PlaywrightExplorer implements AppExplorer {
     if (config.auth) {
       const label =
         config.auth.type === 'form-login' ? config.auth.credentials.username : 'storage-state';
-      console.error(`[qulib] authenticated as ${label}`);
+      progress?.info(`Authenticated context: ${label}`);
+      if (!progress) {
+        process.stderr.write(`[qulib] authenticated as ${label}\n`);
+      }
     }
 
     const visited = new Set<string>();
@@ -69,10 +78,16 @@ export class PlaywrightExplorer implements AppExplorer {
         });
 
         try {
-          await page.goto(url, {
+          const navResponse = await page.goto(url, {
             timeout: config.timeoutMs,
             waitUntil: 'domcontentloaded',
           });
+          const httpStatus = navResponse?.status() ?? 0;
+
+          if (debugMode()) {
+            const html = await page.content();
+            progress?.debug(`page HTML byteLength=${Buffer.byteLength(html, 'utf8')} url=${normalized}`);
+          }
 
           const pageTitle = await page.title();
           const formCount = await page.locator('form').count();
@@ -113,6 +128,9 @@ export class PlaywrightExplorer implements AppExplorer {
             const axeResults = await new AxeBuilder({ page })
               .withTags(['wcag2a', 'wcag2aa'])
               .analyze();
+            if (debugMode()) {
+              progress?.debug(`raw axe violations (pre-map) count=${axeResults.violations.length} json=${JSON.stringify(axeResults.violations)}`);
+            }
             a11yViolations = axeResults.violations.map((v) => ({
               id: v.id,
               impact: v.impact ?? 'unknown',
@@ -125,6 +143,8 @@ export class PlaywrightExplorer implements AppExplorer {
 
           const path = new URL(url).pathname || '/';
 
+          progress?.info(`Crawled ${normalized} status=${httpStatus} a11yViolations=${a11yViolations.length}`);
+
           routes.push({
             path,
             pageTitle,
@@ -134,6 +154,7 @@ export class PlaywrightExplorer implements AppExplorer {
             consoleErrors,
             brokenLinks,
             a11yViolations,
+            statusCode: httpStatus,
           });
         } catch (err) {
           const path = (() => {
@@ -143,6 +164,7 @@ export class PlaywrightExplorer implements AppExplorer {
               return url;
             }
           })();
+          progress?.info(`Crawled ${normalized} status=error a11yViolations=0 err=${String(err).slice(0, 120)}`);
           routes.push({
             path,
             pageTitle: '',

--- a/packages/core/src/tools/public-surface.ts
+++ b/packages/core/src/tools/public-surface.ts
@@ -1,0 +1,17 @@
+import type { RouteInventory } from '../schemas/route-inventory.schema.js';
+import type { Gap } from '../schemas/gap-analysis.schema.js';
+import type { PublicSurface, PublicSurfaceBrokenLink, PublicSurfaceViolation } from '../schemas/public-surface.schema.js';
+
+export function buildPublicSurface(pages: RouteInventory['routes'], gaps: Gap[]): PublicSurface {
+  const accessibilityViolations: PublicSurfaceViolation[] = [];
+  const brokenLinks: PublicSurfaceBrokenLink[] = [];
+  for (const r of pages) {
+    for (const v of r.a11yViolations) {
+      accessibilityViolations.push({ ...v, path: r.path });
+    }
+    for (const b of r.brokenLinks) {
+      brokenLinks.push({ ...b, path: r.path });
+    }
+  }
+  return { pages, gaps, accessibilityViolations, brokenLinks };
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -12,5 +12,5 @@
     "declarationMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -7,7 +7,7 @@
 Tools:
 
 - **`explore_auth(url, timeoutMs?)`** — list all sign-in paths (OAuth, unknown SSO heuristics, forms, magic link) and what the agent must collect before `analyze_app`. Prefer this on unfamiliar apps.
-- **`analyze_app(url, auth?)`** — full quality scan (optional form-login or storage-state auth).
+- **`analyze_app`** — quality scan (optional form-login or storage-state auth). **Default payload is summary-first:** `summary`, `topGaps`, `costIntelligenceSummary`, `nextDeterministicChecks`, small previews. Set **`includeFullReport: true`** for the full `analyzeApp` result (all scenarios). Optional harness overrides: **`llmMaxOutputTokensPerCall`**, **`llmTokenBudget`** (legacy), **`testGenerationLimit`**, **`enableLlmScenarios`** (default true when omitted).
 - **`detect_auth(url, timeoutMs?)`** — single-pattern auth guess with a short recommendation (lighter than `explore_auth`).
 
 Returns from `analyze_app`:
@@ -60,6 +60,30 @@ On unfamiliar apps, call **`explore_auth`** before **`analyze_app`**. The respon
 When the model sees **`unrecognizedButtons`**, it can ask the user to register a label on the **MCP host** with the CLI:
 
 `qulib auth providers add --id <kebab-id> --label "..." --pattern "..."` — patterns are saved under **`~/.qulib/providers.json`** and merged with the built-in list on the next `explore_auth` / `explore-auth`. Nothing is auto-written without an explicit `providers add`.
+
+## Compact vs full `analyze_app` response
+
+| | Default (`includeFullReport` omitted or false) | `includeFullReport: true` |
+|--|--|--|
+| Size | Small: top gaps, cost summary, next checks | Full `gapAnalysis` with every scenario |
+| When to use | Routine agent turns, chat context limits | Deep dives, exporting full scenario JSON |
+
+Example (full):
+
+```json
+{ "url": "https://example.com", "includeFullReport": true }
+```
+
+Example (tighter LLM envelope from MCP):
+
+```json
+{
+  "url": "https://example.com",
+  "llmMaxOutputTokensPerCall": 2048,
+  "testGenerationLimit": 5,
+  "enableLlmScenarios": true
+}
+```
 
 ## Example usage
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -28,7 +28,8 @@
   ],
   "scripts": {
     "build": "tsc && chmod +x dist/index.js",
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "node --import tsx/esm --test src/compact-analyze-payload.test.ts"
   },
   "dependencies": {
     "@qulib/core": "0.2.2",

--- a/packages/mcp/src/compact-analyze-payload.test.ts
+++ b/packages/mcp/src/compact-analyze-payload.test.ts
@@ -3,57 +3,64 @@ import assert from 'node:assert/strict';
 import { buildCompactAnalyzePayload } from './compact-analyze-payload.js';
 import type { AnalyzeResult } from '@qulib/core';
 
-const minimalResult = (): AnalyzeResult => ({
-  releaseConfidence: 55,
-  gapAnalysis: {
-    analyzedAt: new Date().toISOString(),
-    mode: 'url-only',
-    releaseConfidence: 55,
-    coveragePagesScanned: 2,
-    coverageBudgetExceeded: false,
-    gaps: [
-      {
-        id: '1',
-        path: '/a',
-        severity: 'high',
-        reason: 'console',
-        category: 'console-error',
-      },
-      {
-        id: '2',
-        path: '/b',
-        severity: 'low',
-        reason: 'link',
-        category: 'broken-link',
-      },
-    ],
-    scenarios: [],
-    generatedTests: [],
-    costIntelligence: {
-      maxOutputTokensPerLlmCall: 1024,
-      budgetRole: 'max-output-tokens-per-llm-call',
-      records: [],
-      budgetWarnings: [],
-      usageSummary: { totalInputTokens: 0, totalOutputTokens: 0, dataQuality: 'none' },
-      repeatedOperations: [],
-      deterministicMaturity: {
-        level: 1,
-        label: 'L1',
-        rationale: 'test',
-      },
-      conversionRecommendations: ['do x'],
+const minimalResult = (): AnalyzeResult => {
+  const gaps = [
+    {
+      id: '1',
+      path: '/a',
+      severity: 'high' as const,
+      reason: 'console',
+      category: 'console-error' as const,
     },
-  },
-  routeInventory: {
-    scannedAt: new Date().toISOString(),
-    baseUrl: 'https://example.com',
-    routes: [],
-    pagesSkipped: 0,
-    budgetExceeded: false,
-  },
-  repoInventory: null,
-  decisionLog: [],
-});
+    {
+      id: '2',
+      path: '/b',
+      severity: 'low' as const,
+      reason: 'link',
+      category: 'broken-link' as const,
+    },
+  ];
+  return {
+    status: 'complete',
+    coverageScore: 0,
+    releaseConfidence: 55,
+    gaps,
+    gapAnalysis: {
+      analyzedAt: new Date().toISOString(),
+      mode: 'url-only',
+      releaseConfidence: 55,
+      coveragePagesScanned: 2,
+      coverageBudgetExceeded: false,
+      gaps,
+      scenarios: [],
+      generatedTests: [],
+      costIntelligence: {
+        maxOutputTokensPerLlmCall: 1024,
+        budgetRole: 'max-output-tokens-per-llm-call',
+        records: [],
+        budgetWarnings: [],
+        usageSummary: { totalInputTokens: 0, totalOutputTokens: 0, dataQuality: 'none' },
+        repeatedOperations: [],
+        deterministicMaturity: {
+          level: 1,
+          label: 'L1',
+          rationale: 'test',
+        },
+        conversionRecommendations: ['do x'],
+      },
+    },
+    routeInventory: {
+      scannedAt: new Date().toISOString(),
+      baseUrl: 'https://example.com',
+      routes: [],
+      pagesSkipped: 0,
+      budgetExceeded: false,
+    },
+    repoInventory: null,
+    decisionLog: [],
+    publicSurface: null,
+  };
+};
 
 test('buildCompactAnalyzePayload returns full result when includeFullReport', () => {
   const r = minimalResult();
@@ -65,9 +72,39 @@ test('buildCompactAnalyzePayload summary-first shape', () => {
   const r = minimalResult();
   const out = buildCompactAnalyzePayload(r, false) as Record<string, unknown>;
   assert.equal(out.includeFullReport, false);
+  assert.equal((out.summary as { status: string }).status, 'complete');
+  assert.equal((out.summary as { coverageScore: number }).coverageScore, 0);
   assert.ok(Array.isArray(out.topGaps));
   assert.equal((out.topGaps as { severity: string }[])[0]!.severity, 'high');
   assert.ok(out.costIntelligenceSummary);
   assert.equal((out.gapAnalysisPreview as { scenariosOmitted: number }).scenariosOmitted, 0);
   assert.ok(Array.isArray(out.nextDeterministicChecks));
+});
+
+test('buildCompactAnalyzePayload orders critical ahead of high in topGaps', () => {
+  const r = minimalResult();
+  r.gaps.unshift({
+    id: '0',
+    path: '/z',
+    severity: 'critical',
+    reason: 'auth',
+    category: 'coverage',
+  });
+  r.gapAnalysis.gaps = r.gaps;
+  const out = buildCompactAnalyzePayload(r, false) as { topGaps: { severity: string }[] };
+  assert.equal(out.topGaps[0]!.severity, 'critical');
+});
+
+test('buildCompactAnalyzePayload summary includes publicSurface counts when present', () => {
+  const r = minimalResult();
+  r.publicSurface = {
+    pages: [{ path: '/', pageTitle: 'x', links: [], formCount: 0, buttonLabels: [], consoleErrors: [], brokenLinks: [], a11yViolations: [] }],
+    gaps: [],
+    accessibilityViolations: [{ id: 'a', impact: 'serious', helpUrl: 'u', nodeCount: 1, path: '/' }],
+    brokenLinks: [{ url: 'https://x', status: 404, path: '/' }],
+  };
+  const out = buildCompactAnalyzePayload(r, false) as { summary: { publicSurface: Record<string, number> } };
+  assert.equal(out.summary.publicSurface.pageCount, 1);
+  assert.equal(out.summary.publicSurface.accessibilityViolationCount, 1);
+  assert.equal(out.summary.publicSurface.brokenLinkCount, 1);
 });

--- a/packages/mcp/src/compact-analyze-payload.test.ts
+++ b/packages/mcp/src/compact-analyze-payload.test.ts
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildCompactAnalyzePayload } from './compact-analyze-payload.js';
+import type { AnalyzeResult } from '@qulib/core';
+
+const minimalResult = (): AnalyzeResult => ({
+  releaseConfidence: 55,
+  gapAnalysis: {
+    analyzedAt: new Date().toISOString(),
+    mode: 'url-only',
+    releaseConfidence: 55,
+    coveragePagesScanned: 2,
+    coverageBudgetExceeded: false,
+    gaps: [
+      {
+        id: '1',
+        path: '/a',
+        severity: 'high',
+        reason: 'console',
+        category: 'console-error',
+      },
+      {
+        id: '2',
+        path: '/b',
+        severity: 'low',
+        reason: 'link',
+        category: 'broken-link',
+      },
+    ],
+    scenarios: [],
+    generatedTests: [],
+    costIntelligence: {
+      maxOutputTokensPerLlmCall: 1024,
+      budgetRole: 'max-output-tokens-per-llm-call',
+      records: [],
+      budgetWarnings: [],
+      usageSummary: { totalInputTokens: 0, totalOutputTokens: 0, dataQuality: 'none' },
+      repeatedOperations: [],
+      deterministicMaturity: {
+        level: 1,
+        label: 'L1',
+        rationale: 'test',
+      },
+      conversionRecommendations: ['do x'],
+    },
+  },
+  routeInventory: {
+    scannedAt: new Date().toISOString(),
+    baseUrl: 'https://example.com',
+    routes: [],
+    pagesSkipped: 0,
+    budgetExceeded: false,
+  },
+  repoInventory: null,
+  decisionLog: [],
+});
+
+test('buildCompactAnalyzePayload returns full result when includeFullReport', () => {
+  const r = minimalResult();
+  const out = buildCompactAnalyzePayload(r, true);
+  assert.equal(out, r);
+});
+
+test('buildCompactAnalyzePayload summary-first shape', () => {
+  const r = minimalResult();
+  const out = buildCompactAnalyzePayload(r, false) as Record<string, unknown>;
+  assert.equal(out.includeFullReport, false);
+  assert.ok(Array.isArray(out.topGaps));
+  assert.equal((out.topGaps as { severity: string }[])[0]!.severity, 'high');
+  assert.ok(out.costIntelligenceSummary);
+  assert.equal((out.gapAnalysisPreview as { scenariosOmitted: number }).scenariosOmitted, 0);
+  assert.ok(Array.isArray(out.nextDeterministicChecks));
+});

--- a/packages/mcp/src/compact-analyze-payload.ts
+++ b/packages/mcp/src/compact-analyze-payload.ts
@@ -1,12 +1,12 @@
 import type { AnalyzeResult } from '@qulib/core';
 
-const severityOrder = { high: 0, medium: 1, low: 2 } as const;
+const severityOrder = { critical: 0, high: 1, medium: 2, low: 3 } as const;
 
-function topGapsBySeverity(gaps: AnalyzeResult['gapAnalysis']['gaps'], limit: number) {
+function topGapsBySeverity(gaps: AnalyzeResult['gaps'], limit: number) {
   return [...gaps].sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity]).slice(0, limit);
 }
 
-function nextDeterministicChecks(gaps: AnalyzeResult['gapAnalysis']['gaps'], conversion: string[]): string[] {
+function nextDeterministicChecks(gaps: AnalyzeResult['gaps'], conversion: string[]): string[] {
   const out: string[] = [];
   const byCat = new Map<string, number>();
   for (const g of gaps) {
@@ -25,7 +25,7 @@ export function buildCompactAnalyzePayload(result: AnalyzeResult, includeFullRep
   }
   const g = result.gapAnalysis;
   const ci = g.costIntelligence;
-  const top = topGapsBySeverity(g.gaps, 5);
+  const top = topGapsBySeverity(result.gaps, 5);
   const costSummary = ci
     ? {
         maxOutputTokensPerLlmCall: ci.maxOutputTokensPerLlmCall,
@@ -38,8 +38,12 @@ export function buildCompactAnalyzePayload(result: AnalyzeResult, includeFullRep
       }
     : null;
 
+  const ps = result.publicSurface;
+
   return {
     summary: {
+      status: result.status,
+      coverageScore: result.coverageScore,
       releaseConfidence: g.releaseConfidence,
       mode: g.mode,
       coveragePagesScanned: g.coveragePagesScanned,
@@ -48,6 +52,15 @@ export function buildCompactAnalyzePayload(result: AnalyzeResult, includeFullRep
       gapCount: g.gaps.length,
       scenarioCount: g.scenarios.length,
       generatedTestCount: g.generatedTests.length,
+      publicSurface:
+        ps === null
+          ? null
+          : {
+              pageCount: ps.pages.length,
+              gapCount: ps.gaps.length,
+              accessibilityViolationCount: ps.accessibilityViolations.length,
+              brokenLinkCount: ps.brokenLinks.length,
+            },
     },
     topGaps: top.map((x) => ({
       path: x.path,
@@ -58,8 +71,8 @@ export function buildCompactAnalyzePayload(result: AnalyzeResult, includeFullRep
     costIntelligenceSummary: costSummary,
     costIntelligence: ci ?? null,
     nextDeterministicChecks: ci
-      ? nextDeterministicChecks(g.gaps, ci.conversionRecommendations)
-      : nextDeterministicChecks(g.gaps, []),
+      ? nextDeterministicChecks(result.gaps, ci.conversionRecommendations)
+      : nextDeterministicChecks(result.gaps, []),
     gapAnalysisPreview: {
       analyzedAt: g.analyzedAt,
       gapsSample: g.gaps.slice(0, 8),

--- a/packages/mcp/src/compact-analyze-payload.ts
+++ b/packages/mcp/src/compact-analyze-payload.ts
@@ -1,0 +1,82 @@
+import type { AnalyzeResult } from '@qulib/core';
+
+const severityOrder = { high: 0, medium: 1, low: 2 } as const;
+
+function topGapsBySeverity(gaps: AnalyzeResult['gapAnalysis']['gaps'], limit: number) {
+  return [...gaps].sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity]).slice(0, limit);
+}
+
+function nextDeterministicChecks(gaps: AnalyzeResult['gapAnalysis']['gaps'], conversion: string[]): string[] {
+  const out: string[] = [];
+  const byCat = new Map<string, number>();
+  for (const g of gaps) {
+    byCat.set(g.category, (byCat.get(g.category) ?? 0) + 1);
+  }
+  for (const [cat, n] of [...byCat.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3)) {
+    out.push(`Add or tighten deterministic coverage for **${cat}** (${n} gap(s) in this scan).`);
+  }
+  out.push(...conversion.slice(0, 2));
+  return out.slice(0, 5);
+}
+
+export function buildCompactAnalyzePayload(result: AnalyzeResult, includeFullReport: boolean) {
+  if (includeFullReport) {
+    return result;
+  }
+  const g = result.gapAnalysis;
+  const ci = g.costIntelligence;
+  const top = topGapsBySeverity(g.gaps, 5);
+  const costSummary = ci
+    ? {
+        maxOutputTokensPerLlmCall: ci.maxOutputTokensPerLlmCall,
+        usageDataQuality: ci.usageSummary.dataQuality,
+        totalInputTokens: ci.usageSummary.totalInputTokens,
+        totalOutputTokens: ci.usageSummary.totalOutputTokens,
+        budgetWarningCount: ci.budgetWarnings.length,
+        maturityLevel: ci.deterministicMaturity.level,
+        maturityLabel: ci.deterministicMaturity.label,
+      }
+    : null;
+
+  return {
+    summary: {
+      releaseConfidence: g.releaseConfidence,
+      mode: g.mode,
+      coveragePagesScanned: g.coveragePagesScanned,
+      coverageBudgetExceeded: g.coverageBudgetExceeded,
+      coverageWarning: g.coverageWarning ?? null,
+      gapCount: g.gaps.length,
+      scenarioCount: g.scenarios.length,
+      generatedTestCount: g.generatedTests.length,
+    },
+    topGaps: top.map((x) => ({
+      path: x.path,
+      category: x.category,
+      severity: x.severity,
+      reason: x.reason,
+    })),
+    costIntelligenceSummary: costSummary,
+    costIntelligence: ci ?? null,
+    nextDeterministicChecks: ci
+      ? nextDeterministicChecks(g.gaps, ci.conversionRecommendations)
+      : nextDeterministicChecks(g.gaps, []),
+    gapAnalysisPreview: {
+      analyzedAt: g.analyzedAt,
+      gapsSample: g.gaps.slice(0, 8),
+      scenariosOmitted: g.scenarios.length,
+      generatedTestsOmitted: g.generatedTests.length,
+    },
+    routeInventorySummary: {
+      scannedAt: result.routeInventory.scannedAt,
+      baseUrl: result.routeInventory.baseUrl,
+      routeCount: result.routeInventory.routes.length,
+      pagesSkipped: result.routeInventory.pagesSkipped,
+      budgetExceeded: result.routeInventory.budgetExceeded,
+    },
+    repoInventory: result.repoInventory,
+    decisionLogPreview: result.decisionLog.slice(-8),
+    ...(result.detectedAuth !== undefined && { detectedAuth: result.detectedAuth }),
+    includeFullReport: false,
+    note: 'Summary-first payload. Pass includeFullReport: true for full gapAnalysis (all scenarios and generatedTests).',
+  };
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -3,8 +3,9 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { analyzeApp, detectAuth, exploreAuth } from '@qulib/core';
-import type { AnalyzeResult } from '@qulib/core';
+import type { HarnessConfig } from '@qulib/core';
 import { z } from 'zod';
+import { buildCompactAnalyzePayload } from './compact-analyze-payload.js';
 
 const FormLoginMcpAuthSchema = z.object({
   type: z.literal('form-login'),
@@ -28,46 +29,11 @@ const AnalyzeInputSchema = z.object({
   timeoutMs: z.number().int().positive().optional(),
   auth: z.discriminatedUnion('type', [FormLoginMcpAuthSchema, StorageStateMcpAuthSchema]).optional(),
   includeFullReport: z.boolean().optional(),
+  llmTokenBudget: z.number().int().positive().optional(),
+  llmMaxOutputTokensPerCall: z.number().int().positive().optional(),
+  testGenerationLimit: z.number().int().positive().max(50).optional(),
+  enableLlmScenarios: z.boolean().optional(),
 });
-
-function compactAnalyzeAppResponse(result: AnalyzeResult, includeFullReport: boolean) {
-  if (includeFullReport) {
-    return result;
-  }
-  const g = result.gapAnalysis;
-  return {
-    summary: {
-      releaseConfidence: g.releaseConfidence,
-      mode: g.mode,
-      coveragePagesScanned: g.coveragePagesScanned,
-      coverageBudgetExceeded: g.coverageBudgetExceeded,
-      coverageWarning: g.coverageWarning ?? null,
-      gapCount: g.gaps.length,
-      scenarioCount: g.scenarios.length,
-      generatedTestCount: g.generatedTests.length,
-    },
-    gapAnalysisPreview: {
-      analyzedAt: g.analyzedAt,
-      releaseConfidence: g.releaseConfidence,
-      gapsSample: g.gaps.slice(0, 8),
-      scenariosOmitted: g.scenarios.length,
-      generatedTestsOmitted: g.generatedTests.length,
-      costIntelligence: g.costIntelligence ?? null,
-    },
-    routeInventorySummary: {
-      scannedAt: result.routeInventory.scannedAt,
-      baseUrl: result.routeInventory.baseUrl,
-      routeCount: result.routeInventory.routes.length,
-      pagesSkipped: result.routeInventory.pagesSkipped,
-      budgetExceeded: result.routeInventory.budgetExceeded,
-    },
-    repoInventory: result.repoInventory,
-    decisionLogPreview: result.decisionLog.slice(-8),
-    ...(result.detectedAuth !== undefined && { detectedAuth: result.detectedAuth }),
-    includeFullReport: false,
-    note: 'Default payload omits gapAnalysis.scenarios and gapAnalysis.generatedTests. Pass includeFullReport: true for the complete analyzeApp result.',
-  };
-}
 
 const server = new Server(
   {
@@ -99,7 +65,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'analyze_app',
       description:
-        'Analyze a deployed web app for quality gaps. Returns a release confidence score (0-100), accessibility violations, broken links, and prioritized risks. Supports optional form-login or storage-state (Playwright) authentication. By default the response is summary-first (truncated gaps list, scenarios omitted); set includeFullReport to true for the full gapAnalysis payload.',
+        'Analyze a deployed web app for quality gaps. Default response is summary-first (top gaps, cost summary, next checks). Set includeFullReport for the full gapAnalysis. Optional llmMaxOutputTokensPerCall / llmTokenBudget (legacy), testGenerationLimit, enableLlmScenarios align with @qulib/core HarnessConfig.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -144,7 +110,22 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           includeFullReport: {
             type: 'boolean',
             description:
-              'When true, returns the full analyzeApp payload including all scenarios. Default false returns a summary-first shape to keep MCP responses compact.',
+              'When true, returns the full analyzeApp payload including all scenarios. Default false returns a summary-first shape.',
+          },
+          llmTokenBudget: {
+            type: 'number',
+            description:
+              'Legacy per-completion max output tokens (same as HarnessConfig.llmTokenBudget). Prefer llmMaxOutputTokensPerCall when both are set.',
+          },
+          llmMaxOutputTokensPerCall: {
+            type: 'number',
+            description:
+              'Optional override for per-completion max output tokens (maps to HarnessConfig.llmMaxOutputTokensPerCall).',
+          },
+          testGenerationLimit: { type: 'number', description: 'Max gaps fed into scenario generation (default 5).' },
+          enableLlmScenarios: {
+            type: 'boolean',
+            description: 'When false, never calls an LLM for scenarios (default true when omitted).',
           },
         },
         required: ['url'],
@@ -225,28 +206,32 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         ? { type: 'storage-state' as const, path: input.auth.path }
         : undefined;
 
+  const harnessConfig: HarnessConfig = {
+    maxPagesToScan: input.maxPagesToScan ?? 10,
+    maxDepth: 3,
+    minPagesForConfidence: 3,
+    timeoutMs: input.timeoutMs ?? 30000,
+    retryCount: 0,
+    llmTokenBudget: input.llmTokenBudget ?? input.llmMaxOutputTokensPerCall ?? 4096,
+    llmMaxOutputTokensPerCall: input.llmMaxOutputTokensPerCall,
+    testGenerationLimit: input.testGenerationLimit ?? 5,
+    enableLlmScenarios: input.enableLlmScenarios !== false,
+    readOnlyMode: true,
+    requireHumanReview: false,
+    failOnConsoleError: false,
+    explorer: 'playwright',
+    defaultAdapter: 'playwright',
+    adapters: ['playwright'],
+    ...(authConfig && { auth: authConfig }),
+  };
+
   const result = await analyzeApp({
     url: input.url,
     writeArtifacts: false,
-    config: {
-      maxPagesToScan: input.maxPagesToScan ?? 10,
-      maxDepth: 3,
-      minPagesForConfidence: 3,
-      timeoutMs: input.timeoutMs ?? 30000,
-      retryCount: 0,
-      llmTokenBudget: 1,
-      testGenerationLimit: 1,
-      readOnlyMode: true,
-      requireHumanReview: false,
-      failOnConsoleError: false,
-      explorer: 'playwright',
-      defaultAdapter: 'playwright',
-      adapters: ['playwright'],
-      ...(authConfig && { auth: authConfig }),
-    },
+    config: harnessConfig,
   });
 
-  const payload = compactAnalyzeAppResponse(result, input.includeFullReport === true);
+  const payload = buildCompactAnalyzePayload(result, input.includeFullReport === true);
 
   return {
     content: [

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -3,6 +3,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { analyzeApp, detectAuth, exploreAuth } from '@qulib/core';
+import type { AnalyzeResult } from '@qulib/core';
 import { z } from 'zod';
 
 const FormLoginMcpAuthSchema = z.object({
@@ -26,7 +27,47 @@ const AnalyzeInputSchema = z.object({
   maxPagesToScan: z.number().int().min(1).max(50).optional(),
   timeoutMs: z.number().int().positive().optional(),
   auth: z.discriminatedUnion('type', [FormLoginMcpAuthSchema, StorageStateMcpAuthSchema]).optional(),
+  includeFullReport: z.boolean().optional(),
 });
+
+function compactAnalyzeAppResponse(result: AnalyzeResult, includeFullReport: boolean) {
+  if (includeFullReport) {
+    return result;
+  }
+  const g = result.gapAnalysis;
+  return {
+    summary: {
+      releaseConfidence: g.releaseConfidence,
+      mode: g.mode,
+      coveragePagesScanned: g.coveragePagesScanned,
+      coverageBudgetExceeded: g.coverageBudgetExceeded,
+      coverageWarning: g.coverageWarning ?? null,
+      gapCount: g.gaps.length,
+      scenarioCount: g.scenarios.length,
+      generatedTestCount: g.generatedTests.length,
+    },
+    gapAnalysisPreview: {
+      analyzedAt: g.analyzedAt,
+      releaseConfidence: g.releaseConfidence,
+      gapsSample: g.gaps.slice(0, 8),
+      scenariosOmitted: g.scenarios.length,
+      generatedTestsOmitted: g.generatedTests.length,
+      costIntelligence: g.costIntelligence ?? null,
+    },
+    routeInventorySummary: {
+      scannedAt: result.routeInventory.scannedAt,
+      baseUrl: result.routeInventory.baseUrl,
+      routeCount: result.routeInventory.routes.length,
+      pagesSkipped: result.routeInventory.pagesSkipped,
+      budgetExceeded: result.routeInventory.budgetExceeded,
+    },
+    repoInventory: result.repoInventory,
+    decisionLogPreview: result.decisionLog.slice(-8),
+    ...(result.detectedAuth !== undefined && { detectedAuth: result.detectedAuth }),
+    includeFullReport: false,
+    note: 'Default payload omits gapAnalysis.scenarios and gapAnalysis.generatedTests. Pass includeFullReport: true for the complete analyzeApp result.',
+  };
+}
 
 const server = new Server(
   {
@@ -58,7 +99,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'analyze_app',
       description:
-        'Analyze a deployed web app for quality gaps. Returns a release confidence score (0-100), accessibility violations, broken links, and prioritized risks. Supports optional form-login or storage-state (Playwright) authentication.',
+        'Analyze a deployed web app for quality gaps. Returns a release confidence score (0-100), accessibility violations, broken links, and prioritized risks. Supports optional form-login or storage-state (Playwright) authentication. By default the response is summary-first (truncated gaps list, scenarios omitted); set includeFullReport to true for the full gapAnalysis payload.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -99,6 +140,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
                 required: ['type', 'path'],
               },
             ],
+          },
+          includeFullReport: {
+            type: 'boolean',
+            description:
+              'When true, returns the full analyzeApp payload including all scenarios. Default false returns a summary-first shape to keep MCP responses compact.',
           },
         },
         required: ['url'],
@@ -200,11 +246,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     },
   });
 
+  const payload = compactAnalyzeAppResponse(result, input.includeFullReport === true);
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(result, null, 2),
+        text: JSON.stringify(payload, null, 2),
       },
     ],
   };

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -3,9 +3,17 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { analyzeApp, detectAuth, exploreAuth } from '@qulib/core';
-import type { HarnessConfig } from '@qulib/core';
+import type { HarnessConfig, AnalyzeProgressSink } from '@qulib/core';
 import { z } from 'zod';
 import { buildCompactAnalyzePayload } from './compact-analyze-payload.js';
+import { log } from './logger.js';
+
+const mcpProgressLog: AnalyzeProgressSink = {
+  info: (message) => log.info(message),
+  warn: (message) => log.warn(message),
+  error: (message) => log.error(message),
+  debug: (message) => log.debug(message),
+};
 
 const FormLoginMcpAuthSchema = z.object({
   type: z.literal('form-login'),
@@ -156,7 +164,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       })
       .parse(request.params.arguments ?? {});
 
-    const result = await exploreAuth(url, timeoutMs);
+    log.info(`explore_auth tool url=${url} timeoutMs=${timeoutMs ?? 20000}`);
+    const result = await exploreAuth(url, timeoutMs, mcpProgressLog);
+    log.info(`explore_auth tool done authRequired=${result.authRequired} paths=${result.authPaths.length}`);
     return {
       content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
     };
@@ -170,7 +180,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       })
       .parse(request.params.arguments ?? {});
 
-    const result = await detectAuth(url, timeoutMs);
+    log.info(`detect_auth tool url=${url} timeoutMs=${timeoutMs ?? 15000}`);
+    const result = await detectAuth(url, timeoutMs, mcpProgressLog);
+    const providerSummary =
+      result.oauthButtons.length > 0
+        ? result.oauthButtons.map((b) => b.provider).join(', ')
+        : result.provider ?? 'none';
+    log.info(
+      `detect_auth tool done type=${result.type} providers=${providerSummary} automatable=${result.type === 'form-login'}`
+    );
     return {
       content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
     };
@@ -229,6 +247,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     url: input.url,
     writeArtifacts: false,
     config: harnessConfig,
+    progressLog: mcpProgressLog,
   });
 
   const payload = buildCompactAnalyzePayload(result, input.includeFullReport === true);

--- a/packages/mcp/src/logger.ts
+++ b/packages/mcp/src/logger.ts
@@ -1,0 +1,33 @@
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function wallTime(): string {
+  const d = new Date();
+  return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+}
+
+function isDebugEnabled(): boolean {
+  return process.env.QULIB_DEBUG === '1';
+}
+
+function emit(level: 'INFO' | 'WARN' | 'ERROR' | 'DEBUG', message: string): void {
+  process.stderr.write(`[qulib ${wallTime()}] ${level}  ${message}\n`);
+}
+
+export const log = {
+  info(message: string): void {
+    emit('INFO', message);
+  },
+  warn(message: string): void {
+    emit('WARN', message);
+  },
+  error(message: string): void {
+    emit('ERROR', message);
+  },
+  debug(message: string): void {
+    if (isDebugEnabled()) {
+      emit('DEBUG', message);
+    }
+  },
+};

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -14,5 +14,5 @@
     "declarationMap": true
   },
   "include": ["./src/**/*.ts"],
-  "exclude": ["./dist", "./node_modules"]
+  "exclude": ["./dist", "./node_modules", "./src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

This PR bundles **Cost Intelligence** (LLM usage, budgets, maturity, MCP summaries) with **honest auth-gated behavior**: public-surface crawling when OAuth blocks full access, separated **coverage vs quality** scores, and **structured stderr logging** for the MCP server during long scans.

## Cost Intelligence (original scope)

- Optional `costIntelligence` on `GapAnalysis`: token usage records (actual or estimated), SHA-256 prompt/result fingerprints, per-completion output warnings, repeated-prompt hints, deterministic maturity (L0–L3 + honest L4/L5 ceiling), conversion recommendations.
- **@qulib/core**: schemas + `llm/` helpers; `think` / finalize path records scenario-generation usage; Markdown **Cost Intelligence** section; JSON reports include `costIntelligence` when present.
- **@qulib/mcp**: default **summary-first** `analyze_app`; `includeFullReport: true` restores the full payload.

## Auth wall & coverage (OAuth / SSO without storage state)

- `analyzeApp` **no longer stops** at OAuth without credentials: crawls **pre-auth** routes, runs gap checks, exposes **`publicSurface`** (`pages`, `gaps`, `accessibilityViolations`, `brokenLinks`).
- **`status`**: `complete` | `blocked` | `partial`; **`releaseConfidence`** can be `null` when fully blocked; **`coverageScore`** separate from quality; top-level **`gaps`** mirrors `gapAnalysis.gaps`; **`auth-block`** + **`auth-surface`** gap categories.
- **TODO** in `computeCoverageScore` for future explorer “discovered-but-unknown” signal.

## MCP developer experience

- **`packages/mcp/src/logger.ts`**: `[qulib HH:MM:SS]` levels on **stderr only**; **`QULIB_DEBUG=1`** for verbose crawl/auth/axe/gaps logging.
- Optional **`AnalyzeProgressSink`** on `analyzeApp` / `detectAuth` / `exploreAuth` (no MCP tool JSON changes).

## How to verify

```bash
npm run build && npm run test
# optional live scan (network + Playwright)
RUN_NETWORK_INTEGRATION=1 npm run test:integration -w @qulib/core
```

Made with [Cursor](https://cursor.com)