### PR TITLE
fix: Claude 4 LLM scenario generation (fence strip, model, skip-auth)

### DIFF
--- a/packages/core/qulib.config.ts
+++ b/packages/core/qulib.config.ts
@@ -7,8 +7,9 @@ const config: HarnessConfig = {
   timeoutMs: 30000,
   retryCount: 2,
   llmTokenBudget: 4000,
-  // llmMaxOutputTokensPerCall: 2048,
-  // enableLlmScenarios: true,
+  llmMaxOutputTokensPerCall: 8192,
+  // enableLlmScenarios: true, // set to true + add ANTHROPIC_API_KEY to enable LLM scenarios
+  // llmModel: 'claude-sonnet-4-5-20250929', // override the provider default — see available models in your Anthropic console
   testGenerationLimit: 10,
   readOnlyMode: true,
   requireHumanReview: true,

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -108,6 +108,7 @@ async function runAnalyze(options: {
   repo?: string;
   configFile?: string;
   ephemeral?: boolean;
+  skipAuthDetection?: boolean;
   authStorageState?: string;
   authFormLogin?: boolean;
   loginUrl?: string;
@@ -136,6 +137,7 @@ async function runAnalyze(options: {
     repoPath: options.repo,
     config,
     writeArtifacts,
+    skipAuthDetection: options.skipAuthDetection,
   });
 
   if (ephemeral) {
@@ -213,6 +215,7 @@ program
     'playwright'
   )
   .option('--ephemeral', 'Do not write to disk — return full report as JSON on stdout (use for MCP/CI)', false)
+  .option('--skip-auth-detection', 'Crawl the public surface even if auth is detected (useful for sites with sign-in CTAs on public pages)', false)
   .option(
     '--auth-storage-state <path>',
     'Path to a storage state JSON file (use after `qulib auth init`)'
@@ -238,6 +241,7 @@ program
       repo: options.repo,
       configFile: options.config,
       ephemeral: options.ephemeral,
+      skipAuthDetection: Boolean(options.skipAuthDetection),
       authStorageState: options.authStorageState,
       authFormLogin,
       loginUrl,

--- a/packages/core/src/llm/providers/anthropic.ts
+++ b/packages/core/src/llm/providers/anthropic.ts
@@ -2,7 +2,7 @@ import type { LlmCallResult, LlmProvider } from '../provider.interface.js';
 import type { TelemetrySink } from '../../telemetry/telemetry.interface.js';
 import { emitTelemetry } from '../../telemetry/emit.js';
 
-const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
 
 function estimateTokensFromChars(chars: number): number {
   return Math.max(0, Math.ceil(chars / 4));

--- a/packages/core/src/phases/think-finalize.ts
+++ b/packages/core/src/phases/think-finalize.ts
@@ -104,7 +104,13 @@ export async function finalizeGapAnalysisFromDraft(
             : undefined,
       });
       try {
-        const parsed = JSON.parse(llmResult.text) as unknown;
+        // Claude 4 models wrap JSON in markdown fences despite instructions.
+        // Strip ```json ... ``` or ``` ... ``` before parsing.
+        const rawText = llmResult.text.trim();
+        const stripped = rawText.replace(/^```(?:json)?\s*\n?/i, '').replace(/\n?```\s*$/i, '').trim();
+        // Also handle models that embed the array mid-prose — grab first [...] block
+        const jsonText = stripped.startsWith('[') ? stripped : (stripped.match(/\[[\s\S]*\]/)?.[0] ?? stripped);
+        const parsed = JSON.parse(jsonText) as unknown;
         const candidates = Array.isArray(parsed) ? parsed : [];
 
         for (const item of candidates) {


### PR DESCRIPTION
## Problem

Three compounding failures blocked end-to-end LLM scenario generation on Claude 4 API keys:

1. **Model 404** — \`claude-sonnet-4-20250514\` not found. Claude 4 keys have no Claude 3.x access and the naming convention changed.
2. **JSON parse failure** — Claude 4 wraps all responses in \` \`\`\`json \`\`\` \` fences. \`JSON.parse\` threw on every call, silently falling back to templates every run.
3. **False auth detection** — Sites with public CTAs (e.g. "Launch →") misidentified as auth walls, blocking the crawler at 0 pages.

## Fixes

| File | Change |
|---|---|
| \`src/llm/providers/anthropic.ts\` | \`DEFAULT_MODEL\` → \`claude-haiku-4-5-20251001\` |
| \`src/phases/think-finalize.ts\` | Strip \` \`\`\`json \`\`\` \` fences + extract \`[...]\` block before \`JSON.parse\` |
| \`src/cli/index.ts\` | \`--skip-auth-detection\` flag → \`analyzeApp({ skipAuthDetection })\` |
| \`qulib.config.ts\` | \`llmMaxOutputTokensPerCall: 8192\` (prevents JSON truncation) |

## Verified against notquality.com

- \`provider: "anthropic"\`, \`dataQuality: "actual"\` ✓
- \`outputTokens: 1797\`, \`budgetWarnings: []\` ✓
- \`deterministicMaturity: L2\` — up from L1 template fallback ✓
- 5 LLM-generated scenarios with WCAG-specific descriptions and real selectors ✓

Made with [Cursor](https://cursor.com)