### PR TITLE
chore(release): v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Entries for **0.3.1 and earlier** were reconstructed from git tags (`v0.1.1` …
 ### Fixed
 
 - **@qulib/core:** `detectAuth` matches OAuth IdP buttons against `BUILT_IN_OAUTH_PROVIDERS` (including Clever, ClassLink, and other built-ins) instead of a short hard-coded list; single-word labels that match a built-in provider name are accepted; SSO-shaped buttons that do not match any built-in pattern are still surfaced as `provider: 'unknown'` in `oauthButtons`.
+- **@qulib/core:** Click-to-reveal `authOptions` credential fields now include every visible text/email/password input and `select` (with labels from associated `<label>`, placeholder, aria-label, or name); auth-surface analysis no longer flags “OAuth-only” when `authOptions` includes a `form-login` path (emits a low-severity informational gap instead).
 
 ## [0.4.0] — 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Entries for **0.3.1 and earlier** were reconstructed from git tags (`v0.1.1` …
 
 ## [0.4.1] — 2026-05-13
 
+### Added
+
+- **@qulib/core:** Optional `authOptions` on `DetectedAuth` (each entry is an `AuthPath`); `detectAuth` probes up to four non–IdP `<button>` labels for click-to-reveal username/password flows (and visible `<select>` fields such as District), then restores the login URL between probes.
+
 ### Fixed
 
 - **@qulib/core:** `detectAuth` matches OAuth IdP buttons against `BUILT_IN_OAUTH_PROVIDERS` (including Clever, ClassLink, and other built-ins) instead of a short hard-coded list; single-word labels that match a built-in provider name are accepted; SSO-shaped buttons that do not match any built-in pattern are still surfaced as `provider: 'unknown'` in `oauthButtons`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Entries for **0.3.1 and earlier** were reconstructed from git tags (`v0.1.1` … `v0.2.2`) and release commits on `main`.
 
+## [0.4.1] — 2026-05-13
+
+### Fixed
+
+- **@qulib/core:** `detectAuth` matches OAuth IdP buttons against `BUILT_IN_OAUTH_PROVIDERS` (including Clever, ClassLink, and other built-ins) instead of a short hard-coded list; single-word labels that match a built-in provider name are accepted; SSO-shaped buttons that do not match any built-in pattern are still surfaced as `provider: 'unknown'` in `oauthButtons`.
+
 ## [0.4.0] — 2026-05-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -2029,7 +2029,7 @@
     },
     "packages/core": {
       "name": "@qulib/core",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "^4.9.0",
@@ -2049,11 +2049,11 @@
     },
     "packages/mcp": {
       "name": "@qulib/mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@qulib/core": "0.4.0",
+        "@qulib/core": "0.4.1",
         "zod": "^3.23.0"
       },
       "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Qulib — analyze deployed web apps for honest quality gaps (CLI + programmatic API)",
   "license": "MIT",
   "author": "Tapesh Nagarwal",

--- a/packages/core/src/schemas/config.schema.ts
+++ b/packages/core/src/schemas/config.schema.ts
@@ -82,29 +82,6 @@ export function resolveMaxOutputTokensPerLlmCall(config: HarnessConfig): number 
   return config.llmMaxOutputTokensPerCall ?? config.llmTokenBudget;
 }
 
