### PR TITLE
test(core): local HTML fixtures + deterministic fixture server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,30 @@ jobs:
         run: node bin/qulib.js analyze --url https://example.com --ephemeral
         timeout-minutes: 3
 
+  fixture-tests:
+    name: Fixture smoke tests (offline)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run fixture tests
+        working-directory: packages/core
+        run: node --import tsx/esm --test src/__tests__/analyze.fixtures.test.ts
+        timeout-minutes: 5
+
   publish-check:
     name: Verify packages are publishable
     runs-on: ubuntu-latest

--- a/packages/core/fixtures/auth-wall/index.html
+++ b/packages/core/fixtures/auth-wall/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Sign-in wall fixture with OAuth buttons for Qulib offline testing.">
+  <title>Sign in — Qulib Fixture</title>
+</head>
+<body>
+  <h1>Sign in to continue</h1>
+  <main>
+    <div role="group" aria-label="Sign-in options">
+      <button data-provider="google" aria-label="Sign in with Google">Sign in with Google</button>
+      <button data-provider="clever" aria-label="Sign in with Clever">Sign in with Clever</button>
+    </div>
+    <div id="auth-error" role="alert" aria-live="assertive" style="display:none">Authentication failed.</div>
+  </main>
+  <footer>
+    <a href="/help">Need help signing in?</a>
+  </footer>
+</body>
+</html>

--- a/packages/core/fixtures/authenticated/index.html
+++ b/packages/core/fixtures/authenticated/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Authenticated dashboard fixture for Qulib offline testing.">
+  <title>Dashboard — Qulib Fixture</title>
+</head>
+<body>
+  <!-- fixture: authenticated surface — loaded via storage-state -->
+  <h1>Dashboard</h1>
+  <nav aria-label="Dashboard navigation">
+    <ul>
+      <li><a href="/authenticated/reports">Reports</a></li>
+      <li><a href="/authenticated/settings">Settings</a></li>
+      <li><a href="/authenticated/profile">Profile</a></li>
+    </ul>
+  </nav>
+  <main>
+    <p>Welcome back. Your latest scan results are ready.</p>
+  </main>
+</body>
+</html>

--- a/packages/core/fixtures/broken/index.html
+++ b/packages/core/fixtures/broken/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Intentionally broken fixture page for Qulib gap detection testing.">
+  <title>Broken Fixture — Qulib</title>
+</head>
+<body>
+  <h1>Broken Page</h1>
+  <main>
+    <a href="/this-route-does-not-exist-404">Dead link</a>
+    <img src="/nonexistent.png">
+    <a href="https://qulib-broken-fixture.example.invalid">External broken</a>
+  </main>
+  <script>console.error('fixture-console-error: intentional');</script>
+</body>
+</html>

--- a/packages/core/fixtures/public/about.html
+++ b/packages/core/fixtures/public/about.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="About page for the Qulib public fixture site.">
+  <title>About — Qulib Public Fixture</title>
+</head>
+<body>
+  <h1>About</h1>
+  <main>
+    <p>Qulib is a deterministic-first QA intelligence platform for web apps.</p>
+  </main>
+  <nav><a href="/">Home</a></nav>
+</body>
+</html>

--- a/packages/core/fixtures/public/features.html
+++ b/packages/core/fixtures/public/features.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Features page for the Qulib public fixture site.">
+  <title>Features — Qulib Public Fixture</title>
+</head>
+<body>
+  <h1>Features</h1>
+  <main>
+    <ul>
+      <li>Route discovery via Playwright</li>
+      <li>Accessibility checks (axe-core)</li>
+      <li>Broken link detection</li>
+      <li>Console error capture</li>
+      <li>Automation maturity scoring</li>
+    </ul>
+  </main>
+  <nav><a href="/">Home</a></nav>
+</body>
+</html>

