### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Entries for **0.3.1 and earlier** were reconstructed from git tags (`v0.1.1` … `v0.2.2`) and release commits on `main`.
+
 ## [0.4.0] — 2026-05-12
 
 ### Added
@@ -24,6 +26,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **@qulib/mcp:** Deprecated low-level `Server` usage removed in favor of the supported MCP SDK high-level API.
 
-## [0.3.1]
+## [0.3.1] — 2026-05-12
 
-Prior release; see git history for details.
+### Fixed
+
+- **@qulib/core / @qulib/mcp:** Normalize `bin` paths for reliable npm installs on all platforms ([#21](https://github.com/TapeshN/qulib/pull/21)).
+
+## [0.3.0] — 2026-05-12
+
+### Added
+
+- **@qulib/core:** Cost intelligence for LLM usage (token summaries, budget warnings, deterministic maturity hints, conversion recommendations).
+- **@qulib/core:** Auth-wall handling with public-surface analysis, coverage score behavior, and flatter gap reporting for blocked/partial scans.
+- **@qulib/mcp:** Stderr progress logger and optional `AnalyzeProgressSink` for `analyze_app`.
+- **@qulib/core:** `npm run smoke` script for ephemeral `example.com` analyze.
+
+### Changed
+
+- LLM budget field naming clarified (`llmMaxOutputTokensPerCall` vs legacy `llmTokenBudget`); MCP default responses stay summary-first; cost doctor and docs updates.
+
+### Fixed
+
+- **@qulib/mcp:** Build `@qulib/core` before `tsc`; stricter typing for progress logging.
+
+### Chore
+
+- Live `analyzeApp` integration tests and coverage-score TODO follow-ups.
+
+## [0.2.2] — 2026-05-12
+
+### Added
+
+- **@qulib/core / MCP:** `explore_auth` (multi-path auth exploration, curated + heuristic providers, user-local `~/.qulib/providers.json` registry) ([#15](https://github.com/TapeshN/qulib/pull/15)).
+
+## [0.2.1] — 2026-05-11
+
+### Fixed
+
+- Clear error when Playwright Chromium is not installed; auth detector waits for hydration ([#13](https://github.com/TapeshN/qulib/pull/13)).
+
+## [0.2.0] — 2026-05-11
+
+### Added
+
+- **CLI:** `detect-auth` / auth detection pipeline and **`qulib auth init`** for OAuth/SSO-style flows (storage state capture) ([#10](https://github.com/TapeshN/qulib/pull/10)).
+- Manual testing checklist for CLI, auth, and MCP (linked from README).
+
+## [0.1.1] — 2026-05-11
+
+### Fixed
+
+- **Explorer:** Same-site link discovery handles `www` vs apex hostnames ([#8](https://github.com/TapeshN/qulib/pull/8)).
+
+### Chore
+
+- Community onboarding (issue/PR templates, code of conduct, contributing).
+- Root `package.json` repository metadata; publish-readiness README and dry-run verification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.0] — 2026-05-12
+
+### Added
+
+- **@qulib/core:** `LlmProvider` abstraction with `AnthropicProvider` and `createProvider()`; `HarnessConfig` fields `llmProvider`, `llmModel`, `outputDir`, and `scoringWeights`.
+- **@qulib/core:** Telemetry hooks (`TelemetrySink`, `emitTelemetry`, `NoopTelemetrySink`) and optional `telemetry` / `telemetrySessionId` on scan artifact options; phase and LLM lifecycle events.
+- **@qulib/core:** Repo `framework` detection and `automationMaturity` scoring on `RepoAnalysis`; exports `scanRepo`, `computeAutomationMaturity`, `resolveScanStateBaseDir`.
+- **@qulib/mcp:** `qulib_score_automation` tool; structured `QULIB_*` tool errors; optional `QULIB_TELEMETRY_STDERR=1` NDJSON telemetry on stderr; `automationMaturitySummary` in compact `analyze_app` payloads when repo data includes maturity.
+
+### Changed
+
+- **@qulib/core:** `callLLM` delegates to the provider registry; `computeQualityScoreFromGaps` honors optional severity weights (defaults unchanged).
+- **@qulib/core:** `StateManager` and decision log paths respect `config.outputDir` (default remains `.scan-state` under cwd).
+- **@qulib/mcp:** Migrated to `McpServer` + `registerTool`; server metadata includes description and version aligned with the package.
+
+### Fixed
+
+- **@qulib/mcp:** Deprecated low-level `Server` usage removed in favor of the supported MCP SDK high-level API.
+
+## [0.3.1]
+
+Prior release; see git history for details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,17 +7,28 @@ An opinionated QA harness that analyzes deployed web apps and emits honest quali
 ## RULES — READ BEFORE TOUCHING ANYTHING
 
 ### Git
-- Never push directly to `main`. Always work on a branch.
+
+- Do **not** push directly to **`main`** on the remote. Land changes via **PR from a branch** (even when using an agent).
 - Branch naming: `feature/short-description`, `fix/short-description`, `chore/short-description`
-- Run `git branch` to confirm which branch you are on before writing code.
-- Commit messages follow `type: short description` (types: `feat`, `fix`, `chore`, `refactor`, `docs`).
+- Run `git branch` (and `git status`) before writing code so you are not committing on `main` by accident.
+- Commit messages: `type: short description` (types: `feat`, `fix`, `chore`, `refactor`, `docs`).
+- User-facing releases: bump versions in `packages/*/package.json`, refresh `package-lock.json` with `npm install`, update **`CHANGELOG.md`**, then tag if you use tags (see existing entries for format).
 
 ### Code
+
 - Read files before editing them.
+- **ESM only** (`"type": "module"`). TypeScript sources import with **`.js` extensions** (NodeNext / bundler resolution).
 - Do not install packages without explicitly stating what you are installing and why.
-- Run `npm run build` before committing.
-- The schemas in `packages/core/src/schemas/` use zod and are the source of truth. Never widen or relax them without justification.
-- Do not add comments explaining what code does. Add comments only when the WHY is non-obvious.
+- Before commit: **`npm run build`** at repo root (matches CI `build` job).
+- Before PR (or when changing analyzer/MCP behavior): **`npm run test`** at repo root. If you touch the `analyzeApp` pipeline deeply, also run **`npm run test:integration`** from repo root when reasonable.
+- The schemas in `packages/core/src/schemas/` use Zod and are the source of truth. Prefer **additive** changes (`optional()`, new fields). Do not remove or rename fields without a **semver-major** plan and migration notes.
+- Do not add comments explaining what obvious code does. Add comments only when the **why** is non-obvious. **Exception:** brief file-level notes for **package boundaries** (e.g. candidate extraction to `@qulib/analyzer`) where the *why* is architectural.
+
+### Packages
+
+- **`@qulib/mcp` depends on `@qulib/core`.** Put shared logic in **core**, then expose through MCP — do not duplicate the analyzer in MCP.
+- Publishing: CI runs **`npm publish --dry-run`** per package; real publish is manual (`npm publish -w @qulib/core` then `@qulib/mcp`). Keep **`@qulib/mcp`’s `@qulib/core` dependency version** aligned with the published core version for that release.
 
 ### Design principle
+
 The output must be honest. If Qulib has not collected enough data to assess a deployment, it must say so — not report 100% confidence. False confidence is the worst possible failure mode for a QA tool.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2029,7 +2029,7 @@
     },
     "packages/core": {
       "name": "@qulib/core",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "^4.9.0",
@@ -2049,11 +2049,11 @@
     },
     "packages/mcp": {
       "name": "@qulib/mcp",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@qulib/core": "0.3.1",
+        "@qulib/core": "0.4.0",
         "zod": "^3.23.0"
       },
       "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/core",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Qulib — analyze deployed web apps for honest quality gaps (CLI + programmatic API)",
   "license": "MIT",
   "author": "Tapesh Nagarwal",

--- a/packages/core/src/analyze.ts
+++ b/packages/core/src/analyze.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { type HarnessConfig, type DetectedAuth } from './schemas/config.schema.js';
 import type { Gap, GapAnalysis } from './schemas/gap-analysis.schema.js';
 import { RouteInventorySchema, type RouteInventory } from './schemas/route-inventory.schema.js';
@@ -14,6 +15,8 @@ import { buildPublicSurface } from './tools/public-surface.js';
 import { buildAuthBlockGap } from './tools/auth-block-gap.js';
 import { finalizeGapAnalysisFromDraft, type GapAnalysisDraft } from './phases/think-finalize.js';
 import type { AnalyzeProgressSink } from './harness/progress-log.js';
+import type { TelemetrySink } from './telemetry/telemetry.interface.js';
+import { emitTelemetry } from './telemetry/emit.js';
 
 export type AnalyzeStatus = 'complete' | 'blocked' | 'partial';
 
@@ -24,6 +27,7 @@ export interface AnalyzeOptions {
   writeArtifacts?: boolean;
   skipAuthDetection?: boolean;
   progressLog?: AnalyzeProgressSink;
+  telemetry?: TelemetrySink;
 }
 
 export interface AnalyzeResult {
@@ -59,11 +63,20 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
   const writeArtifacts = options.writeArtifacts ?? false;
   const decisionLog: DecisionLogEntry[] = [];
   const progress = options.progressLog;
+  const sessionId = randomUUID();
   const artifacts = {
     writeArtifacts,
     decisionMemory: decisionLog,
+    telemetrySessionId: sessionId,
+    ...(options.telemetry !== undefined && { telemetry: options.telemetry }),
     ...(progress !== undefined && { progressLog: progress }),
   };
+
+  emitTelemetry(options.telemetry, 'scan.started', sessionId, {
+    url: options.url,
+    maxPagesToScan: options.config.maxPagesToScan,
+    hasAuth: Boolean(options.config.auth),
+  });
 
   progress?.info(`Starting scan → ${options.url} maxPagesToScan=${options.config.maxPagesToScan}`);
 
@@ -72,6 +85,12 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
   if (!options.config.auth && !options.skipAuthDetection) {
     detectedAuth = await detectAuth(options.url, options.config.timeoutMs, progress);
     authWall = Boolean(detectedAuth.hasAuth);
+    if (detectedAuth.hasAuth) {
+      emitTelemetry(options.telemetry, 'auth.detected', sessionId, {
+        authType: detectedAuth.type,
+        hasAuth: true,
+      });
+    }
   }
 
   const observed = await observe(options.url, options.repoPath, options.config, artifacts);
@@ -106,7 +125,7 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
     );
     const authBlockGap = buildAuthBlockGap(options.url);
     const qualityInputGaps = [...publicAnalysis.gaps, ...authSurfaceGaps];
-    const qualityScore = computeQualityScoreFromGaps(qualityInputGaps);
+    const qualityScore = computeQualityScoreFromGaps(qualityInputGaps, options.config.scoringWeights);
     const draftRelease = status === 'blocked' ? null : qualityScore;
 
     const draft: GapAnalysisDraft = {
@@ -156,6 +175,17 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
       publicSurface,
     };
     logScanEnd(progress, result);
+    emitTelemetry(
+      options.telemetry,
+      status === 'blocked' ? 'scan.blocked' : 'scan.completed',
+      sessionId,
+      {
+        status: result.status,
+        coverageScore: result.coverageScore,
+        releaseConfidence: result.releaseConfidence,
+        gapCount: result.gaps.length,
+      }
+    );
     return result;
   }
 
@@ -180,5 +210,11 @@ export async function analyzeApp(options: AnalyzeOptions): Promise<AnalyzeResult
     publicSurface,
   };
   logScanEnd(progress, result);
+  emitTelemetry(options.telemetry, 'scan.completed', sessionId, {
+    status: result.status,
+    coverageScore: result.coverageScore,
+    releaseConfidence: result.releaseConfidence,
+    gapCount: result.gaps.length,
+  });
   return result;
 }

--- a/packages/core/src/harness/decision-logger.ts
+++ b/packages/core/src/harness/decision-logger.ts
@@ -3,24 +3,29 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { DecisionLogEntrySchema } from '../schemas/decision-log.schema.js';
 import type { DecisionLogEntry } from '../schemas/decision-log.schema.js';
-
-const LOG_FILE = join(process.cwd(), '.scan-state', 'decision-log.json');
-const STATE_DIR = join(process.cwd(), '.scan-state');
+import { resolveScanStateBaseDir } from './state-manager.js';
 
 export type LogDecisionOptions = {
   persist?: boolean;
   memory?: DecisionLogEntry[];
+  outputDir?: string;
 };
+
+function logFilePath(options?: LogDecisionOptions): string {
+  return join(resolveScanStateBaseDir(options?.outputDir), 'decision-log.json');
+}
 
 export async function logDecision(entry: DecisionLogEntry, options?: LogDecisionOptions): Promise<void> {
   const persist = options?.persist !== false;
   const memory = options?.memory;
+  const logFile = logFilePath(options);
+  const stateDir = resolveScanStateBaseDir(options?.outputDir);
 
   try {
     const validation = DecisionLogEntrySchema.safeParse(entry);
     if (!validation.success) {
       console.warn(
-        `Failed to log decision entry to ${LOG_FILE}: validation issues ${JSON.stringify(validation.error.issues)}`
+        `Failed to log decision entry to ${logFile}: validation issues ${JSON.stringify(validation.error.issues)}`
       );
       return;
     }
@@ -33,15 +38,15 @@ export async function logDecision(entry: DecisionLogEntry, options?: LogDecision
       return;
     }
 
-    await mkdir(STATE_DIR, { recursive: true });
+    await mkdir(stateDir, { recursive: true });
 
     let log: DecisionLogEntry[] = [];
-    if (existsSync(LOG_FILE)) {
+    if (existsSync(logFile)) {
       try {
-        const raw = await readFile(LOG_FILE, 'utf8');
+        const raw = await readFile(logFile, 'utf8');
         const parsed = JSON.parse(raw) as unknown;
         if (!Array.isArray(parsed)) {
-          console.warn(`Failed to log decision entry to ${LOG_FILE}: file is not a JSON array; resetting log`);
+          console.warn(`Failed to log decision entry to ${logFile}: file is not a JSON array; resetting log`);
         } else {
           const validatedEntries: DecisionLogEntry[] = [];
           for (const item of parsed) {
@@ -50,7 +55,7 @@ export async function logDecision(entry: DecisionLogEntry, options?: LogDecision
               validatedEntries.push(itemValidation.data);
             } else {
               console.warn(
-                `Invalid existing entry skipped in ${LOG_FILE}: ${JSON.stringify(itemValidation.error.issues)}`
+                `Invalid existing entry skipped in ${logFile}: ${JSON.stringify(itemValidation.error.issues)}`
               );
             }
           }
@@ -58,26 +63,14 @@ export async function logDecision(entry: DecisionLogEntry, options?: LogDecision
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        console.warn(`Failed to read existing decision log at ${LOG_FILE}: ${message}`);
+        console.warn(`Failed to read existing decision log at ${logFile}: ${message}`);
       }
     }
 
     log.push(validation.data);
-    await writeFile(LOG_FILE, JSON.stringify(log, null, 2), 'utf8');
+    await writeFile(logFile, JSON.stringify(log, null, 2), 'utf8');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn(`Failed to log decision entry to ${LOG_FILE}: ${message}`);
+    console.warn(`Failed to log decision entry to ${logFile}: ${message}`);
   }
 }
-
-/*
-Manual smoke test:
-
-await logDecision({
-  timestamp: new Date().toISOString(),
-  phase: 'observe',
-  decision: 'Started crawl',
-  reason: 'Initial discovery pass',
-  metadata: { url: 'https://example.com' },
-});
-*/

--- a/packages/core/src/harness/run-options.ts
+++ b/packages/core/src/harness/run-options.ts
@@ -1,8 +1,11 @@
 import type { DecisionLogEntry } from '../schemas/decision-log.schema.js';
 import type { AnalyzeProgressSink } from './progress-log.js';
+import type { TelemetrySink } from '../telemetry/telemetry.interface.js';
 
 export type RunArtifactsOptions = {
   writeArtifacts: boolean;
   decisionMemory?: DecisionLogEntry[];
   progressLog?: AnalyzeProgressSink;
+  telemetry?: TelemetrySink;
+  telemetrySessionId?: string;
 };

--- a/packages/core/src/harness/state-manager.ts
+++ b/packages/core/src/harness/state-manager.ts
@@ -1,15 +1,26 @@
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { join, resolve, isAbsolute } from 'path';
 import { ZodError } from 'zod';
 import type { ZodSchema } from 'zod';
 
-const STATE_DIR = join(process.cwd(), '.scan-state');
+export function resolveScanStateBaseDir(outputDir?: string): string {
+  if (outputDir === undefined || outputDir === '') {
+    return join(process.cwd(), '.scan-state');
+  }
+  return isAbsolute(outputDir) ? resolve(outputDir) : resolve(process.cwd(), outputDir);
+}
 
 export class StateManager {
+  private readonly stateDir: string;
+
+  constructor(scanStateBaseDir?: string) {
+    this.stateDir = resolveScanStateBaseDir(scanStateBaseDir);
+  }
+
   async readState<T>(filename: string, schema: ZodSchema<T>): Promise<T> {
-    await mkdir(STATE_DIR, { recursive: true });
-    const filepath = join(STATE_DIR, filename);
+    await mkdir(this.stateDir, { recursive: true });
+    const filepath = join(this.stateDir, filename);
     if (!existsSync(filepath)) {
       throw new Error(`State file missing: ${filename} (${filepath})`);
     }
@@ -38,7 +49,7 @@ export class StateManager {
   }
 
   async writeState<T>(filename: string, data: T, schema: ZodSchema<T>): Promise<void> {
-    const filepath = join(STATE_DIR, filename);
+    const filepath = join(this.stateDir, filename);
 
     let validatedData: T;
     try {
@@ -51,20 +62,7 @@ export class StateManager {
       throw new Error(`Failed to validate state data for ${filename}: ${message}`);
     }
 
-    await mkdir(STATE_DIR, { recursive: true });
+    await mkdir(this.stateDir, { recursive: true });
     await writeFile(filepath, JSON.stringify(validatedData, null, 2), 'utf8');
   }
 }
-
-/*
-Manual smoke test:
-
-import { z } from 'zod';
-
-const manager = new StateManager();
-const DemoSchema = z.object({ count: z.number().int() });
-
-await manager.writeState('demo.json', { count: 1 }, DemoSchema);
-const loaded = await manager.readState('demo.json', DemoSchema);
-console.log(loaded.count); // 1
-*/

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,9 +2,21 @@ export { analyzeApp } from './analyze.js';
 export { detectAuth } from './tools/auth-detector.js';
 export { exploreAuth } from './tools/auth-explorer.js';
 export { addUserProvider, removeUserProvider, listUserProviders } from './tools/user-providers.js';
+export { scanRepo } from './tools/repo-scanner.js';
+export { computeAutomationMaturity } from './tools/automation-maturity.js';
+export { createProvider } from './llm/provider-registry.js';
 export { resolveMaxOutputTokensPerLlmCall } from './schemas/config.schema.js';
+export { resolveScanStateBaseDir } from './harness/state-manager.js';
 export type { AnalyzeOptions, AnalyzeResult, AnalyzeStatus } from './analyze.js';
 export type { AnalyzeProgressSink } from './harness/progress-log.js';
+export type {
+  TelemetrySink,
+  TelemetryEvent,
+  TelemetryEventKind,
+} from './telemetry/telemetry.interface.js';
+export { NoopTelemetrySink } from './telemetry/telemetry.interface.js';
+export type { LlmCallResult, LlmProvider } from './llm/provider.interface.js';
+export type { CallLlmConfigSlice } from './llm/provider.js';
 export type {
   HarnessConfig,
   AuthConfig,
@@ -20,4 +32,8 @@ export type {
   RepeatedAiPattern,
   DeterministicMaturity,
   PublicSurface,
+  AutomationMaturity,
+  AutomationMaturityDimension,
+  FrameworkDetectionResult,
+  DetectedFrameworkPrimary,
 } from './schemas/index.js';

--- a/packages/core/src/llm/cost-intelligence.ts
+++ b/packages/core/src/llm/cost-intelligence.ts
@@ -1,3 +1,17 @@
+/**
+ * @module cost-intelligence
+ * @packageBoundary @qulib/core (candidate: @qulib/cost-intelligence)
+ *
+ * This module assembles CostIntelligence from scan run records.
+ * Extraction to @qulib/cost-intelligence is appropriate when:
+ *   1. Cross-scan aggregation is needed (trend analysis across multiple runs)
+ *   2. Pricing tables for multiple LLM providers need to be maintained
+ *   3. A standalone cost reporting dashboard is built
+ *
+ * The CostIntelligenceSchema is already in @qulib/core/schemas and would
+ * remain there (or be duplicated/re-exported) on extraction.
+ */
+
 import type { GapAnalysis } from '../schemas/gap-analysis.schema.js';
 import type {
   CostIntelligence,

--- a/packages/core/src/llm/provider-registry.ts
+++ b/packages/core/src/llm/provider-registry.ts
@@ -1,0 +1,25 @@
+import type { HarnessConfig } from '../schemas/config.schema.js';
+import type { LlmProvider } from './provider.interface.js';
+import type { TelemetrySink } from '../telemetry/telemetry.interface.js';
+import { AnthropicProvider } from './providers/anthropic.js';
+
+export type CreateProviderInput = Pick<HarnessConfig, 'llmProvider' | 'llmModel'> & {
+  telemetry?: TelemetrySink;
+  telemetrySessionId?: string;
+};
+
+// TODO(@qulib/cost-intelligence): When OpenAI or Vertex provider types are added,
+// LlmUsageRecord.estimatedCostUsd must be populated from provider-specific pricing tables.
+// The cost-intelligence schema already supports this field — it is currently unused.
+
+export function createProvider(config: CreateProviderInput = {}): LlmProvider {
+  const provider = config.llmProvider ?? 'anthropic';
+  if (provider === 'anthropic') {
+    return new AnthropicProvider({
+      model: config.llmModel,
+      telemetry: config.telemetry,
+      sessionId: config.telemetrySessionId,
+    });
+  }
+  throw new Error(`Unsupported llmProvider: ${String(provider)}`);
+}

--- a/packages/core/src/llm/provider.interface.ts
+++ b/packages/core/src/llm/provider.interface.ts
@@ -1,0 +1,16 @@
+export interface LlmCallResult {
+  text: string;
+  usage: {
+    provider: string;
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    dataQuality: 'actual' | 'estimated';
+  };
+}
+
+export interface LlmProvider {
+  readonly name: string;
+  readonly model: string;
+  call(prompt: string, maxOutputTokens: number): Promise<LlmCallResult>;
+}

--- a/packages/core/src/llm/provider.ts
+++ b/packages/core/src/llm/provider.ts
@@ -1,77 +1,28 @@
 import { randomUUID } from 'node:crypto';
 import { NeutralScenarioSchema, type Gap, type NeutralScenario } from '../schemas/gap-analysis.schema.js';
+import type { HarnessConfig } from '../schemas/config.schema.js';
+import type { LlmCallResult } from './provider.interface.js';
+import { createProvider } from './provider-registry.js';
 
-export interface LlmCallResult {
-  text: string;
-  usage: {
-    provider: string;
-    model: string;
-    inputTokens: number;
-    outputTokens: number;
-    dataQuality: 'actual' | 'estimated';
-  } | null;
-}
+export type { LlmCallResult } from './provider.interface.js';
+export type { LlmProvider } from './provider.interface.js';
 
-function estimateTokensFromChars(chars: number): number {
-  return Math.max(0, Math.ceil(chars / 4));
-}
+export type CallLlmConfigSlice = Pick<HarnessConfig, 'llmProvider' | 'llmModel'> & {
+  telemetry?: import('../telemetry/telemetry.interface.js').TelemetrySink;
+  telemetrySessionId?: string;
+};
 
-export async function callLLM(prompt: string, tokenBudget: number): Promise<LlmCallResult> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error('ANTHROPIC_API_KEY is not set');
-
-  const model = 'claude-sonnet-4-20250514';
-
-  const response = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01',
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({
-      model,
-      max_tokens: tokenBudget,
-      messages: [{ role: 'user', content: prompt }],
-    }),
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`LLM call failed: ${response.status} ${text}`);
-  }
-
-  const data = (await response.json()) as {
-    content: Array<{ type: string; text?: string }>;
-    usage?: { input_tokens?: number; output_tokens?: number };
-    model?: string;
-  };
-  const text = data.content.find((b) => b.type === 'text')?.text ?? '';
-  const inTok = data.usage?.input_tokens;
-  const outTok = data.usage?.output_tokens;
-  if (typeof inTok === 'number' && typeof outTok === 'number') {
-    return {
-      text,
-      usage: {
-        provider: 'anthropic',
-        model: data.model ?? model,
-        inputTokens: inTok,
-        outputTokens: outTok,
-        dataQuality: 'actual',
-      },
-    };
-  }
-
-  return {
-    text,
-    usage: {
-      provider: 'anthropic',
-      model: data.model ?? model,
-      inputTokens: estimateTokensFromChars(prompt.length),
-      outputTokens: estimateTokensFromChars(text.length),
-      dataQuality: 'estimated',
-    },
-  };
+export async function callLLM(
+  prompt: string,
+  tokenBudget: number,
+  harness?: CallLlmConfigSlice
+): Promise<LlmCallResult> {
+  return createProvider({
+    llmProvider: harness?.llmProvider,
+    llmModel: harness?.llmModel,
+    telemetry: harness?.telemetry,
+    telemetrySessionId: harness?.telemetrySessionId,
+  }).call(prompt, tokenBudget);
 }
 
 export function generateScenariosFromTemplate(gaps: Gap[]): NeutralScenario[] {

--- a/packages/core/src/llm/providers/anthropic.ts
+++ b/packages/core/src/llm/providers/anthropic.ts
@@ -1,0 +1,124 @@
+import type { LlmCallResult, LlmProvider } from '../provider.interface.js';
+import type { TelemetrySink } from '../../telemetry/telemetry.interface.js';
+import { emitTelemetry } from '../../telemetry/emit.js';
+
+const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+
+function estimateTokensFromChars(chars: number): number {
+  return Math.max(0, Math.ceil(chars / 4));
+}
+
+export type AnthropicProviderOptions = {
+  model?: string;
+  telemetry?: TelemetrySink;
+  sessionId?: string;
+};
+
+export class AnthropicProvider implements LlmProvider {
+  readonly name = 'anthropic';
+  readonly model: string;
+  private readonly telemetry?: TelemetrySink;
+  private readonly sessionId: string;
+
+  constructor(options?: AnthropicProviderOptions) {
+    this.model = options?.model ?? DEFAULT_MODEL;
+    this.telemetry = options?.telemetry;
+    this.sessionId = options?.sessionId ?? 'anonymous';
+  }
+
+  async call(prompt: string, maxOutputTokens: number): Promise<LlmCallResult> {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) throw new Error('ANTHROPIC_API_KEY is not set');
+
+    const started = Date.now();
+    emitTelemetry(this.telemetry, 'llm.call.started', this.sessionId, {
+      model: this.model,
+      promptLength: prompt.length,
+      provider: this.name,
+    });
+
+    try {
+      const response = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: this.model,
+          max_tokens: maxOutputTokens,
+          messages: [{ role: 'user', content: prompt }],
+        }),
+      });
+
+      if (!response.ok) {
+        const errBody = await response.text();
+        emitTelemetry(this.telemetry, 'llm.call.failed', this.sessionId, {
+          model: this.model,
+          error: `${response.status} ${errBody.slice(0, 500)}`,
+          provider: this.name,
+        });
+        throw new Error(`LLM call failed: ${response.status} ${errBody}`);
+      }
+
+      const data = (await response.json()) as {
+        content: Array<{ type: string; text?: string }>;
+        usage?: { input_tokens?: number; output_tokens?: number };
+        model?: string;
+      };
+      const text = data.content.find((b) => b.type === 'text')?.text ?? '';
+      const inTok = data.usage?.input_tokens;
+      const outTok = data.usage?.output_tokens;
+      const durationMs = Date.now() - started;
+
+      let result: LlmCallResult;
+      if (typeof inTok === 'number' && typeof outTok === 'number') {
+        result = {
+          text,
+          usage: {
+            provider: this.name,
+            model: data.model ?? this.model,
+            inputTokens: inTok,
+            outputTokens: outTok,
+            dataQuality: 'actual',
+          },
+        };
+      } else {
+        const inputTokens = estimateTokensFromChars(prompt.length);
+        const outputTokens = estimateTokensFromChars(text.length);
+        result = {
+          text,
+          usage: {
+            provider: this.name,
+            model: data.model ?? this.model,
+            inputTokens,
+            outputTokens,
+            dataQuality: 'estimated',
+          },
+        };
+      }
+
+      const u = result.usage;
+      emitTelemetry(this.telemetry, 'llm.call.completed', this.sessionId, {
+        model: this.model,
+        inputTokens: u.inputTokens,
+        outputTokens: u.outputTokens,
+        durationMs,
+        provider: this.name,
+      });
+      return result;
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('LLM call failed:')) {
+        throw err;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      emitTelemetry(this.telemetry, 'llm.call.failed', this.sessionId, {
+        model: this.model,
+        error: msg.slice(0, 500),
+        provider: this.name,
+      });
+      throw err;
+    }
+  }
+}

--- a/packages/core/src/phases/act.ts
+++ b/packages/core/src/phases/act.ts
@@ -5,19 +5,30 @@ import { writeJsonReport } from '../reporters/json-reporter.js';
 import { writeMarkdownReport } from '../reporters/markdown-reporter.js';
 import { logDecision } from '../harness/decision-logger.js';
 import type { RunArtifactsOptions } from '../harness/run-options.js';
+import { emitTelemetry } from '../telemetry/emit.js';
+import { resolveScanStateBaseDir } from '../harness/state-manager.js';
 
 export async function act(
   analysis: GapAnalysis,
   config: HarnessConfig,
   artifacts: RunArtifactsOptions = { writeArtifacts: true }
 ): Promise<void> {
-  const outputDir = join(process.cwd(), 'output');
-  const logOpts = { persist: artifacts.writeArtifacts, memory: artifacts.decisionMemory };
+  const sessionId = artifacts.telemetrySessionId ?? 'none';
+  const reportDir = join(process.cwd(), 'output');
+  const logOpts = {
+    persist: artifacts.writeArtifacts,
+    memory: artifacts.decisionMemory,
+    outputDir: config.outputDir,
+  };
   const log = artifacts.writeArtifacts ? console.log : console.error;
 
+  emitTelemetry(artifacts.telemetry, 'phase.act.started', sessionId, {
+    writeArtifacts: artifacts.writeArtifacts,
+  });
+
   if (artifacts.writeArtifacts) {
-    await writeJsonReport(analysis, outputDir);
-    await writeMarkdownReport(analysis, outputDir);
+    await writeJsonReport(analysis, reportDir);
+    await writeMarkdownReport(analysis, reportDir);
   }
 
   await logDecision(
@@ -26,7 +37,7 @@ export async function act(
       phase: 'act',
       decision: 'reports-written',
       reason: artifacts.writeArtifacts
-        ? `Wrote JSON and Markdown reports to ${outputDir}`
+        ? `Wrote JSON and Markdown reports to ${reportDir}`
         : 'Skipped writing reports (ephemeral run)',
       metadata: {
         gapCount: analysis.gaps.length,
@@ -37,6 +48,11 @@ export async function act(
     },
     logOpts
   );
+
+  emitTelemetry(artifacts.telemetry, 'phase.act.completed', sessionId, {
+    gapCount: analysis.gaps.length,
+    wroteReports: artifacts.writeArtifacts,
+  });
 
   log('\n[qulib] Analysis complete');
   log(`  Gaps found:          ${analysis.gaps.length}`);
@@ -52,7 +68,7 @@ export async function act(
     log('\n[qulib] Human review required before applying any generated output.');
     if (artifacts.writeArtifacts) {
       log('  Reports:   output/report.json and output/report.md');
-      log('  Decisions: .scan-state/decision-log.json');
+      log(`  Decisions: ${join(resolveScanStateBaseDir(config.outputDir), 'decision-log.json')}`);
     } else {
       log('  Ephemeral run: inspect JSON printed to stdout (no files written).');
     }

--- a/packages/core/src/phases/observe.ts
+++ b/packages/core/src/phases/observe.ts
@@ -6,6 +6,7 @@ import { scanRepo } from '../tools/repo-scanner.js';
 import { StateManager } from '../harness/state-manager.js';
 import { logDecision } from '../harness/decision-logger.js';
 import type { RunArtifactsOptions } from '../harness/run-options.js';
+import { emitTelemetry } from '../telemetry/emit.js';
 
 export interface ObserveResult {
   routes: RouteInventory;
@@ -18,9 +19,19 @@ export async function observe(
   config: HarnessConfig,
   artifacts: RunArtifactsOptions = { writeArtifacts: true }
 ): Promise<ObserveResult> {
+  const sessionId = artifacts.telemetrySessionId ?? 'none';
   const explorer = createExplorer(config.explorer);
-  const stateManager = new StateManager();
-  const logOpts = { persist: artifacts.writeArtifacts, memory: artifacts.decisionMemory };
+  const stateManager = new StateManager(config.outputDir);
+  const logOpts = {
+    persist: artifacts.writeArtifacts,
+    memory: artifacts.decisionMemory,
+    outputDir: config.outputDir,
+  };
+
+  emitTelemetry(artifacts.telemetry, 'phase.observe.started', sessionId, {
+    baseUrl,
+    hasRepoPath: Boolean(repoPath),
+  });
 
   const rawRoutes = await explorer.explore(baseUrl, config, artifacts);
   const routes = RouteInventorySchema.parse(rawRoutes);
@@ -48,6 +59,10 @@ export async function observe(
   if (repoPath) {
     const rawRepo = await scanRepo(repoPath);
     repo = RepoAnalysisSchema.parse(rawRepo);
+    emitTelemetry(artifacts.telemetry, 'repo.scanned', sessionId, {
+      routeCount: repo.routes.length,
+      testFileCount: repo.testFiles.length,
+    });
     if (artifacts.writeArtifacts) {
       await stateManager.writeState('repo-inventory.json', repo, RepoAnalysisSchema);
     }
@@ -67,6 +82,11 @@ export async function observe(
       logOpts
     );
   }
+
+  emitTelemetry(artifacts.telemetry, 'phase.observe.completed', sessionId, {
+    routeCount: routes.routes.length,
+    repoScanned: Boolean(repo),
+  });
 
   return { routes, repo };
 }

--- a/packages/core/src/phases/think-finalize.ts
+++ b/packages/core/src/phases/think-finalize.ts
@@ -17,8 +17,12 @@ export async function finalizeGapAnalysisFromDraft(
   artifacts: RunArtifactsOptions = { writeArtifacts: true },
   costContext?: Pick<GapAnalysis, 'mode' | 'coveragePagesScanned' | 'releaseConfidence' | 'gaps'>
 ): Promise<GapAnalysis> {
-  const stateManager = new StateManager();
-  const logOpts = { persist: artifacts.writeArtifacts, memory: artifacts.decisionMemory };
+  const stateManager = new StateManager(config.outputDir);
+  const logOpts = {
+    persist: artifacts.writeArtifacts,
+    memory: artifacts.decisionMemory,
+    outputDir: config.outputDir,
+  };
   const partialAnalysis = GapAnalysisSchema.parse({
     ...draft,
     scenarios: [],
@@ -76,7 +80,12 @@ export async function finalizeGapAnalysisFromDraft(
     const prompt = buildGapPrompt(partialAnalysis.gaps, config.testGenerationLimit);
     const promptHash = hashForCostIntelligence(prompt);
     try {
-      const llmResult = await callLLM(prompt, maxOut);
+      const llmResult = await callLLM(prompt, maxOut, {
+        llmProvider: config.llmProvider,
+        llmModel: config.llmModel,
+        telemetry: artifacts.telemetry,
+        telemetrySessionId: artifacts.telemetrySessionId,
+      });
       const resultHash = hashForCostIntelligence(llmResult.text);
       const usage = llmResult.usage;
       llmRecords.push({

--- a/packages/core/src/phases/think.ts
+++ b/packages/core/src/phases/think.ts
@@ -5,14 +5,22 @@ import { analyzeGaps } from '../tools/gap-engine.js';
 import { logDecision } from '../harness/decision-logger.js';
 import type { RunArtifactsOptions } from '../harness/run-options.js';
 import { finalizeGapAnalysisFromDraft } from './think-finalize.js';
+import { emitTelemetry } from '../telemetry/emit.js';
 
 export async function think(
   observed: ObserveResult,
   config: HarnessConfig,
   artifacts: RunArtifactsOptions = { writeArtifacts: true }
 ): Promise<GapAnalysis> {
+  const sessionId = artifacts.telemetrySessionId ?? 'none';
   const mode = observed.repo ? 'url-repo' : 'url-only';
-  const logOpts = { persist: artifacts.writeArtifacts, memory: artifacts.decisionMemory };
+  const logOpts = {
+    persist: artifacts.writeArtifacts,
+    memory: artifacts.decisionMemory,
+    outputDir: config.outputDir,
+  };
+
+  emitTelemetry(artifacts.telemetry, 'phase.think.started', sessionId, { mode });
 
   const gapBlock = analyzeGaps(observed.routes, observed.repo, mode, config);
   const draft = {
@@ -46,7 +54,14 @@ export async function think(
     logOpts
   );
 
-  return finalizeGapAnalysisFromDraft(draft, config, artifacts);
+  const finalized = await finalizeGapAnalysisFromDraft(draft, config, artifacts);
+
+  emitTelemetry(artifacts.telemetry, 'phase.think.completed', sessionId, {
+    gapCount: finalized.gaps.length,
+    mode: finalized.mode,
+  });
+
+  return finalized;
 }
 
 export { finalizeGapAnalysisFromDraft } from './think-finalize.js';

--- a/packages/core/src/schemas/automation-maturity.schema.ts
+++ b/packages/core/src/schemas/automation-maturity.schema.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const AutomationMaturityDimensionSchema = z.object({
+  dimension: z.enum([
+    'test-coverage-breadth',
+    'framework-adoption',
+    'test-id-hygiene',
+    'ci-integration',
+    'auth-test-coverage',
+    'component-test-ratio',
+  ]),
+  score: z.number().min(0).max(100),
+  weight: z.number().min(0).max(1),
+  evidence: z.array(z.string()),
+  recommendations: z.array(z.string()),
+});
+
+export const AutomationMaturitySchema = z.object({
+  computedAt: z.string().datetime(),
+  repoPath: z.string(),
+  overallScore: z.number().min(0).max(100),
+  level: z.number().int().min(1).max(5),
+  label: z.string(),
+  dimensions: z.array(AutomationMaturityDimensionSchema),
+  topRecommendations: z.array(z.string()),
+});
+
+export type AutomationMaturityDimension = z.infer<typeof AutomationMaturityDimensionSchema>;
+export type AutomationMaturity = z.infer<typeof AutomationMaturitySchema>;

--- a/packages/core/src/schemas/config.schema.ts
+++ b/packages/core/src/schemas/config.schema.ts
@@ -62,6 +62,17 @@ export const HarnessConfigSchema = z.object({
   explorer: z.enum(['playwright', 'cypress']).default('playwright'),
   defaultAdapter: z.enum(['playwright', 'cypress-e2e', 'cypress-component', 'api', 'accessibility']).default('playwright'),
   adapters: z.array(z.enum(['playwright', 'cypress-e2e', 'cypress-component', 'api', 'accessibility'])).default(['playwright']),
+  llmProvider: z.enum(['anthropic']).optional(),
+  llmModel: z.string().optional(),
+  outputDir: z.string().optional(),
+  scoringWeights: z
+    .object({
+      critical: z.number().min(0).max(100).optional(),
+      high: z.number().min(0).max(100).optional(),
+      medium: z.number().min(0).max(100).optional(),
+      low: z.number().min(0).max(100).optional(),
+    })
+    .optional(),
   auth: AuthConfigSchema.optional(),
 });
 

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -59,8 +59,20 @@ export {
 } from './cost-intelligence.schema.js';
 export {
   RepoAnalysisSchema,
+  FrameworkDetectionSchema,
+  DetectedFrameworkPrimarySchema,
+  FrameworkDetectionConfidenceSchema,
+  TestFrameworkDetectedSchema,
   type RepoAnalysis,
+  type FrameworkDetectionResult,
+  type DetectedFrameworkPrimary,
 } from './repo-analysis.schema.js';
+export {
+  AutomationMaturitySchema,
+  AutomationMaturityDimensionSchema,
+  type AutomationMaturity,
+  type AutomationMaturityDimension,
+} from './automation-maturity.schema.js';
 export {
   PublicSurfaceSchema,
   PublicSurfaceViolationSchema,

--- a/packages/core/src/schemas/repo-analysis.schema.ts
+++ b/packages/core/src/schemas/repo-analysis.schema.ts
@@ -1,4 +1,38 @@
 import { z } from 'zod';
+import { AutomationMaturitySchema } from './automation-maturity.schema.js';
+
+export const DetectedFrameworkPrimarySchema = z.enum([
+  'nextjs-app-router',
+  'nextjs-pages-router',
+  'express',
+  'remix',
+  'nuxt',
+  'sveltekit',
+  'astro',
+  'vite',
+  'unknown',
+]);
+
+export const FrameworkDetectionConfidenceSchema = z.enum(['high', 'medium', 'low']);
+
+export const TestFrameworkDetectedSchema = z.enum([
+  'playwright',
+  'cypress-e2e',
+  'cypress-component',
+  'jest',
+  'vitest',
+  'other',
+]);
+
+export const FrameworkDetectionSchema = z.object({
+  primary: DetectedFrameworkPrimarySchema,
+  confidence: FrameworkDetectionConfidenceSchema,
+  evidence: z.array(z.string()),
+  testFrameworks: z.array(TestFrameworkDetectedSchema),
+});
+
+export type DetectedFrameworkPrimary = z.infer<typeof DetectedFrameworkPrimarySchema>;
+export type FrameworkDetectionResult = z.infer<typeof FrameworkDetectionSchema>;
 
 export const RepoRouteSchema = z.object({
   path: z.string(),
@@ -30,6 +64,8 @@ export const RepoAnalysisSchema = z.object({
   testFiles: z.array(TestFileSchema),
   missingTestIds: z.array(z.string()),
   cypressStructure: CypressStructureSchema,
+  framework: FrameworkDetectionSchema.optional(),
+  automationMaturity: AutomationMaturitySchema.optional(),
 });
 
 export type RepoAnalysis = z.infer<typeof RepoAnalysisSchema>;

--- a/packages/core/src/telemetry/emit.ts
+++ b/packages/core/src/telemetry/emit.ts
@@ -1,0 +1,18 @@
+import type { TelemetryEvent, TelemetryEventKind, TelemetrySink } from './telemetry.interface.js';
+
+export function emitTelemetry(
+  sink: TelemetrySink | undefined,
+  kind: TelemetryEventKind,
+  sessionId: string,
+  metadata: TelemetryEvent['metadata'],
+  durationMs?: number
+): void {
+  if (!sink) return;
+  sink.emit({
+    kind,
+    timestamp: new Date().toISOString(),
+    sessionId,
+    metadata,
+    ...(durationMs !== undefined && { durationMs }),
+  });
+}

--- a/packages/core/src/telemetry/telemetry.interface.ts
+++ b/packages/core/src/telemetry/telemetry.interface.ts
@@ -1,0 +1,32 @@
+export type TelemetryEventKind =
+  | 'scan.started'
+  | 'scan.completed'
+  | 'scan.blocked'
+  | 'phase.observe.started'
+  | 'phase.observe.completed'
+  | 'phase.think.started'
+  | 'phase.think.completed'
+  | 'phase.act.started'
+  | 'phase.act.completed'
+  | 'llm.call.started'
+  | 'llm.call.completed'
+  | 'llm.call.failed'
+  | 'gap.detected'
+  | 'auth.detected'
+  | 'repo.scanned';
+
+export interface TelemetryEvent {
+  kind: TelemetryEventKind;
+  timestamp: string;
+  sessionId: string;
+  durationMs?: number;
+  metadata: Record<string, string | number | boolean | null>;
+}
+
+export interface TelemetrySink {
+  emit(event: TelemetryEvent): void;
+}
+
+export const NoopTelemetrySink: TelemetrySink = {
+  emit: () => {},
+};

--- a/packages/core/src/tools/automation-maturity.ts
+++ b/packages/core/src/tools/automation-maturity.ts
@@ -1,0 +1,178 @@
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type { RepoAnalysis } from '../schemas/repo-analysis.schema.js';
+import type { AutomationMaturity, AutomationMaturityDimension } from '../schemas/automation-maturity.schema.js';
+import { AutomationMaturitySchema } from '../schemas/automation-maturity.schema.js';
+
+/**
+ * Dimension weights (sum = 1). Breadth + harness adoption dominate: shipping risk is mostly
+ * untested routes and missing Playwright/Cypress-level coverage.
+ */
+const W_TEST_BREADTH = 0.28;
+const W_FRAMEWORK = 0.22;
+const W_TEST_ID = 0.18;
+const W_CI = 0.14;
+const W_AUTH_TESTS = 0.1;
+const W_COMPONENT_RATIO = 0.08;
+
+function hasCiAtRoot(repoPath: string): { ok: boolean; evidence: string[] } {
+  const ev: string[] = [];
+  const gh = join(repoPath, '.github', 'workflows');
+  if (existsSync(gh) && statSync(gh).isDirectory()) {
+    try {
+      const files = readdirSync(gh).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+      if (files.length > 0) {
+        ev.push(`.github/workflows (${files.length} workflow file(s))`);
+        return { ok: true, evidence: ev };
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  if (existsSync(join(repoPath, '.circleci'))) {
+    ev.push('.circleci/ present');
+    return { ok: true, evidence: ev };
+  }
+  for (const f of ['.gitlab-ci.yml', 'Jenkinsfile']) {
+    if (existsSync(join(repoPath, f))) {
+      ev.push(`${f} present`);
+      return { ok: true, evidence: ev };
+    }
+  }
+  return { ok: false, evidence: ['No GitHub Actions, CircleCI, GitLab CI, or Jenkinsfile detected at repo root'] };
+}
+
+function scoreLevel(overall: number): { level: number; label: string } {
+  if (overall < 20) return { level: 1, label: 'L1 — nascent automation' };
+  if (overall < 40) return { level: 2, label: 'L2 — emerging coverage' };
+  if (overall < 60) return { level: 3, label: 'L3 — building maturity' };
+  if (overall < 80) return { level: 4, label: 'L4 — strong automation' };
+  return { level: 5, label: 'L5 — advanced QA automation' };
+}
+
+export function computeAutomationMaturity(repo: RepoAnalysis): AutomationMaturity {
+  const routePaths = [...new Set(repo.routes.map((r) => r.path))];
+  let coveredRoutes = 0;
+  for (const p of routePaths) {
+    const covered = repo.testFiles.some((tf) =>
+      tf.coveredPaths.some((c) => p === c || (c !== '/' && p.startsWith(c)))
+    );
+    if (covered) coveredRoutes++;
+  }
+  const breadthScore =
+    routePaths.length === 0 ? 100 : Math.round((100 * coveredRoutes) / routePaths.length);
+  const breadthDim: AutomationMaturityDimension = {
+    dimension: 'test-coverage-breadth',
+    score: breadthScore,
+    weight: W_TEST_BREADTH,
+    evidence:
+      routePaths.length === 0
+        ? ['No static routes inferred from repo layout']
+        : [
+            `${coveredRoutes}/${routePaths.length} inferred routes appear in at least one test coveredPaths`,
+          ],
+    recommendations:
+      breadthScore >= 80
+        ? []
+        : ['Add route-level smoke tests that assert critical paths referenced in production URLs.'],
+  };
+
+  const types = new Set(repo.testFiles.map((t) => t.type));
+  let frameworkScore = 0;
+  const fwEvidence: string[] = [`Test runners seen: ${[...types].join(', ') || 'none'}`];
+  if (types.has('playwright') || types.has('cypress-e2e') || types.has('cypress-component')) {
+    frameworkScore = 100;
+    fwEvidence.push('Playwright or Cypress present — good browser harness signal.');
+  } else if (types.has('jest') || types.has('vitest')) {
+    frameworkScore = 55;
+    fwEvidence.push('Jest/Vitest only — add Playwright or Cypress for deployment-facing checks.');
+  } else if (repo.testFiles.length > 0) {
+    frameworkScore = 30;
+    fwEvidence.push('Tests exist but no recognized browser harness in scanned files.');
+  } else {
+    frameworkScore = 0;
+    fwEvidence.push('No test files matched qulib scan globs.');
+  }
+  const frameworkDim: AutomationMaturityDimension = {
+    dimension: 'framework-adoption',
+    score: frameworkScore,
+    weight: W_FRAMEWORK,
+    evidence: fwEvidence,
+    recommendations: frameworkScore >= 80 ? [] : ['Standardize on Playwright or Cypress for E2E against deployed URLs.'],
+  };
+
+  const hygienePenalty = Math.min(100, repo.missingTestIds.length * 6);
+  const hygieneScore = Math.max(0, 100 - hygienePenalty);
+  const hygieneDim: AutomationMaturityDimension = {
+    dimension: 'test-id-hygiene',
+    score: hygieneScore,
+    weight: W_TEST_ID,
+    evidence: [
+      `${repo.missingTestIds.length} TSX file(s) with interactive markup but no data-testid (heuristic scan).`,
+    ],
+    recommendations:
+      hygieneScore >= 85 ? [] : ['Add stable data-testid (or role-based selectors) on interactive components used in tests.'],
+  };
+
+  const ci = hasCiAtRoot(repo.repoPath);
+  const ciDim: AutomationMaturityDimension = {
+    dimension: 'ci-integration',
+    score: ci.ok ? 100 : 0,
+    weight: W_CI,
+    evidence: ci.evidence,
+    recommendations: ci.ok ? [] : ['Add a CI workflow that runs unit/E2E tests on every PR.'],
+  };
+
+  const authRe = /\/(login|auth|signin)(\/|$)/i;
+  const authCovered = repo.testFiles.some((tf) => tf.coveredPaths.some((c) => authRe.test(c)));
+  const authScore = authCovered ? 90 : 25;
+  const authDim: AutomationMaturityDimension = {
+    dimension: 'auth-test-coverage',
+    score: authScore,
+    weight: W_AUTH_TESTS,
+    evidence: authCovered
+      ? ['At least one test references /login, /auth, or /signin in coveredPaths.']
+      : ['No obvious auth-route coverage in extracted test path strings.'],
+    recommendations: authCovered ? [] : ['Add focused tests for sign-in and post-auth landing behavior.'],
+  };
+
+  const cypressE2e = repo.testFiles.filter((t) => t.type === 'cypress-e2e').length;
+  const cypressComp = repo.testFiles.filter((t) => t.type === 'cypress-component').length;
+  const cypressTotal = cypressE2e + cypressComp;
+  const compRatioScore =
+    cypressTotal === 0 ? 50 : Math.round((100 * cypressComp) / cypressTotal);
+  const compDim: AutomationMaturityDimension = {
+    dimension: 'component-test-ratio',
+    score: compRatioScore,
+    weight: W_COMPONENT_RATIO,
+    evidence: [
+      `Cypress e2e files (matched): ${cypressE2e}, component: ${cypressComp}.`,
+    ],
+    recommendations:
+      cypressComp === 0 || cypressTotal === 0
+        ? []
+        : ['Balance component vs E2E Cypress tests so critical flows stay fast in CI.'],
+  };
+
+  const dimensions = [breadthDim, frameworkDim, hygieneDim, ciDim, authDim, compDim];
+  const overallScore = Math.round(
+    dimensions.reduce((s, d) => s + d.score * d.weight, 0)
+  );
+  const { level, label } = scoreLevel(overallScore);
+
+  const topRecommendations = [...dimensions]
+    .sort((a, b) => a.score - b.score)
+    .flatMap((d) => d.recommendations)
+    .filter(Boolean)
+    .slice(0, 8);
+
+  return AutomationMaturitySchema.parse({
+    computedAt: new Date().toISOString(),
+    repoPath: repo.repoPath,
+    overallScore,
+    level,
+    label,
+    dimensions,
+    topRecommendations,
+  });
+}

--- a/packages/core/src/tools/framework-detector.ts
+++ b/packages/core/src/tools/framework-detector.ts
@@ -1,0 +1,148 @@
+/**
+ * @module framework-detector
+ * @packageBoundary @qulib/core (candidate: @qulib/analyzer)
+ *
+ * Framework detection runs during the observe phase as part of repo scanning.
+ * It is a pure static analysis operation with no browser or LLM dependency.
+ * Move this to @qulib/analyzer when that package is created.
+ *
+ * // TODO(@qulib/analyzer): When @qulib/analyzer is extracted, this module should move there.
+ * // It is currently embedded in @qulib/core because repo scanning is part of the observe phase.
+ * // The package boundary decision: core = runtime QA analysis, analyzer = static repo intelligence.
+ */
+
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { join } from 'node:path';
+import { FrameworkDetectionSchema, type FrameworkDetectionResult } from '../schemas/repo-analysis.schema.js';
+
+async function fileExists(repoPath: string, rel: string): Promise<boolean> {
+  try {
+    await access(join(repoPath, rel), constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+type PkgJson = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+
+function depNames(pkg: PkgJson): Set<string> {
+  return new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+  ]);
+}
+
+export async function detectFramework(repoPath: string): Promise<FrameworkDetectionResult> {
+  const evidence: string[] = [];
+  const testFrameworks = new Set<FrameworkDetectionResult['testFrameworks'][number]>();
+
+  let pkg: PkgJson = {};
+  try {
+    const raw = await readFile(join(repoPath, 'package.json'), 'utf8');
+    pkg = JSON.parse(raw) as PkgJson;
+    evidence.push('read package.json');
+  } catch {
+    evidence.push('package.json missing or unreadable');
+  }
+
+  const deps = depNames(pkg);
+  const has = (n: string) => deps.has(n);
+
+  if (has('@playwright/test') || has('playwright')) {
+    testFrameworks.add('playwright');
+    evidence.push('dependency: @playwright/test or playwright');
+  }
+  if (has('cypress')) {
+    testFrameworks.add('cypress-e2e');
+    evidence.push('dependency: cypress');
+  }
+  if (has('jest')) {
+    testFrameworks.add('jest');
+    evidence.push('dependency: jest');
+  }
+  if (has('vitest')) {
+    testFrameworks.add('vitest');
+    evidence.push('dependency: vitest');
+  }
+  if (testFrameworks.size === 0) {
+    testFrameworks.add('other');
+  }
+
+  const nextCfg =
+    (await fileExists(repoPath, 'next.config.js')) ||
+    (await fileExists(repoPath, 'next.config.mjs')) ||
+    (await fileExists(repoPath, 'next.config.ts'));
+  const nuxtCfg = await fileExists(repoPath, 'nuxt.config.ts');
+  const svelteCfg = await fileExists(repoPath, 'svelte.config.js');
+  const astroCfg = await fileExists(repoPath, 'astro.config.mjs');
+  const remixCfg = await fileExists(repoPath, 'remix.config.js');
+  const viteCfg = await fileExists(repoPath, 'vite.config.ts');
+
+  if (nextCfg) evidence.push('found next.config.*');
+  if (nuxtCfg) evidence.push('found nuxt.config.ts');
+  if (svelteCfg) evidence.push('found svelte.config.js');
+  if (astroCfg) evidence.push('found astro.config.mjs');
+  if (remixCfg) evidence.push('found remix.config.js');
+  if (viteCfg) evidence.push('found vite.config.ts');
+
+  const hasAppDir = await fileExists(repoPath, 'app');
+  const hasPagesDir = await fileExists(repoPath, 'pages');
+  if (has('next') && hasAppDir) evidence.push('Next.js app/ directory present');
+  if (has('next') && hasPagesDir) evidence.push('Next.js pages/ directory present');
+  if (has('@remix-run/react') || has('@remix-run/node')) evidence.push('Remix packages in package.json');
+  if (has('nuxt') || has('nuxt3')) evidence.push('Nuxt in package.json');
+  if (has('@sveltejs/kit')) evidence.push('@sveltejs/kit in package.json');
+  if (has('astro')) evidence.push('astro in package.json');
+  if (has('vite') && !has('next')) evidence.push('vite in package.json (non-Next)');
+
+  let primary: FrameworkDetectionResult['primary'] = 'unknown';
+  let confidence: FrameworkDetectionResult['confidence'] = 'low';
+
+  if (has('next')) {
+    if (hasAppDir && (await fileExists(repoPath, join('app', 'layout.tsx')))) {
+      primary = 'nextjs-app-router';
+      confidence = nextCfg || hasAppDir ? 'high' : 'medium';
+    } else if (hasPagesDir) {
+      primary = 'nextjs-pages-router';
+      confidence = nextCfg || hasPagesDir ? 'high' : 'medium';
+    } else {
+      primary = 'nextjs-app-router';
+      confidence = 'medium';
+      evidence.push('next detected without clear app/ vs pages/ layout');
+    }
+  } else if (has('@remix-run/react') || remixCfg) {
+    primary = 'remix';
+    confidence = remixCfg ? 'high' : 'medium';
+  } else if (has('nuxt') || nuxtCfg) {
+    primary = 'nuxt';
+    confidence = nuxtCfg ? 'high' : 'medium';
+  } else if (has('@sveltejs/kit') || svelteCfg) {
+    primary = 'sveltekit';
+    confidence = svelteCfg ? 'high' : 'medium';
+  } else if (has('astro') || astroCfg) {
+    primary = 'astro';
+    confidence = astroCfg ? 'high' : 'medium';
+  } else if (viteCfg && !has('next')) {
+    primary = 'vite';
+    confidence = 'medium';
+  } else if (has('express')) {
+    primary = 'express';
+    confidence = 'medium';
+    evidence.push('express listed in dependencies');
+  } else {
+    /* keep unknown */
+  }
+
+  const raw: FrameworkDetectionResult = {
+    primary,
+    confidence,
+    evidence,
+    testFrameworks: [...testFrameworks],
+  };
+  return FrameworkDetectionSchema.parse(raw);
+}

--- a/packages/core/src/tools/gap-engine.ts
+++ b/packages/core/src/tools/gap-engine.ts
@@ -4,7 +4,16 @@ import type { RouteInventory } from '../schemas/route-inventory.schema.js';
 import type { RepoAnalysis } from '../schemas/repo-analysis.schema.js';
 import type { HarnessConfig } from '../schemas/config.schema.js';
 
-export function computeQualityScoreFromGaps(gaps: Gap[]): number {
+// TODO: Add category-specific weight overrides (e.g., auth-surface gaps should cost more than untested-route gaps by default).
+// Requires a 2D weight matrix: { [severity]: { [category]: number } }.
+// Deferred until there is empirical data from real scan runs to calibrate.
+
+const DEFAULT_SCORING_WEIGHTS = { critical: 25, high: 20, medium: 8, low: 3 } as const;
+
+export function computeQualityScoreFromGaps(
+  gaps: Gap[],
+  scoringWeights?: HarnessConfig['scoringWeights']
+): number {
   let critical = 0;
   let high = 0;
   let medium = 0;
@@ -15,7 +24,13 @@ export function computeQualityScoreFromGaps(gaps: Gap[]): number {
     else if (g.severity === 'medium') medium++;
     else low++;
   }
-  return Math.max(0, 100 - critical * 25 - high * 20 - medium * 8 - low * 3);
+  const w = {
+    critical: scoringWeights?.critical ?? DEFAULT_SCORING_WEIGHTS.critical,
+    high: scoringWeights?.high ?? DEFAULT_SCORING_WEIGHTS.high,
+    medium: scoringWeights?.medium ?? DEFAULT_SCORING_WEIGHTS.medium,
+    low: scoringWeights?.low ?? DEFAULT_SCORING_WEIGHTS.low,
+  };
+  return Math.max(0, 100 - critical * w.critical - high * w.high - medium * w.medium - low * w.low);
 }
 
 export function computeCoverageScore(routes: RouteInventory): number | null {
@@ -118,7 +133,7 @@ export function analyzeGaps(
     }
   }
 
-  const releaseConfidence = computeQualityScoreFromGaps(gaps);
+  const releaseConfidence = computeQualityScoreFromGaps(gaps, config.scoringWeights);
 
   const pagesScanned = routes.routes.length;
   let coverageWarning: GapAnalysis['coverageWarning'];

--- a/packages/core/src/tools/repo-scanner.ts
+++ b/packages/core/src/tools/repo-scanner.ts
@@ -1,7 +1,26 @@
+/**
+ * @module repo-scanner
+ * @packageBoundary @qulib/core (candidate: @qulib/analyzer)
+ *
+ * This module performs static analysis of a repository's file structure.
+ * It is currently embedded in @qulib/core because repo scanning is part of
+ * the observe phase and @qulib/core is the only consumer.
+ *
+ * Extraction to @qulib/analyzer is appropriate when:
+ *   1. A consumer needs repo analysis without URL crawling
+ *   2. The module grows to include PRD/Jira/Confluence ingestion
+ *   3. A standalone CLI command `qulib analyze-repo` is needed
+ *
+ * Before extraction: ensure RepoAnalysis schema is re-exported from @qulib/analyzer
+ * and @qulib/core depends on @qulib/analyzer (not the reverse).
+ */
+
 import { readFile } from 'node:fs/promises';
 import { relative, basename } from 'node:path';
 import glob from 'fast-glob';
 import { RepoAnalysisSchema, type RepoAnalysis } from '../schemas/repo-analysis.schema.js';
+import { detectFramework } from './framework-detector.js';
+import { computeAutomationMaturity } from './automation-maturity.js';
 
 const IGNORE_PATTERNS = ['**/node_modules/**', '**/.next/**', '**/dist/**', '**/build/**'];
 
@@ -141,7 +160,7 @@ export async function scanRepo(repoPath: string): Promise<RepoAnalysis> {
     }
   }
 
-  return RepoAnalysisSchema.parse({
+  const base: Omit<RepoAnalysis, 'framework' | 'automationMaturity'> = {
     scannedAt: new Date().toISOString(),
     repoPath,
     routes,
@@ -157,5 +176,18 @@ export async function scanRepo(repoPath: string): Promise<RepoAnalysis> {
       existingE2eFiles,
       existingComponentFiles,
     },
-  });
+  };
+
+  let parsed = RepoAnalysisSchema.parse(base);
+
+  try {
+    const framework = await detectFramework(repoPath);
+    parsed = RepoAnalysisSchema.parse({ ...parsed, framework });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.warn(`[qulib] framework detection failed for ${repoPath}: ${msg}`);
+  }
+
+  const automationMaturity = computeAutomationMaturity(parsed);
+  return RepoAnalysisSchema.parse({ ...parsed, automationMaturity });
 }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,6 +2,28 @@
 
 **@qulib/mcp** is an MCP server that exposes Qulib so AI clients can analyze a deployed URL for release confidence, accessibility, broken links, console noise, and prioritized gaps (CLI entry `qulib-mcp`).
 
+## Setup
+
+To enable LLM-powered scenario generation, add your Anthropic API key to the
+`env` block in your MCP host config (Claude Desktop, Claude Code, Cursor, etc.):
+
+```json
+{
+  "mcpServers": {
+    "qulib": {
+      "command": "npx",
+      "args": ["@qulib/mcp"],
+      "env": {
+        "ANTHROPIC_API_KEY": "sk-ant-..."
+      }
+    }
+  }
+}
+```
+
+Without this key, qulib still runs but uses built-in template scenarios only.
+Your key is never stored by qulib — it is read from your local config at runtime.
+
 ## What it does
 
 Tools:

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/mcp",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "MCP server for Qulib — AI-callable QA gap analysis",
   "license": "MIT",
   "author": "Tapesh Nagarwal",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@qulib/core": "0.3.1",
+    "@qulib/core": "0.4.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/mcp/src/compact-analyze-payload.ts
+++ b/packages/mcp/src/compact-analyze-payload.ts
@@ -86,6 +86,14 @@ export function buildCompactAnalyzePayload(result: AnalyzeResult, includeFullRep
       pagesSkipped: result.routeInventory.pagesSkipped,
       budgetExceeded: result.routeInventory.budgetExceeded,
     },
+    ...(result.repoInventory?.automationMaturity && {
+      automationMaturitySummary: {
+        overallScore: result.repoInventory.automationMaturity.overallScore,
+        level: result.repoInventory.automationMaturity.level,
+        label: result.repoInventory.automationMaturity.label,
+        topRecommendations: result.repoInventory.automationMaturity.topRecommendations,
+      },
+    }),
     repoInventory: result.repoInventory,
     decisionLogPreview: result.decisionLog.slice(-8),
     ...(result.detectedAuth !== undefined && { detectedAuth: result.detectedAuth }),

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -105,7 +105,7 @@ function validateAbsoluteRepoPath(repoPath: string): string {
 const mcpServer = new McpServer(
   {
     name: 'qulib-mcp',
-    version: '0.3.1',
+    version: '0.4.0',
     description:
       'Qulib QA intelligence platform — gap analysis, auth exploration, and quality scoring for deployed web applications',
   },

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { analyzeApp, detectAuth, exploreAuth } from '@qulib/core';
 import type { HarnessConfig, AnalyzeProgressSink } from '@qulib/core';
 import { z } from 'zod';
@@ -43,10 +42,10 @@ const AnalyzeInputSchema = z.object({
   enableLlmScenarios: z.boolean().optional(),
 });
 
-const server = new Server(
+const mcpServer = new McpServer(
   {
     name: 'qulib-mcp',
-    version: '0.1.0',
+    version: '0.3.1',
   },
   {
     capabilities: {
@@ -55,115 +54,33 @@ const server = new Server(
   }
 );
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
-    {
-      name: 'explore_auth',
-      description:
-        'Use this BEFORE analyze_app when scanning unfamiliar apps. Returns all detected sign-in paths with per-path requirements describing what credentials or actions the agent must collect from the user before calling analyze_app. Combines built-in OAuth/SSO labels, user-local patterns from ~/.qulib/providers.json, and heuristic unknown buttons.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          url: { type: 'string', description: 'Full URL of the deployed app or login page' },
-          timeoutMs: { type: 'number', description: 'Navigation timeout in milliseconds (default 20000)' },
-        },
-        required: ['url'],
-      },
-    },
-    {
-      name: 'analyze_app',
-      description:
-        'Analyze a deployed web app for quality gaps. Default response is summary-first (top gaps, cost summary, next checks). Set includeFullReport for the full gapAnalysis. Optional llmMaxOutputTokensPerCall / llmTokenBudget (legacy), testGenerationLimit, enableLlmScenarios align with @qulib/core HarnessConfig.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          url: { type: 'string', description: 'Full URL of the deployed app' },
-          maxPagesToScan: { type: 'number', description: 'Max pages to crawl (default 10)' },
-          timeoutMs: { type: 'number', description: 'Per-page timeout in milliseconds (default 30000)' },
-          auth: {
-            description: 'Optional auth: form-login credentials or path to a storage state JSON from `qulib auth init`',
-            oneOf: [
-              {
-                type: 'object',
-                properties: {
-                  type: { type: 'string', enum: ['form-login'] },
-                  loginUrl: { type: 'string' },
-                  username: { type: 'string' },
-                  password: { type: 'string' },
-                  usernameSelector: { type: 'string' },
-                  passwordSelector: { type: 'string' },
-                  submitSelector: { type: 'string' },
-                  successUrlContains: { type: 'string' },
-                },
-                required: [
-                  'type',
-                  'loginUrl',
-                  'username',
-                  'password',
-                  'usernameSelector',
-                  'passwordSelector',
-                  'submitSelector',
-                ],
-              },
-              {
-                type: 'object',
-                properties: {
-                  type: { type: 'string', enum: ['storage-state'] },
-                  path: { type: 'string', description: 'Absolute path to storage state JSON on the MCP host' },
-                },
-                required: ['type', 'path'],
-              },
-            ],
-          },
-          includeFullReport: {
-            type: 'boolean',
-            description:
-              'When true, returns the full analyzeApp payload including all scenarios. Default false returns a summary-first shape.',
-          },
-          llmTokenBudget: {
-            type: 'number',
-            description:
-              'Legacy per-completion max output tokens (same as HarnessConfig.llmTokenBudget). Prefer llmMaxOutputTokensPerCall when both are set.',
-          },
-          llmMaxOutputTokensPerCall: {
-            type: 'number',
-            description:
-              'Optional override for per-completion max output tokens (maps to HarnessConfig.llmMaxOutputTokensPerCall).',
-          },
-          testGenerationLimit: { type: 'number', description: 'Max gaps fed into scenario generation (default 5).' },
-          enableLlmScenarios: {
-            type: 'boolean',
-            description: 'When false, never calls an LLM for scenarios (default true when omitted).',
-          },
-        },
-        required: ['url'],
-      },
-    },
-    {
-      name: 'detect_auth',
-      description:
-        'Detect the authentication pattern used by a deployed web app. Returns the auth type (form-login, oauth, magic-link, none, or unknown) and a recommendation for how to configure qulib to scan past it.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          url: { type: 'string', description: 'Full URL of the deployed app or login page' },
-          timeoutMs: { type: 'number', description: 'Page load timeout in milliseconds (default 15000)' },
-        },
-        required: ['url'],
-      },
-    },
-  ],
-}));
+if (!process.env.ANTHROPIC_API_KEY) {
+  process.stderr.write(
+    '[qulib] WARN  ANTHROPIC_API_KEY is not set.\n' +
+      '              LLM scenario generation will be skipped — only template scenarios will run.\n' +
+      '              Add your key to the env block in your MCP host config.\n' +
+      '              See: https://github.com/TapeshN/qulib#setup\n'
+  );
+}
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  if (request.params.name === 'explore_auth') {
-    const { url, timeoutMs } = z
-      .object({
-        url: z.string().url(),
-        timeoutMs: z.number().int().positive().optional(),
-      })
-      .parse(request.params.arguments ?? {});
+const ExploreAuthToolInputSchema = z.object({
+  url: z.string().url().describe('Full URL of the deployed app or login page'),
+  timeoutMs: z.number().int().positive().optional().describe('Navigation timeout in milliseconds (default 20000)'),
+});
 
+const DetectAuthToolInputSchema = z.object({
+  url: z.string().url().describe('Full URL of the deployed app or login page'),
+  timeoutMs: z.number().int().positive().optional().describe('Page load timeout in milliseconds (default 15000)'),
+});
+
+mcpServer.registerTool(
+  'explore_auth',
+  {
+    description:
+      'Use this BEFORE analyze_app when scanning unfamiliar apps. Returns all detected sign-in paths with per-path requirements describing what credentials or actions the agent must collect from the user before calling analyze_app. Combines built-in OAuth/SSO labels, user-local patterns from ~/.qulib/providers.json, and heuristic unknown buttons.',
+    inputSchema: ExploreAuthToolInputSchema,
+  },
+  async ({ url, timeoutMs }) => {
     log.info(`explore_auth tool url=${url} timeoutMs=${timeoutMs ?? 20000}`);
     const result = await exploreAuth(url, timeoutMs, mcpProgressLog);
     log.info(`explore_auth tool done authRequired=${result.authRequired} paths=${result.authPaths.length}`);
@@ -171,15 +88,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
     };
   }
+);
 
-  if (request.params.name === 'detect_auth') {
-    const { url, timeoutMs } = z
-      .object({
-        url: z.string().url(),
-        timeoutMs: z.number().int().positive().optional(),
-      })
-      .parse(request.params.arguments ?? {});
-
+mcpServer.registerTool(
+  'detect_auth',
+  {
+    description:
+      'Detect the authentication pattern used by a deployed web app. Returns the auth type (form-login, oauth, magic-link, none, or unknown) and a recommendation for how to configure qulib to scan past it.',
+    inputSchema: DetectAuthToolInputSchema,
+  },
+  async ({ url, timeoutMs }) => {
     log.info(`detect_auth tool url=${url} timeoutMs=${timeoutMs ?? 15000}`);
     const result = await detectAuth(url, timeoutMs, mcpProgressLog);
     const providerSummary =
@@ -193,74 +111,77 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
     };
   }
+);
 
-  if (request.params.name !== 'analyze_app') {
-    throw new Error(`Unknown tool: ${request.params.name}`);
-  }
+mcpServer.registerTool(
+  'analyze_app',
+  {
+    description:
+      'Analyze a deployed web app for quality gaps. Default response is summary-first (top gaps, cost summary, next checks). Set includeFullReport for the full gapAnalysis. Optional llmMaxOutputTokensPerCall / llmTokenBudget (legacy), testGenerationLimit, enableLlmScenarios align with @qulib/core HarnessConfig.',
+    inputSchema: AnalyzeInputSchema,
+  },
+  async (input) => {
+    const successIndicator =
+      input.auth?.type === 'form-login' &&
+      input.auth.successUrlContains !== undefined &&
+      input.auth.successUrlContains !== ''
+        ? { urlContains: input.auth.successUrlContains }
+        : {};
 
-  const input = AnalyzeInputSchema.parse(request.params.arguments ?? {});
+    const authConfig =
+      input.auth?.type === 'form-login'
+        ? {
+            type: 'form-login' as const,
+            loginUrl: input.auth.loginUrl,
+            credentials: { username: input.auth.username, password: input.auth.password },
+            selectors: {
+              username: input.auth.usernameSelector,
+              password: input.auth.passwordSelector,
+              submit: input.auth.submitSelector,
+            },
+            successIndicator,
+          }
+        : input.auth?.type === 'storage-state'
+          ? { type: 'storage-state' as const, path: input.auth.path }
+          : undefined;
 
-  const successIndicator =
-    input.auth?.type === 'form-login' &&
-    input.auth.successUrlContains !== undefined &&
-    input.auth.successUrlContains !== ''
-      ? { urlContains: input.auth.successUrlContains }
-      : {};
+    const harnessConfig: HarnessConfig = {
+      maxPagesToScan: input.maxPagesToScan ?? 10,
+      maxDepth: 3,
+      minPagesForConfidence: 3,
+      timeoutMs: input.timeoutMs ?? 30000,
+      retryCount: 0,
+      llmTokenBudget: input.llmTokenBudget ?? input.llmMaxOutputTokensPerCall ?? 4096,
+      llmMaxOutputTokensPerCall: input.llmMaxOutputTokensPerCall,
+      testGenerationLimit: input.testGenerationLimit ?? 5,
+      enableLlmScenarios: input.enableLlmScenarios !== false,
+      readOnlyMode: true,
+      requireHumanReview: false,
+      failOnConsoleError: false,
+      explorer: 'playwright',
+      defaultAdapter: 'playwright',
+      adapters: ['playwright'],
+      ...(authConfig && { auth: authConfig }),
+    };
 
-  const authConfig =
-    input.auth?.type === 'form-login'
-      ? {
-          type: 'form-login' as const,
-          loginUrl: input.auth.loginUrl,
-          credentials: { username: input.auth.username, password: input.auth.password },
-          selectors: {
-            username: input.auth.usernameSelector,
-            password: input.auth.passwordSelector,
-            submit: input.auth.submitSelector,
-          },
-          successIndicator,
-        }
-      : input.auth?.type === 'storage-state'
-        ? { type: 'storage-state' as const, path: input.auth.path }
-        : undefined;
+    const result = await analyzeApp({
+      url: input.url,
+      writeArtifacts: false,
+      config: harnessConfig,
+      progressLog: mcpProgressLog,
+    });
 
-  const harnessConfig: HarnessConfig = {
-    maxPagesToScan: input.maxPagesToScan ?? 10,
-    maxDepth: 3,
-    minPagesForConfidence: 3,
-    timeoutMs: input.timeoutMs ?? 30000,
-    retryCount: 0,
-    llmTokenBudget: input.llmTokenBudget ?? input.llmMaxOutputTokensPerCall ?? 4096,
-    llmMaxOutputTokensPerCall: input.llmMaxOutputTokensPerCall,
-    testGenerationLimit: input.testGenerationLimit ?? 5,
-    enableLlmScenarios: input.enableLlmScenarios !== false,
-    readOnlyMode: true,
-    requireHumanReview: false,
-    failOnConsoleError: false,
-    explorer: 'playwright',
-    defaultAdapter: 'playwright',
-    adapters: ['playwright'],
-    ...(authConfig && { auth: authConfig }),
-  };
+    const payload = buildCompactAnalyzePayload(result, input.includeFullReport === true);
 
-  const result = await analyzeApp({
-    url: input.url,
-    writeArtifacts: false,
-    config: harnessConfig,
-    progressLog: mcpProgressLog,
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(payload, null, 2),
+        },
+      ],
+    };
   });
 
-  const payload = buildCompactAnalyzePayload(result, input.includeFullReport === true);
-
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: JSON.stringify(payload, null, 2),
-      },
-    ],
-  };
-});
-
 const transport = new StdioServerTransport();
-await server.connect(transport);
+await mcpServer.connect(transport);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,11 +1,52 @@
 #!/usr/bin/env node
+// Naming convention: qulib_{verb}_{noun}. Existing 3 tools predate this convention and retain their names for backwards compatibility.
+//
+// TODO(@qulib/mcp): When tool count exceeds ~10, evaluate MCP resource types and
+// prompt templates as complementary surfaces. Tool explosion is an MCP anti-pattern.
+// Prefer composable tools over one-tool-per-capability.
+//
+// TODO(@qulib/mcp): Evaluate tool-level permission modeling when MCP spec stabilizes.
+// Today: all tools are equally trusted. Future: read-only tools (detect_auth, explore_auth)
+// vs. write-capable tools (analyze_app with writeArtifacts) should carry different trust levels.
+
+import { isAbsolute, normalize, resolve } from 'node:path';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { analyzeApp, detectAuth, exploreAuth } from '@qulib/core';
-import type { HarnessConfig, AnalyzeProgressSink } from '@qulib/core';
+import {
+  analyzeApp,
+  detectAuth,
+  exploreAuth,
+  scanRepo,
+  computeAutomationMaturity,
+} from '@qulib/core';
+import type { HarnessConfig, AnalyzeProgressSink, TelemetrySink } from '@qulib/core';
 import { z } from 'zod';
 import { buildCompactAnalyzePayload } from './compact-analyze-payload.js';
 import { log } from './logger.js';
+
+function toolError(code: string, message: string, detail?: unknown): {
+  content: [{ type: 'text'; text: string }];
+} {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ error: { code, message, detail: detail ?? null } }, null, 2),
+      },
+    ],
+  };
+}
+
+function stderrTelemetrySink(): TelemetrySink {
+  return {
+    emit(event) {
+      process.stderr.write(`${JSON.stringify(event)}\n`);
+    },
+  };
+}
+
+const telemetrySink: TelemetrySink | undefined =
+  process.env.QULIB_TELEMETRY_STDERR === '1' ? stderrTelemetrySink() : undefined;
 
 const mcpProgressLog: AnalyzeProgressSink = {
   info: (message: string) => log.info(message),
@@ -42,10 +83,31 @@ const AnalyzeInputSchema = z.object({
   enableLlmScenarios: z.boolean().optional(),
 });
 
+const ScoreAutomationInputSchema = z.object({
+  repoPath: z.string().describe('Absolute path to the automation repository on the MCP host filesystem'),
+  includeFullDimensions: z
+    .boolean()
+    .optional()
+    .describe('When true, includes all dimension detail. Default false returns top recommendations only.'),
+});
+
+function validateAbsoluteRepoPath(repoPath: string): string {
+  const norm = normalize(repoPath.trim());
+  if (!norm || norm === '.' || norm.includes('..')) {
+    throw new Error('repoPath must be absolute and must not contain path traversal segments');
+  }
+  if (!isAbsolute(norm)) {
+    throw new Error('repoPath must be an absolute path on the MCP host');
+  }
+  return resolve(norm);
+}
+
 const mcpServer = new McpServer(
   {
     name: 'qulib-mcp',
     version: '0.3.1',
+    description:
+      'Qulib QA intelligence platform — gap analysis, auth exploration, and quality scoring for deployed web applications',
   },
   {
     capabilities: {
@@ -81,12 +143,18 @@ mcpServer.registerTool(
     inputSchema: ExploreAuthToolInputSchema,
   },
   async ({ url, timeoutMs }) => {
-    log.info(`explore_auth tool url=${url} timeoutMs=${timeoutMs ?? 20000}`);
-    const result = await exploreAuth(url, timeoutMs, mcpProgressLog);
-    log.info(`explore_auth tool done authRequired=${result.authRequired} paths=${result.authPaths.length}`);
-    return {
-      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-    };
+    try {
+      log.info(`explore_auth tool url=${url} timeoutMs=${timeoutMs ?? 20000}`);
+      const result = await exploreAuth(url, timeoutMs, mcpProgressLog);
+      log.info(`explore_auth tool done authRequired=${result.authRequired} paths=${result.authPaths.length}`);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`explore_auth failed: ${msg}`);
+      return toolError('QULIB_AUTH_EXPLORE_FAILED', msg, err instanceof Error ? err.stack : undefined);
+    }
   }
 );
 
@@ -98,18 +166,24 @@ mcpServer.registerTool(
     inputSchema: DetectAuthToolInputSchema,
   },
   async ({ url, timeoutMs }) => {
-    log.info(`detect_auth tool url=${url} timeoutMs=${timeoutMs ?? 15000}`);
-    const result = await detectAuth(url, timeoutMs, mcpProgressLog);
-    const providerSummary =
-      result.oauthButtons.length > 0
-        ? result.oauthButtons.map((b) => b.provider).join(', ')
-        : result.provider ?? 'none';
-    log.info(
-      `detect_auth tool done type=${result.type} providers=${providerSummary} automatable=${result.type === 'form-login'}`
-    );
-    return {
-      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-    };
+    try {
+      log.info(`detect_auth tool url=${url} timeoutMs=${timeoutMs ?? 15000}`);
+      const result = await detectAuth(url, timeoutMs, mcpProgressLog);
+      const providerSummary =
+        result.oauthButtons.length > 0
+          ? result.oauthButtons.map((b) => b.provider).join(', ')
+          : result.provider ?? 'none';
+      log.info(
+        `detect_auth tool done type=${result.type} providers=${providerSummary} automatable=${result.type === 'form-login'}`
+      );
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`detect_auth failed: ${msg}`);
+      return toolError('QULIB_AUTH_DETECT_FAILED', msg, err instanceof Error ? err.stack : undefined);
+    }
   }
 );
 
@@ -121,67 +195,117 @@ mcpServer.registerTool(
     inputSchema: AnalyzeInputSchema,
   },
   async (input) => {
-    const successIndicator =
-      input.auth?.type === 'form-login' &&
-      input.auth.successUrlContains !== undefined &&
-      input.auth.successUrlContains !== ''
-        ? { urlContains: input.auth.successUrlContains }
-        : {};
+    try {
+      const successIndicator =
+        input.auth?.type === 'form-login' &&
+        input.auth.successUrlContains !== undefined &&
+        input.auth.successUrlContains !== ''
+          ? { urlContains: input.auth.successUrlContains }
+          : {};
 
-    const authConfig =
-      input.auth?.type === 'form-login'
-        ? {
-            type: 'form-login' as const,
-            loginUrl: input.auth.loginUrl,
-            credentials: { username: input.auth.username, password: input.auth.password },
-            selectors: {
-              username: input.auth.usernameSelector,
-              password: input.auth.passwordSelector,
-              submit: input.auth.submitSelector,
-            },
-            successIndicator,
-          }
-        : input.auth?.type === 'storage-state'
-          ? { type: 'storage-state' as const, path: input.auth.path }
-          : undefined;
+      const authConfig =
+        input.auth?.type === 'form-login'
+          ? {
+              type: 'form-login' as const,
+              loginUrl: input.auth.loginUrl,
+              credentials: { username: input.auth.username, password: input.auth.password },
+              selectors: {
+                username: input.auth.usernameSelector,
+                password: input.auth.passwordSelector,
+                submit: input.auth.submitSelector,
+              },
+              successIndicator,
+            }
+          : input.auth?.type === 'storage-state'
+            ? { type: 'storage-state' as const, path: input.auth.path }
+            : undefined;
 
-    const harnessConfig: HarnessConfig = {
-      maxPagesToScan: input.maxPagesToScan ?? 10,
-      maxDepth: 3,
-      minPagesForConfidence: 3,
-      timeoutMs: input.timeoutMs ?? 30000,
-      retryCount: 0,
-      llmTokenBudget: input.llmTokenBudget ?? input.llmMaxOutputTokensPerCall ?? 4096,
-      llmMaxOutputTokensPerCall: input.llmMaxOutputTokensPerCall,
-      testGenerationLimit: input.testGenerationLimit ?? 5,
-      enableLlmScenarios: input.enableLlmScenarios !== false,
-      readOnlyMode: true,
-      requireHumanReview: false,
-      failOnConsoleError: false,
-      explorer: 'playwright',
-      defaultAdapter: 'playwright',
-      adapters: ['playwright'],
-      ...(authConfig && { auth: authConfig }),
-    };
+      const harnessConfig: HarnessConfig = {
+        maxPagesToScan: input.maxPagesToScan ?? 10,
+        maxDepth: 3,
+        minPagesForConfidence: 3,
+        timeoutMs: input.timeoutMs ?? 30000,
+        retryCount: 0,
+        llmTokenBudget: input.llmTokenBudget ?? input.llmMaxOutputTokensPerCall ?? 4096,
+        llmMaxOutputTokensPerCall: input.llmMaxOutputTokensPerCall,
+        testGenerationLimit: input.testGenerationLimit ?? 5,
+        enableLlmScenarios: input.enableLlmScenarios !== false,
+        readOnlyMode: true,
+        requireHumanReview: false,
+        failOnConsoleError: false,
+        explorer: 'playwright',
+        defaultAdapter: 'playwright',
+        adapters: ['playwright'],
+        ...(authConfig && { auth: authConfig }),
+      };
 
-    const result = await analyzeApp({
-      url: input.url,
-      writeArtifacts: false,
-      config: harnessConfig,
-      progressLog: mcpProgressLog,
-    });
+      const result = await analyzeApp({
+        url: input.url,
+        writeArtifacts: false,
+        config: harnessConfig,
+        progressLog: mcpProgressLog,
+        telemetry: telemetrySink,
+      });
 
-    const payload = buildCompactAnalyzePayload(result, input.includeFullReport === true);
+      const payload = buildCompactAnalyzePayload(result, input.includeFullReport === true);
 
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify(payload, null, 2),
-        },
-      ],
-    };
-  });
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(payload, null, 2),
+          },
+        ],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`analyze_app failed: ${msg}`);
+      return toolError('QULIB_SCAN_FAILED', msg, err instanceof Error ? err.stack : undefined);
+    }
+  }
+);
+
+mcpServer.registerTool(
+  'qulib_score_automation',
+  {
+    description:
+      'Score an automation repository for QA maturity across six dimensions: test coverage breadth, framework adoption, test-id hygiene, CI integration, auth test coverage, and component test ratio. Returns an overall score (0–100), maturity level (L1–L5), and prioritized recommendations.',
+    inputSchema: ScoreAutomationInputSchema,
+  },
+  async ({ repoPath, includeFullDimensions }) => {
+    try {
+      // Security: repoPath is an absolute path on the MCP host. We validate it is absolute
+      // and does not contain path traversal sequences. The MCP host is responsible for ensuring
+      // the path is within an allowed directory. We do not enforce a sandbox here — that is a
+      // host-level concern.
+      const abs = validateAbsoluteRepoPath(repoPath);
+      log.info(`qulib_score_automation repoPath=${abs}`);
+      const repo = await scanRepo(abs);
+      const maturity = computeAutomationMaturity(repo);
+      const payload =
+        includeFullDimensions === true
+          ? maturity
+          : {
+              overallScore: maturity.overallScore,
+              level: maturity.level,
+              label: maturity.label,
+              topRecommendations: maturity.topRecommendations,
+              repoPath: maturity.repoPath,
+              computedAt: maturity.computedAt,
+            };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('repoPath must')) {
+        return toolError('QULIB_INPUT_INVALID', msg, undefined);
+      }
+      log.error(`qulib_score_automation failed: ${msg}`);
+      return toolError('QULIB_REPO_SCORE_FAILED', msg, err instanceof Error ? err.stack : undefined);
+    }
+  }
+);
 
 const transport = new StdioServerTransport();
 await mcpServer.connect(transport);


