### PR TITLE
fix(mcp): core-first build and progress log types

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -27,13 +27,13 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc && chmod +x dist/index.js",
+    "build": "npm --prefix ../.. run build -w @qulib/core && tsc && chmod +x dist/index.js",
     "dev": "tsx src/index.ts",
     "test": "node --import tsx/esm --test src/compact-analyze-payload.test.ts"
   },
   "dependencies": {
-    "@qulib/core": "0.2.2",
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "@qulib/core": "0.2.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -9,10 +9,10 @@ import { buildCompactAnalyzePayload } from './compact-analyze-payload.js';
 import { log } from './logger.js';
 
 const mcpProgressLog: AnalyzeProgressSink = {
-  info: (message) => log.info(message),
-  warn: (message) => log.warn(message),
-  error: (message) => log.error(message),
-  debug: (message) => log.debug(message),
+  info: (message: string) => log.info(message),
+  warn: (message: string) => log.warn(message),
+  error: (message: string) => log.error(message),
+  debug: (message: string) => log.debug(message),
 };
 
 const FormLoginMcpAuthSchema = z.object({


### PR DESCRIPTION
## Summary

Follow-up to [#18](https://github.com/TapeshN/qulib/pull/18).

- **MCP `build`**: run `@qulib/core` `tsc` before MCP `tsc` so types match when building from `packages/mcp` alone.
- **Strict callbacks**: explicit `string` types on `mcpProgressLog` handlers.

## Context

A nested `packages/mcp/node_modules/@qulib/core` (from installing under `packages/mcp`) can shadow the workspace package and surface **stale** `.d.ts` → many TS errors. Prefer `npm install` / `npm run build` from the **repo root**; removing nested `@qulib` fixes it.

## Verify

```bash
npm run build && npm test
```

Made with [Cursor](https://cursor.com)