--- a/packages/core/fixtures/public/index.html
+++ b/packages/core/fixtures/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Qulib public fixture — a simple multi-page site for offline integration testing.">
+  <title>Qulib Public Fixture</title>
+</head>
+<body>
+  <h1>Welcome to Qulib Fixture</h1>
+  <nav aria-label="Main navigation">
+    <ul>
+      <li><a href="/about">About</a></li>
+      <li><a href="/features">Features</a></li>
+      <li><a href="/docs">Docs</a></li>
+    </ul>
+  </nav>
+  <main>
+    <p>This is a deterministic fixture page used by Qulib's offline test suite.</p>
+  </main>
+</body>
+</html>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "analyze": "tsx src/cli/index.ts analyze",
     "clean": "tsx src/cli/index.ts clean",
     "build": "tsc",
-    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/analyze.storage-state-invalid.test.ts",
+    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts",
     "test:integration": "node --import tsx/esm --test src/__tests__/analyze.integration.test.ts",
     "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral",
     "cost-doctor": "tsx src/cli/index.ts cost doctor"

--- a/packages/core/src/__tests__/analyze.fixtures.test.ts
+++ b/packages/core/src/__tests__/analyze.fixtures.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Offline smoke tests for `analyzeApp` against the local fixture server.
+ *
+ * These tests boot a Node.js fixture server on loopback, point `analyzeApp`
+ * at it, and assert structural shape (not exact counts). They must run
+ * unconditionally on every CI run — no env-gated skips.
+ *
+ * Server lifecycle: a single fixture server is started in `t.before` and
+ * shared across the three sub-tests via `await t.test(...)`. This matches
+ * the node:test API for sharing a resource across related tests. The
+ * existing flat `test(...)` style in `analyze.integration.test.ts` is
+ * preserved for tests that don't need shared state.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { startFixtureServer, type FixtureServerHandle } from './fixture-server.js';
+import { analyzeApp } from '../analyze.js';
+import { HarnessConfigSchema, type HarnessConfig } from '../schemas/config.schema.js';
+
+function fixtureHarness(): HarnessConfig {
+  return HarnessConfigSchema.parse({
+    maxPagesToScan: 4,
+    maxDepth: 2,
+    minPagesForConfidence: 1,
+    timeoutMs: 30000,
+    retryCount: 0,
+    llmTokenBudget: 1024,
+    testGenerationLimit: 1,
+    enableLlmScenarios: false,
+    readOnlyMode: true,
+    requireHumanReview: false,
+    failOnConsoleError: false,
+    explorer: 'playwright',
+    defaultAdapter: 'playwright',
+    adapters: ['playwright'],
+  });
+}
+
+test('Fixture smoke tests', async (t) => {
+  let handle: FixtureServerHandle | undefined;
+
+  t.before(async () => {
+    handle = await startFixtureServer();
+  });
+
+  t.after(async () => {
+    if (handle) await handle.close();
+  });
+
+  await t.test('public fixture: status is complete or partial, coverageScore non-null', async () => {
+    assert.ok(handle, 'fixture server must be started');
+    const result = await analyzeApp({
+      url: `${handle.baseUrl}/`,
+      config: fixtureHarness(),
+      writeArtifacts: false,
+    });
+
+    assert.ok(
+      result.status === 'complete' || result.status === 'partial',
+      `expected status complete|partial, got ${result.status}`
+    );
+    assert.ok(result.coverageScore !== null, 'coverageScore must not be null');
+    assert.ok(result.coverageScore > 0, `coverageScore must be > 0, got ${result.coverageScore}`);
+    assert.ok(result.publicSurface !== null, 'publicSurface must not be null');
+    assert.ok(Array.isArray(result.gaps), 'gaps must be an array');
+  });
+
+  await t.test('auth-wall fixture: detectedAuth.detected is true', async () => {
+    assert.ok(handle, 'fixture server must be started');
+    const result = await analyzeApp({
+      url: `${handle.baseUrl}/auth`,
+      config: fixtureHarness(),
+      writeArtifacts: false,
+    });
+
+    assert.ok(
+      result.status === 'blocked' || result.status === 'partial',
+      `expected status blocked|partial, got ${result.status}`
+    );
+    assert.equal(result.detectedAuth?.hasAuth, true, 'expected detectedAuth.hasAuth === true');
+    assert.ok(
+      Array.isArray(result.detectedAuth?.authOptions) && result.detectedAuth.authOptions.length > 0,
+      'expected at least one detected authOption'
+    );
+  });
+
+  await t.test('broken fixture: at least one gap surfaced', async () => {
+    assert.ok(handle, 'fixture server must be started');
+    const result = await analyzeApp({
+      url: `${handle.baseUrl}/broken`,
+      config: fixtureHarness(),
+      writeArtifacts: false,
+    });
+
+    assert.ok(result.gaps.length > 0, 'expected at least one gap from the broken fixture');
+  });
+});