### PR DESCRIPTION
## Summary

This PR **ships v0.4.0 on `main`**: the full `release/v0.4.0` stack plus the **`chore/claude-md-guardrails`** docs commit, merged with `--no-ff` so branch history stays explicit. Direct pushes to `main` are blocked by repository rules, so this is the same release content as the release branch—landed via PR rather than a second, divergent history.

## LLM provider abstraction & harness config (`@qulib/core`)

- **`LlmProvider`** abstraction with **`AnthropicProvider`** and **`createProvider()`**; **`callLLM`** delegates through the provider registry instead of ad hoc wiring.
- **`HarnessConfig`** gains **`llmProvider`**, **`llmModel`**, **`outputDir`**, and **`scoringWeights`** so scans can target a model, persist artifacts under a chosen directory, and tune how gap severity feeds the quality score.
- **`StateManager`** and decision-log paths **respect `config.outputDir`** (default remains **`.scan-state`** under the current working directory).

## Telemetry (`@qulib/core`)

- **`TelemetrySink`**, **`emitTelemetry`**, **`NoopTelemetrySink`**, plus optional **`telemetry`** / **`telemetrySessionId`** on scan-related options.
- Emits **phase and LLM lifecycle** events for downstream observability without changing default public APIs for consumers who do not opt in.

