### PR TITLE
chore: add keywords to @qulib/core package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,16 @@
   "bugs": {
     "url": "https://github.com/TapeshN/qulib/issues"
   },
+  "keywords": [
+    "qa",
+    "quality",
+    "accessibility",
+    "gap-analysis",
+    "release-confidence",
+    "playwright",
+    "mcp",
+    "ai"
+  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Adds `keywords` field to `@qulib/core` package.json to match `@qulib/mcp`
- Keywords: `qa`, `quality`, `accessibility`, `gap-analysis`, `release-confidence`, `playwright`, `mcp`, `ai`
- Improves discoverability on npmjs.com