--- a/packages/core/src/__tests__/fixture-server.ts
+++ b/packages/core/src/__tests__/fixture-server.ts
@@ -1,0 +1,166 @@
+/**
+ * Deterministic Node.js fixture server for offline Qulib integration tests.
+ *
+ * Serves the static HTML files in `packages/core/fixtures/` over loopback so
+ * the test suite never depends on a live website. Used by
+ * `analyze.fixtures.test.ts` and any future offline integration coverage.
+ *
+ * Never imported by product code. Helpers are private to this module; only
+ * `startFixtureServer` and `FixtureServerHandle` are exported.
+ */
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface FixtureServerHandle {
+  baseUrl: string;
+  close: () => Promise<void>;
+}
+
+const HTML_CONTENT_TYPE = 'text/html; charset=utf-8';
+const TEXT_CONTENT_TYPE = 'text/plain; charset=utf-8';
+
+function resolveFixturesDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '../../fixtures');
+}
+
+function routeToFile(pathname: string): string | null {
+  if (pathname.includes('..')) return null;
+
+  const fixturesDir = resolveFixturesDir();
+
+  if (pathname === '/' || pathname === '/index.html') {
+    return join(fixturesDir, 'public/index.html');
+  }
+  if (pathname === '/about') {
+    return join(fixturesDir, 'public/about.html');
+  }
+  if (pathname === '/features') {
+    return join(fixturesDir, 'public/features.html');
+  }
+  if (pathname === '/docs') {
+    return join(fixturesDir, 'public/index.html');
+  }
+  if (pathname === '/auth') {
+    return join(fixturesDir, 'auth-wall/index.html');
+  }
+  if (pathname === '/authenticated' || pathname.startsWith('/authenticated/')) {
+    return join(fixturesDir, 'authenticated/index.html');
+  }
+  if (pathname === '/broken') {
+    return join(fixturesDir, 'broken/index.html');
+  }
+  return null;
+}
+
+async function readFixture(filePath: string): Promise<Buffer> {
+  return readFile(filePath);
+}
+
+function respond(
+  res: ServerResponse,
+  status: number,
+  body: Buffer | string,
+  contentType: string
+): void {
+  const buf = typeof body === 'string' ? Buffer.from(body, 'utf8') : body;
+  res.writeHead(status, {
+    'Content-Type': contentType,
+    'Content-Length': buf.length,
+    'Cache-Control': 'no-store',
+  });
+  res.end(buf);
+}
+
+function respondNotFound(res: ServerResponse): void {
+  respond(res, 404, 'Not found', TEXT_CONTENT_TYPE);
+}
+
+function respondServerError(res: ServerResponse, message: string): void {
+  respond(res, 500, `Fixture server error: ${message}`, TEXT_CONTENT_TYPE);
+}
+
+function respondMethodNotAllowed(res: ServerResponse): void {
+  res.writeHead(405, {
+    Allow: 'GET',
+    'Content-Type': TEXT_CONTENT_TYPE,
+    'Cache-Control': 'no-store',
+  });
+  res.end('Method Not Allowed');
+}
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  try {
+    if (req.method !== 'GET') {
+      respondMethodNotAllowed(res);
+      return;
+    }
+
+    const rawUrl = req.url ?? '/';
+    let pathname: string;
+    try {
+      pathname = new URL(rawUrl, 'http://127.0.0.1').pathname;
+    } catch {
+      respondNotFound(res);
+      return;
+    }
+
+    const filePath = routeToFile(pathname);
+    if (filePath === null) {
+      respondNotFound(res);
+      return;
+    }
+
+    const body = await readFixture(filePath);
+    respond(res, 200, body, HTML_CONTENT_TYPE);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    respondServerError(res, message);
+  }
+}
+
+export async function startFixtureServer(): Promise<FixtureServerHandle> {
+  const fixturesDir = resolveFixturesDir();
+  try {
+    const s = await stat(fixturesDir);
+    if (!s.isDirectory()) {
+      throw new Error(`fixtures path is not a directory: ${fixturesDir}`);
+    }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`Fixture directory not found at ${fixturesDir}: ${detail}`);
+  }
+
+  const server = createServer((req, res) => {
+    void handleRequest(req, res);
+  });
+
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    server.once('error', rejectPromise);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', rejectPromise);
+      resolvePromise();
+    });
+  });
+
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    server.close();
+    throw new Error('Fixture server did not return a usable address after listen');
+  }
+
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  return {
+    baseUrl,
+    close: () =>
+      new Promise<void>((resolvePromise, rejectPromise) => {
+        server.close((err) => {
+          if (err) rejectPromise(err);
+          else resolvePromise();
+        });
+      }),
+  };
+}


