### PR TITLE
feat(ci): offline fixture CLI smoke + unit-tests job (v0.5.0 PR 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,30 +31,21 @@ jobs:
           npx tsc --noEmit -p packages/mcp/tsconfig.json
 
   smoke-test-cli:
-    name: Smoke test CLI
+    name: CLI smoke (offline fixture)
     runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
-      - name: Build
-        run: npm run build
-
-      - name: Run analyze on example.com (ephemeral)
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run build
+      - name: CLI smoke against local fixture
         working-directory: packages/core
-        run: node bin/qulib.js analyze --url https://example.com --ephemeral
+        run: node --import tsx/esm src/__tests__/cli-smoke-fixture.ts
         timeout-minutes: 3
 
   fixture-tests:
@@ -80,6 +71,23 @@ jobs:
         working-directory: packages/core
         run: node --import tsx/esm --test src/__tests__/analyze.fixtures.test.ts
         timeout-minutes: 5
+
+  unit-tests:
+    name: Unit + fixture tests
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run all tests
+        working-directory: packages/core
+        run: npm test
+        timeout-minutes: 8
 
   publish-check:
     name: Verify packages are publishable

--- a/packages/core/src/__tests__/cli-smoke-fixture.ts
+++ b/packages/core/src/__tests__/cli-smoke-fixture.ts
@@ -1,0 +1,73 @@
+/**
+ * Offline CLI smoke: spawn `node bin/qulib.js analyze --url <fixture>` against
+ * the local fixture server and assert the CLI exited 0. Runnable script (not a
+ * node:test file) — invoked in CI by `node --import tsx/esm src/__tests__/cli-smoke-fixture.ts`.
+ *
+ * Removes the live `https://example.com` dependency from CI's smoke-test-cli job.
+ *
+ * The fixture server runs in this process; the CLI is spawned as a child. We use
+ * async `spawn` (not `spawnSync`) so the parent event loop stays free to serve
+ * the child's HTTP requests against the fixture.
+ */
+import { spawn } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startFixtureServer } from './fixture-server.js';
+
+interface CliResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const cliPath = resolve(__dir, '../../bin/qulib.js');
+
+function runCli(url: string): Promise<CliResult> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn('node', [cliPath, 'analyze', '--url', url, '--ephemeral'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      rejectPromise(new Error('CLI smoke timed out after 120s'));
+    }, 120_000);
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      rejectPromise(err);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolvePromise({
+        exitCode: code ?? -1,
+        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf8'),
+      });
+    });
+  });
+}
+
+function assertCliPassed(result: CliResult): void {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `CLI exited with code ${result.exitCode}\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+    );
+  }
+}
+
+const handle = await startFixtureServer();
+try {
+  const result = await runCli(`${handle.baseUrl}/`);
+  assertCliPassed(result);
+  console.log('[cli-smoke] ✔ CLI exited 0 against fixture public surface');
+} finally {
+  await handle.close();
+}


### PR DESCRIPTION
## Summary

This PR is **v0.5.0 PR 2** in the train. It removes live-site dependency from CI smoke coverage by switching the CLI smoke check to the local fixture server introduced in PR 1, and adds an explicit unit+fixture test job.

## Why

The previous CI smoke path called:

- `node bin/qulib.js analyze --url https://example.com --ephemeral`

That introduces external network risk (DNS, transient failures, unrelated content shifts) into CI signal. For deterministic CI, smoke checks should run against repo-owned fixtures.

## Changes

### 1) New offline CLI smoke runner

File: `packages/core/src/__tests__/cli-smoke-fixture.ts`

- Starts the local fixture server (`startFixtureServer()`)
- Spawns CLI as a child process:
  - `node bin/qulib.js analyze --url <fixture-base>/ --ephemeral`
- Asserts exit code `0`; if non-zero, throws with full stdout/stderr payload
- Always closes fixture server in `finally`

Implementation detail:
- Uses async `spawn` (not `spawnSync`) so the parent event loop remains available to serve fixture HTTP traffic while the child CLI runs.

### 2) CI workflow updates

File: `.github/workflows/ci.yml`

- Replaces `smoke-test-cli` run target from live `https://example.com` to local fixture script:
  - `node --import tsx/esm src/__tests__/cli-smoke-fixture.ts`
- Adds new job `unit-tests`:
  - installs deps + Playwright Chromium
  - runs full `npm test` in `packages/core`

### 3) Scope boundaries kept

- No analyzer/schema/reporter logic changes
- No package dependency changes
- No `packages/mcp` source changes

## Validation

Local run completed before PR creation:

- `npm run build` ✅
- `node --import tsx/esm src/__tests__/cli-smoke-fixture.ts` ✅
- `npm test` (`packages/core`) ✅ `70/70`

## Risk / rollback

- Low risk: CI-only + test infrastructure changes
- Rollback is straightforward: restore previous `smoke-test-cli` block and remove `unit-tests`

## Follow-up

PR 3 adds guidance-carrying SKIP semantics for automation maturity dimensions and MCP summarization.