-export const DetectedAuthSchema = z.object({
-  hasAuth: z.boolean(),
-  type: z.enum(['none', 'form-login', 'oauth', 'magic-link', 'unknown']),
-  provider: z.string().nullable(),
-  loginUrl: z.string().nullable(),
-  observedSelectors: z
-    .object({
-      usernameSelector: z.string().nullable(),
-      passwordSelector: z.string().nullable(),
-      submitSelector: z.string().nullable(),
-    })
-    .nullable(),
-  oauthButtons: z.array(
-    z.object({
-      provider: z.string(),
-      text: z.string(),
-    })
-  ),
-  recommendation: z.string(),
-});
-
-export type DetectedAuth = z.infer<typeof DetectedAuthSchema>;
-
 export const AuthPathRequirementsSchema = z.discriminatedUnion('method', [
   z.object({ method: z.literal('storage-state'), instruction: z.string() }),
   z.object({
@@ -131,6 +108,30 @@ export const AuthPathSchema = z.object({
   confidence: z.enum(['high', 'medium', 'low']),
   requirements: AuthPathRequirementsSchema,
 });
+
+export const DetectedAuthSchema = z.object({
+  hasAuth: z.boolean(),
+  type: z.enum(['none', 'form-login', 'oauth', 'magic-link', 'unknown']),
+  provider: z.string().nullable(),
+  loginUrl: z.string().nullable(),
+  observedSelectors: z
+    .object({
+      usernameSelector: z.string().nullable(),
+      passwordSelector: z.string().nullable(),
+      submitSelector: z.string().nullable(),
+    })
+    .nullable(),
+  oauthButtons: z.array(
+    z.object({
+      provider: z.string(),
+      text: z.string(),
+    })
+  ),
+  authOptions: z.array(AuthPathSchema).optional(),
+  recommendation: z.string(),
+});
+
+export type DetectedAuth = z.infer<typeof DetectedAuthSchema>;
 
 export const AuthExplorationSchema = z.object({
   url: z.string(),

--- a/packages/core/src/tools/auth-detector.ts
+++ b/packages/core/src/tools/auth-detector.ts
@@ -2,6 +2,7 @@ import type { Page } from '@playwright/test';
 import type { DetectedAuth } from '../schemas/config.schema.js';
 import type { AnalyzeProgressSink } from '../harness/progress-log.js';
 import { launchBrowser } from './browser.js';
+import { BUILT_IN_OAUTH_PROVIDERS } from './oauth-providers.js';
 
 async function waitNetworkIdleBestEffort(page: Page): Promise<void> {
   try {
@@ -11,30 +12,21 @@ async function waitNetworkIdleBestEffort(page: Page): Promise<void> {
   }
 }
 
-const OAUTH_PROVIDERS: Array<{ provider: string; patterns: RegExp[] }> = [
-  { provider: 'github', patterns: [/github/i, /sign in with github/i] },
-  {
-    provider: 'google',
-    patterns: [/google/i, /sign in with google/i, /accounts\.google\.com/i],
-  },
-  {
-    provider: 'microsoft',
-    patterns: [/microsoft/i, /sign in with microsoft/i, /login\.microsoftonline\.com/i],
-  },
-  { provider: 'apple', patterns: [/apple/i, /sign in with apple/i] },
-  { provider: 'auth0', patterns: [/auth0/i] },
-  { provider: 'okta', patterns: [/okta/i] },
-];
+const PROVIDER_LABELS = new Set(BUILT_IN_OAUTH_PROVIDERS.map((p) => p.label.toLowerCase()));
 
 function textLooksLikeOAuthIdpButton(text: string): boolean {
   const t = text.trim();
   if (t.length === 0 || t.length > 120) {
     return false;
   }
-  return (
-    /\b(sign in with|log in with|continue with|sign up with)\b/i.test(t) ||
-    /^(github|google|microsoft|apple)$/i.test(t)
-  );
+  if (/\b(sign in with|log in with|continue with|sign up with)\b/i.test(t)) {
+    return true;
+  }
+  // Accept single-word / short labels that exactly match a known provider name
+  if (PROVIDER_LABELS.has(t.toLowerCase())) {
+    return true;
+  }
+  return false;
 }
 
 const MAGIC_LINK_PATTERNS = [
@@ -120,16 +112,22 @@ export async function detectAuth(
         }
         continue;
       }
-      for (const { provider, patterns } of OAUTH_PROVIDERS) {
+      let matchedAny = false;
+      for (const { id, patterns } of BUILT_IN_OAUTH_PROVIDERS) {
         const matched = patterns.some((p) => p.test(trimmed));
         if (debugAuth()) {
-          progress?.debug(`detect_auth oauth pattern try provider=${provider} matched=${matched}`);
+          progress?.debug(`detect_auth oauth pattern try provider=${id} matched=${matched}`);
         }
         if (matched) {
-          if (!oauthButtons.find((b) => b.provider === provider)) {
-            oauthButtons.push({ provider, text: trimmed.slice(0, 100) });
+          if (!oauthButtons.find((b) => b.provider === id)) {
+            oauthButtons.push({ provider: id, text: trimmed.slice(0, 100) });
           }
+          matchedAny = true;
         }
+      }
+      // Capture unrecognized SSO-like buttons so they appear in the result
+      if (!matchedAny && !oauthButtons.find((b) => b.text === trimmed.slice(0, 100))) {
+        oauthButtons.push({ provider: 'unknown', text: trimmed.slice(0, 100) });
       }
     }
 

--- a/packages/core/src/tools/auth-detector.ts
+++ b/packages/core/src/tools/auth-detector.ts
@@ -1,5 +1,5 @@
 import type { Page } from '@playwright/test';
-import type { DetectedAuth } from '../schemas/config.schema.js';
+import type { AuthPath, DetectedAuth } from '../schemas/config.schema.js';
 import type { AnalyzeProgressSink } from '../harness/progress-log.js';
 import { launchBrowser } from './browser.js';
 import { BUILT_IN_OAUTH_PROVIDERS } from './oauth-providers.js';
@@ -54,6 +54,195 @@ async function firstTextInputNameForLogin(page: import('@playwright/test').Page)
 
 function debugAuth(): boolean {
   return process.env.QULIB_DEBUG === '1';
+}
+
+function slugify(label: string): string {
+  const s = label
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '')
+    .replace(/^-+|-+$/g, '');
+  return s.length > 0 ? s : 'custom';
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function buildCredentialFieldsFromVisibleForm(
+  page: Page,
+  usernameName: string | null,
+  passwordName: string | null
+): Promise<
+  Array<{
+    name: string;
+    label: string;
+    type: 'text' | 'password' | 'email' | 'select' | 'checkbox';
+    observedOptions: string[];
+  }>
+> {
+  const fields: Array<{
+    name: string;
+    label: string;
+    type: 'text' | 'password' | 'email' | 'select' | 'checkbox';
+    observedOptions: string[];
+  }> = [];
+
+  let uname = usernameName;
+  if (!uname) {
+    const ti = page.locator('input[type="text"]:visible, input[type="email"]:visible');
+    const c = await ti.count();
+    for (let j = 0; j < c; j++) {
+      const nm = await ti.nth(j).getAttribute('name');
+      if (nm && nm.trim().length > 0) {
+        uname = nm.trim();
+        break;
+      }
+    }
+  }
+  const emailCount = await page.locator('input[type="email"]:visible').count();
+  const usernameType: 'email' | 'text' = emailCount > 0 ? 'email' : 'text';
+  fields.push({
+    name: uname ?? 'username',
+    label: usernameType === 'email' ? 'Email or username' : 'Username',
+    type: usernameType,
+    observedOptions: [],
+  });
+
+  const pwdName = passwordName ?? 'password';
+  fields.push({
+    name: pwdName,
+    label: 'Password',
+    type: 'password',
+    observedOptions: [],
+  });
+
+  const selects = page.locator('select:visible');
+  const scount = await selects.count();
+  for (let si = 0; si < scount; si++) {
+    const sel = selects.nth(si);
+    const name = await sel.getAttribute('name');
+    const nid = name && name.trim().length > 0 ? name.trim() : `select-${si}`;
+    const opts = await sel.locator('option').allInnerTexts();
+    const observedOptions = opts.map((o) => o.trim()).filter((x) => x.length > 0);
+    let lbl = (await sel.getAttribute('aria-label'))?.trim() ?? '';
+    if (!lbl) {
+      const sid = await sel.getAttribute('id');
+      if (sid) {
+        const lt = await page.locator(`label[for="${CSS.escape(sid)}"]`).first().textContent().catch(() => null);
+        lbl = (lt ?? '').trim();
+      }
+    }
+    if (!lbl) lbl = nid;
+    fields.push({
+      name: nid,
+      label: lbl,
+      type: 'select',
+      observedOptions,
+    });
+  }
+
+  return fields;
+}
+
+function authPathsFromOauthButtons(oauthButtons: { provider: string; text: string }[], loginUrl: string): AuthPath[] {
+  return oauthButtons.map((b) => {
+    const isUnknown = b.provider === 'unknown';
+    const id = isUnknown ? slugify(b.text) : b.provider;
+    return {
+      id,
+      label: b.text,
+      type: isUnknown ? 'oauth-unknown' : 'oauth',
+      provider: isUnknown ? slugify(b.text) : b.provider,
+      source: isUnknown ? 'heuristic' : 'built-in',
+      automatable: false,
+      confidence: isUnknown ? 'low' : 'high',
+      requirements: {
+        method: 'storage-state',
+        instruction: `Run qulib auth init --base-url ${loginUrl}`,
+      },
+    };
+  });
+}
+
+async function probeClickToRevealForms(
+  page: Page,
+  loginUrl: string,
+  alreadyMatchedTexts: Set<string>,
+  timeoutMs: number,
+  progress?: AnalyzeProgressSink
+): Promise<AuthPath[]> {
+  const out: AuthPath[] = [];
+  const buttons = page.locator('button');
+  const n = await buttons.count();
+  const seenLabels = new Set<string>();
+  const SUBMIT_RE = /^(sign in|log in|submit|continue|next|cancel|close)$/i;
+
+  let candidateAttempts = 0;
+  for (let i = 0; i < n && candidateAttempts < 4; i++) {
+    const label = ((await buttons.nth(i).textContent()) ?? '').trim();
+    if (!label || label.length > 80) continue;
+    if (alreadyMatchedTexts.has(label)) continue;
+    if (SUBMIT_RE.test(label)) continue;
+    if (seenLabels.has(label)) continue;
+    seenLabels.add(label);
+    candidateAttempts += 1;
+
+    if (debugAuth()) {
+      progress?.debug(`detect_auth click-reveal try label="${label.slice(0, 80)}"`);
+    }
+
+    let clicked = false;
+    try {
+      await page.getByRole('button', { name: label, exact: true }).first().click({ timeout: 2000 });
+      clicked = true;
+    } catch {
+      try {
+        await page
+          .locator('button')
+          .filter({ hasText: new RegExp(`^\\s*${escapeRegExp(label)}\\s*$`, 'i') })
+          .first()
+          .click({ timeout: 2000 });
+        clicked = true;
+      } catch {
+        /* skip */
+      }
+    }
+    if (!clicked) {
+      continue;
+    }
+
+    try {
+      await page.locator('input[type="password"]').first().waitFor({ state: 'visible', timeout: 2000 });
+    } catch {
+      await page.goto(loginUrl, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
+      await waitNetworkIdleBestEffort(page);
+      continue;
+    }
+
+    const usernameName = await firstTextInputNameForLogin(page);
+    const passwordName = await page.locator('input[type="password"]').first().getAttribute('name').catch(() => null);
+    const fields = await buildCredentialFieldsFromVisibleForm(page, usernameName, passwordName);
+    const slug = slugify(label);
+    out.push({
+      id: slug,
+      label,
+      type: 'form-login',
+      provider: slug,
+      source: 'heuristic',
+      automatable: true,
+      confidence: 'medium',
+      requirements: {
+        method: 'credentials',
+        fields,
+      },
+    });
+
+    await page.goto(loginUrl, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
+    await waitNetworkIdleBestEffort(page);
+  }
+
+  return out;
 }
 
 export async function detectAuth(
@@ -131,6 +320,12 @@ export async function detectAuth(
       }
     }
 
+    // Only skip buttons already tied to a built-in IdP — leave `unknown` labels probe-able for click-to-reveal forms.
+    const skipProbeLabels = new Set(
+      oauthButtons.filter((b) => b.provider !== 'unknown').map((b) => b.text.trim())
+    );
+    const clickRevealForms = await probeClickToRevealForms(page, loginUrl, skipProbeLabels, timeoutMs, progress);
+
     const pageText = await page.locator('body').innerText().catch(() => '');
     const hasMagicLink = MAGIC_LINK_PATTERNS.some((p) => p.test(pageText));
 
@@ -142,7 +337,7 @@ export async function detectAuth(
     if (oauthButtons.length > 0) {
       type = 'oauth';
       provider = oauthButtons[0].provider;
-      recommendation = `OAuth detected (${oauthButtons.map((b) => b.provider).join(', ')}). OAuth cannot be automated. Run "qulib auth init --base-url ${url}" to log in manually once and save a reusable storage state file.`;
+      recommendation = `OAuth detected (${oauthButtons.map((b) => b.provider).join(', ')}). OAuth cannot be automated. Run "qulib auth init --base-url ${loginUrl}" to log in manually once and save a reusable storage state file.`;
     } else if (hasFormLogin) {
       type = 'form-login';
       const usernameName = await firstTextInputNameForLogin(page);
@@ -166,27 +361,35 @@ export async function detectAuth(
       recommendation = `Form login detected. Configure auth with type="form-login", credentials, and the selectors above. Test selectors in your browser dev tools to confirm.`;
     } else if (hasMagicLink) {
       type = 'magic-link';
-      recommendation = `Magic link / passwordless auth detected. Qulib cannot complete email-link flows. Run "qulib auth init --base-url ${url}" to log in manually once and save a storage state file.`;
+      recommendation = `Magic link / passwordless auth detected. Qulib cannot complete email-link flows. Run "qulib auth init --base-url ${loginUrl}" to log in manually once and save a storage state file.`;
     } else if (looksLikeLoginPage) {
       type = 'unknown';
-      recommendation = `Authentication required but the pattern is unrecognized. Use "qulib auth init --base-url ${url}" to capture a storage state by logging in manually.`;
+      recommendation = `Authentication required but the pattern is unrecognized. Use "qulib auth init --base-url ${loginUrl}" to capture a storage state by logging in manually.`;
     } else {
       type = 'none';
       recommendation = `No authentication required for the entry URL. Qulib can scan anonymously.`;
     }
 
+    if (clickRevealForms.length > 0) {
+      recommendation += `\nAutomatable form login detected via: ${clickRevealForms.map((f) => f.label).join(', ')}. Use type="form-login" with the observed selectors in authOptions.`;
+    }
+
     const providerList =
       oauthButtons.length > 0 ? oauthButtons.map((b) => b.provider).join(', ') : provider ?? 'none';
-    const automatable = type === 'form-login';
+    const automatable = type === 'form-login' || clickRevealForms.length > 0;
     progress?.info(`Auth detected: ${type} (${providerList}) automatable=${automatable}`);
 
+    const authOptions: AuthPath[] = [...authPathsFromOauthButtons(oauthButtons, loginUrl), ...clickRevealForms];
+
     return {
-      hasAuth: type !== 'none',
+      hasAuth: type !== 'none' || oauthButtons.length > 0 || clickRevealForms.length > 0,
       type,
       provider,
-      loginUrl: type === 'none' ? null : loginUrl,
+      loginUrl:
+        type === 'none' && oauthButtons.length === 0 && clickRevealForms.length === 0 ? null : loginUrl,
       observedSelectors,
       oauthButtons,
+      ...(authOptions.length > 0 ? { authOptions } : {}),
       recommendation,
     };
   } finally {

--- a/packages/core/src/tools/auth-detector.ts
+++ b/packages/core/src/tools/auth-detector.ts
@@ -72,7 +72,7 @@ function escapeRegExp(s: string): string {
 async function resolveVisibleFieldLabel(page: Page, el: import('@playwright/test').Locator): Promise<string> {
   const id = await el.getAttribute('id');
   if (id) {
-    const lt = await page.locator(`label[for="${CSS.escape(id)}"]`).first().textContent().catch(() => null);
+    const lt = await page.locator(`label[for="${id.replace(/"/g, '\\"')}"]`).first().textContent().catch(() => null);
     const fromLabel = (lt ?? '').trim();
     if (fromLabel) return fromLabel;
   }

--- a/packages/core/src/tools/auth-detector.ts
+++ b/packages/core/src/tools/auth-detector.ts
@@ -69,11 +69,36 @@ function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-async function buildCredentialFieldsFromVisibleForm(
-  page: Page,
-  usernameName: string | null,
-  passwordName: string | null
-): Promise<
+async function resolveVisibleFieldLabel(page: Page, el: import('@playwright/test').Locator): Promise<string> {
+  const id = await el.getAttribute('id');
+  if (id) {
+    const lt = await page.locator(`label[for="${CSS.escape(id)}"]`).first().textContent().catch(() => null);
+    const fromLabel = (lt ?? '').trim();
+    if (fromLabel) return fromLabel;
+  }
+  const placeholder = (await el.getAttribute('placeholder'))?.trim();
+  if (placeholder) return placeholder;
+  const aria = (await el.getAttribute('aria-label'))?.trim();
+  if (aria) return aria;
+  const name = (await el.getAttribute('name'))?.trim();
+  if (name) return name;
+  const typ = (await el.getAttribute('type'))?.trim();
+  return typ && typ !== 'select' ? typ : 'text';
+}
+
+async function deriveCredentialFieldName(el: import('@playwright/test').Locator): Promise<string> {
+  const name = (await el.getAttribute('name'))?.trim();
+  if (name) return name;
+  const placeholder = (await el.getAttribute('placeholder'))?.trim();
+  if (placeholder) return slugify(placeholder);
+  const aria = (await el.getAttribute('aria-label'))?.trim();
+  if (aria) return slugify(aria);
+  const id = (await el.getAttribute('id'))?.trim();
+  if (id) return slugify(id);
+  return 'field';
+}
+
+async function buildCredentialFieldsFromVisibleForm(page: Page): Promise<
   Array<{
     name: string;
     label: string;
@@ -87,59 +112,37 @@ async function buildCredentialFieldsFromVisibleForm(
     type: 'text' | 'password' | 'email' | 'select' | 'checkbox';
     observedOptions: string[];
   }> = [];
+  const seen = new Set<string>();
 
-  let uname = usernameName;
-  if (!uname) {
-    const ti = page.locator('input[type="text"]:visible, input[type="email"]:visible');
-    const c = await ti.count();
-    for (let j = 0; j < c; j++) {
-      const nm = await ti.nth(j).getAttribute('name');
-      if (nm && nm.trim().length > 0) {
-        uname = nm.trim();
-        break;
-      }
+  const loc = page.locator(
+    'input[type="text"]:visible, input[type="email"]:visible, input[type="password"]:visible, select:visible'
+  );
+  const count = await loc.count();
+  for (let i = 0; i < count; i++) {
+    const el = loc.nth(i);
+    const tag = await el.evaluate((node) => node.tagName.toLowerCase()).catch(() => '');
+    if (tag === 'select') {
+      const name = await deriveCredentialFieldName(el);
+      const label = await resolveVisibleFieldLabel(page, el);
+      const opts = await el.locator('option').allInnerTexts();
+      const observedOptions = opts.map((o) => o.trim()).filter((x) => x.length > 0).slice(0, 20);
+      const dedupeKey = `select|${name}|${label}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      fields.push({ name, label, type: 'select', observedOptions });
+      continue;
     }
-  }
-  const emailCount = await page.locator('input[type="email"]:visible').count();
-  const usernameType: 'email' | 'text' = emailCount > 0 ? 'email' : 'text';
-  fields.push({
-    name: uname ?? 'username',
-    label: usernameType === 'email' ? 'Email or username' : 'Username',
-    type: usernameType,
-    observedOptions: [],
-  });
 
-  const pwdName = passwordName ?? 'password';
-  fields.push({
-    name: pwdName,
-    label: 'Password',
-    type: 'password',
-    observedOptions: [],
-  });
-
-  const selects = page.locator('select:visible');
-  const scount = await selects.count();
-  for (let si = 0; si < scount; si++) {
-    const sel = selects.nth(si);
-    const name = await sel.getAttribute('name');
-    const nid = name && name.trim().length > 0 ? name.trim() : `select-${si}`;
-    const opts = await sel.locator('option').allInnerTexts();
-    const observedOptions = opts.map((o) => o.trim()).filter((x) => x.length > 0);
-    let lbl = (await sel.getAttribute('aria-label'))?.trim() ?? '';
-    if (!lbl) {
-      const sid = await sel.getAttribute('id');
-      if (sid) {
-        const lt = await page.locator(`label[for="${CSS.escape(sid)}"]`).first().textContent().catch(() => null);
-        lbl = (lt ?? '').trim();
-      }
-    }
-    if (!lbl) lbl = nid;
-    fields.push({
-      name: nid,
-      label: lbl,
-      type: 'select',
-      observedOptions,
-    });
+    const rawType = ((await el.getAttribute('type')) ?? 'text').toLowerCase();
+    if (rawType === 'hidden') continue;
+    const fieldType = rawType === 'email' ? 'email' : rawType === 'password' ? 'password' : 'text';
+    const name = await deriveCredentialFieldName(el);
+    const label = await resolveVisibleFieldLabel(page, el);
+    const placeholder = (await el.getAttribute('placeholder'))?.trim() ?? '';
+    const dedupeKey = `${name}|${placeholder}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    fields.push({ name, label, type: fieldType, observedOptions: [] });
   }
 
   return fields;
@@ -220,9 +223,7 @@ async function probeClickToRevealForms(
       continue;
     }
 
-    const usernameName = await firstTextInputNameForLogin(page);
-    const passwordName = await page.locator('input[type="password"]').first().getAttribute('name').catch(() => null);
-    const fields = await buildCredentialFieldsFromVisibleForm(page, usernameName, passwordName);
+    const fields = await buildCredentialFieldsFromVisibleForm(page);
     const slug = slugify(label);
     out.push({
       id: slug,

--- a/packages/core/src/tools/auth-surface-analyzer.ts
+++ b/packages/core/src/tools/auth-surface-analyzer.ts
@@ -124,16 +124,33 @@ export async function analyzeAuthSurfaceGaps(
     const hasOAuthUi =
       detection.oauthButtons.length > 0 ||
       (await page.getByText(/sign in with|continue with google|microsoft|github/i).count()) > 0;
-    if (hasOAuthUi && !hasPassword && !hasEmailLink) {
-      gaps.push({
-        id: randomUUID(),
-        path: '/',
-        severity: 'medium',
-        category: 'auth-surface',
-        reason: 'OAuth-only entry with no visible password or magic-link fallback.',
-        description: 'Users who cannot use a social IdP need another path (email/password, help, or support).',
-        recommendation: 'Add a documented fallback (email/password, help desk link, or alternate IdP).',
-      });
+    const formLoginFallbacks = (detection.authOptions ?? []).filter((o) => o.type === 'form-login');
+    const hasFormLoginFallback = formLoginFallbacks.length > 0;
+
+    if (detection.type === 'oauth' && hasOAuthUi && !hasPassword && !hasEmailLink) {
+      if (hasFormLoginFallback) {
+        const labels = formLoginFallbacks.map((o) => o.label).join(', ');
+        gaps.push({
+          id: randomUUID(),
+          path: '/',
+          severity: 'low',
+          category: 'auth-surface',
+          reason: `OAuth-primary login with form-login fallback detected via: ${labels}`,
+          description:
+            'A form-based login path exists alongside OAuth. Automate via type="form-login" using the selectors in authOptions.',
+          recommendation: `Automatable form option(s): ${labels}. Configure type="form-login" with credentials and selectors from detectedAuth.authOptions.`,
+        });
+      } else {
+        gaps.push({
+          id: randomUUID(),
+          path: '/',
+          severity: 'medium',
+          category: 'auth-surface',
+          reason: 'OAuth-only entry with no visible password or magic-link fallback.',
+          description: 'Users who cannot use a social IdP need another path (email/password, help, or support).',
+          recommendation: 'Add a documented fallback (email/password, help desk link, or alternate IdP).',
+        });
+      }
     }
 
     const errorSelectors = '[role="alert"], [data-testid*="error" i], .error, .alert-danger, [class*="error" i]';

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for Qulib — AI-callable QA gap analysis",
   "license": "MIT",
   "author": "Tapesh Nagarwal",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@qulib/core": "0.4.0",
+    "@qulib/core": "0.4.1",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -105,7 +105,7 @@ function validateAbsoluteRepoPath(repoPath: string): string {
 const mcpServer = new McpServer(
   {
     name: 'qulib-mcp',
-    version: '0.4.0',
+    version: '0.4.1',
     description:
       'Qulib QA intelligence platform — gap analysis, auth exploration, and quality scoring for deployed web applications',
   },


### PR DESCRIPTION
## Summary

Patch release **v0.4.1** for `@qulib/core` and `@qulib/mcp`.

### Fixes (`@qulib/core`)

- `detectAuth` now matches OAuth controls against **`BUILT_IN_OAUTH_PROVIDERS`** (Clever, ClassLink, and the full built-in list) instead of a short hard-coded provider list.
- **Label gate:** single-word button text that exactly matches a built-in provider **label** (e.g. "Clever", "ClassLink") is treated as IdP-shaped.
- **Unknown SSO:** SSO-shaped buttons that do not match any built-in pattern are still recorded as `provider: 'unknown'` in `oauthButtons`.

### Versions

- `@qulib/core` **0.4.1**
- `@qulib/mcp` **0.4.1** (pins `@qulib/core` **0.4.1**; MCP server metadata version **0.4.1**)

`CHANGELOG.md` updated.

## Verify

```bash
npm install && npm run build && npm test
```

After merge: tag `v0.4.1`, push tags, then `npm publish -w @qulib/core` and `npm publish -w @qulib/mcp` with OTP when ready.

Made with [Cursor](https://cursor.com)