### PR DESCRIPTION
## Summary

First PR of the v0.5.0 "Runtime QA Intelligence Baseline" series. Adds an offline foundation so integration tests stop depending on live websites.

- **6 HTML fixture files** under `packages/core/fixtures/` — public multi-page site, OAuth auth-wall, authenticated dashboard, and an intentionally broken page (dead link, missing `alt`, `console.error`).
- **Deterministic Node.js fixture server** (`src/__tests__/fixture-server.ts`) — `http.createServer` on port `0` / `127.0.0.1`, explicit route table, directory-traversal rejection, 405 for non-GET. Only `startFixtureServer` and `FixtureServerHandle` are exported.
- **3 smoke tests** (`src/__tests__/analyze.fixtures.test.ts`) that run `analyzeApp` against the local fixture server:
  1. **Public fixture:** `status` is `complete` or `partial`, `coverageScore > 0`, `publicSurface` non-null.
  2. **Auth-wall fixture:** `detectedAuth.hasAuth === true`, at least one `authOption` detected.
  3. **Broken fixture:** at least one gap surfaced (broken link, console error, or a11y violation).
- **New CI job** `fixture-tests` (offline, Playwright + Chromium, 5-min timeout). Existing 3 CI jobs untouched.

### What does NOT change

- No product code edits (`src/analyze.ts`, schemas, reporters, tools, CLI).
- No `packages/mcp/` changes.
- No new dependencies.
- No public API changes.
- No docs changes (docs are PR 4 of v0.5.0).
- Fixtures are under `packages/core/fixtures/`, which is not in the `files` array — they don't ship to npm.

## Test plan

- [x] `npm run build` — passes (`tsc` clean)
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 70/70 pass (66 existing + 1 storage-state-invalid + 3 new fixture tests)
- [x] All 3 fixture tests run unconditionally — no env-gated skips

## Deferred items (not in this PR)

- `failOnConsoleError: false` in fixture harness — PR 3 should consider surfacing guidance when this is false and the broken fixture would have caught an error.
- Fixture for `storage-state` flow (authenticated + valid storage state) — requires wiring a mock storage state into the fixture server, belongs in a follow-up.
- Docs/README updates — PR 4 of v0.5.0.


Made with [Cursor](https://cursor.com)