### PR TITLE
chore: normalize bin paths for npm (0.3.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2029,7 +2029,7 @@
     },
     "packages/core": {
       "name": "@qulib/core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "^4.9.0",
@@ -2049,11 +2049,11 @@
     },
     "packages/mcp": {
       "name": "@qulib/mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@qulib/core": "0.3.0",
+        "@qulib/core": "0.3.1",
         "zod": "^3.23.0"
       },
       "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Qulib — analyze deployed web apps for honest quality gaps (CLI + programmatic API)",
   "license": "MIT",
   "author": "Tapesh Nagarwal",
@@ -31,7 +31,7 @@
     "README.md"
   ],
   "bin": {
-    "qulib": "./bin/qulib.js"
+    "qulib": "bin/qulib.js"
   },
   "scripts": {
     "dev": "tsx src/cli/index.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "MCP server for Qulib — AI-callable QA gap analysis",
   "license": "MIT",
   "author": "Tapesh Nagarwal",
@@ -20,7 +20,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "qulib-mcp": "./dist/index.js"
+    "qulib-mcp": "dist/index.js"
   },
   "files": [
     "dist",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@qulib/core": "0.3.0",
+    "@qulib/core": "0.3.1",
     "zod": "^3.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Applies the same normalization as `npm pkg fix`: bin targets use paths without a leading `./`, which avoids npm's "bin script name was cleaned" warning on publish.

Bumps `@qulib/core` and `@qulib/mcp` to **0.3.1** so you can republish both with OTP after merge.

Made with [Cursor](https://cursor.com)