## Repo intelligence, maturity, and scoring (`@qulib/core`)

- **`RepoAnalysis`** gains **`framework`** detection and **`automationMaturity`** scoring; schemas and **`repo-scanner`** are extended accordingly.
- Public surface: **`scanRepo`**, **`computeAutomationMaturity`**, **`resolveScanStateBaseDir`** (exported from core).
- **`computeQualityScoreFromGaps`** honors **optional severity weights**; defaults match prior behavior when weights are omitted.

## MCP (`@qulib/mcp`)

- **SDK migration:** **`McpServer`** + **`registerTool`**; removes deprecated low-level **`Server`** usage. Server metadata (**description**, **version**) stays aligned with the **`@qulib/mcp`** package version.
- **Structured tool errors:** failures return **`QULIB_*`** codes (e.g. auth detect/explore, scan, repo score, invalid input) instead of opaque strings only.
- **Stderr telemetry:** set **`QULIB_TELEMETRY_STDERR=1`** for **NDJSON** telemetry lines on stderr (complements existing **`QULIB_DEBUG=1`** verbose logging in **`packages/mcp/src/logger.ts`**).
- **New tool:** **`qulib_score_automation`** for automation maturity scoring from repo context.
- **`analyze_app`:** compact payloads can include **`automationMaturitySummary`** when repo analysis includes maturity data.
- **Operator hint:** if **`ANTHROPIC_API_KEY`** is unset, the server logs a **stderr WARN** at startup so local MCP setups fail visibly but predictably.

## Docs & repo hygiene

- **`CHANGELOG.md`** added at the repo root with **Keep a Changelog** structure; entries for **0.3.1 and earlier** were **backfilled** from existing tags and release history on `main`.
- **`CLAUDE.md`** updated to match **CI**, **releases**, and **monorepo** conventions (from **`chore/claude-md-guardrails`**).

## Tags & npm

- Git tags **`v0.3.0`**, **`v0.3.1`**, and **`v0.4.0`** are already on the remote and point at the corresponding release commits in this history.
- After merge: **`npm publish`** for **`@qulib/core`** then **`@qulib/mcp`** when you are ready (same OTP flow as prior releases).

## How to verify

```bash
npm install && npm run build && npm test
# optional live scan (network + Playwright)
RUN_NETWORK_INTEGRATION=1 npm run test:integration -w @qulib/core
```

Made with [Cursor](https://cursor.com)
