### PR TITLE
feat(core): SKIP semantics with guidance on not_applicable dimensions (v0.5.0 PR 3)

### DIFF
--- a/packages/core/src/schemas/automation-maturity.schema.ts
+++ b/packages/core/src/schemas/automation-maturity.schema.ts
@@ -40,6 +40,7 @@ export const AutomationMaturityDimensionSchema = z.object({
   recommendations: z.array(z.string()),
   applicability: AutomationMaturityApplicabilitySchema.optional(),
   reason: z.string().optional(),
+  guidance: z.string().optional(),
 });
 
 export const AutomationMaturitySchema = z.object({

--- a/packages/core/src/tools/scoring/__tests__/automation-maturity.test.ts
+++ b/packages/core/src/tools/scoring/__tests__/automation-maturity.test.ts
@@ -151,3 +151,30 @@ test('scoreFormula is documented on the result', () => {
   assert.ok(maturity.scoreFormula, 'scoreFormula present');
   assert.match(maturity.scoreFormula!, /applicable/i);
 });
+
+test('not_applicable dimensions carry a non-empty guidance string', () => {
+  const maturity = computeAutomationMaturity(baseRepo());
+  const naDims = maturity.dimensions.filter((d) => d.applicability === 'not_applicable');
+  assert.ok(naDims.length > 0, 'baseRepo() should produce at least one not_applicable dimension');
+  for (const d of naDims) {
+    assert.ok(
+      typeof d.guidance === 'string' && d.guidance.length > 0,
+      `dimension ${d.dimension} (not_applicable) must carry guidance, got: ${JSON.stringify(d.guidance)}`
+    );
+  }
+});
+
+test('guidance text is actionable', () => {
+  const maturity = computeAutomationMaturity(baseRepo());
+  const dimsWithGuidance = maturity.dimensions.filter(
+    (d) => typeof d.guidance === 'string' && d.guidance.length > 0
+  );
+  assert.ok(dimsWithGuidance.length > 0, 'expected at least one dimension to carry guidance');
+  for (const d of dimsWithGuidance) {
+    const g = d.guidance!;
+    assert.ok(
+      g.includes('Add') || g.includes('Run') || g.includes('No'),
+      `guidance for ${d.dimension} should include actionable verb (Add/Run/No), got: ${g}`
+    );
+  }
+});

--- a/packages/core/src/tools/scoring/automation-maturity.ts
+++ b/packages/core/src/tools/scoring/automation-maturity.ts
@@ -110,10 +110,13 @@ export function computeAutomationMaturity(repo: RepoAnalysis): AutomationMaturit
   let hygieneScore = 0;
   let hygieneApplicability: AutomationMaturityApplicability = 'applicable';
   let hygieneReason: string | undefined;
+  let hygieneGuidance: string | undefined;
   const hygieneEvidence: string[] = [];
   if (interactiveTsxScanned === 0) {
     hygieneApplicability = 'unknown';
     hygieneReason = 'No interactive TSX files scanned — cannot compute a missing-id ratio honestly.';
+    hygieneGuidance =
+      'Qulib could not collect enough signal to score this dimension. Run against a repo with more test files or a larger page scan to improve signal.';
     hygieneEvidence.push(hygieneReason);
   } else {
     const missingRatio = missingIds / interactiveTsxScanned;
@@ -133,6 +136,7 @@ export function computeAutomationMaturity(repo: RepoAnalysis): AutomationMaturit
         : [],
     applicability: hygieneApplicability,
     ...(hygieneReason && { reason: hygieneReason }),
+    ...(hygieneGuidance && { guidance: hygieneGuidance }),
   };
 
   const ci = hasCiAtRoot(repo.repoPath);
@@ -153,10 +157,13 @@ export function computeAutomationMaturity(repo: RepoAnalysis): AutomationMaturit
   let authScore = 0;
   let authApplicability: AutomationMaturityApplicability = 'applicable';
   let authReason: string | undefined;
+  let authGuidance: string | undefined;
   const authEvidence: string[] = [];
   if (!repoHasAnyAuthSignal) {
     authApplicability = 'not_applicable';
     authReason = 'No auth routes, auth-named test files, or auth path coverage detected — repo appears auth-free.';
+    authGuidance =
+      'No auth signal detected in this app. If authentication exists, run qulib with a storage-state file to enable auth-test-coverage scoring.';
     authEvidence.push(authReason);
   } else {
     authScore = authCovered ? 90 : 25;
@@ -177,6 +184,7 @@ export function computeAutomationMaturity(repo: RepoAnalysis): AutomationMaturit
         : [],
     applicability: authApplicability,
     ...(authReason && { reason: authReason }),
+    ...(authGuidance && { guidance: authGuidance }),
   };
 
   const cypressE2e = repo.testFiles.filter((t) => t.type === 'cypress-e2e').length;
@@ -185,10 +193,13 @@ export function computeAutomationMaturity(repo: RepoAnalysis): AutomationMaturit
   let compRatioScore = 0;
   let compApplicability: AutomationMaturityApplicability = 'applicable';
   let compReason: string | undefined;
+  let compGuidance: string | undefined;
   const compEvidence: string[] = [];
   if (cypressTotal === 0) {
     compApplicability = 'not_applicable';
     compReason = 'No Cypress (e2e or component) tests detected — component-test-ratio does not apply.';
+    compGuidance =
+      'No Cypress component test setup detected. Add cypress/component/ tests and a component config to enable this dimension.';
     compEvidence.push(compReason);
   } else {
     compRatioScore = Math.round((100 * cypressComp) / cypressTotal);
@@ -205,6 +216,7 @@ export function computeAutomationMaturity(repo: RepoAnalysis): AutomationMaturit
         : [],
     applicability: compApplicability,
     ...(compReason && { reason: compReason }),
+    ...(compGuidance && { guidance: compGuidance }),
   };
 
   const dimensions = [breadthDim, frameworkDim, hygieneDim, ciDim, authDim, compDim];

--- a/packages/mcp/src/__tests__/summarize-analyze-result.test.ts
+++ b/packages/mcp/src/__tests__/summarize-analyze-result.test.ts
@@ -157,6 +157,74 @@ test('summarizeAnalyzeResult replaces repoInventory with a bounded repoInventory
   assert.ok(!serialized.includes('comp-0.tsx'), 'missingTestIds array must not leak into compact payload');
 });
 
+test('summarizeAnalyzeResult includes maturity dimensions with applicability and guidance', () => {
+  const r = minimalResult();
+  r.repoInventory = {
+    scannedAt: new Date().toISOString(),
+    repoPath: '/tmp/repo',
+    routes: [],
+    testFiles: [],
+    missingTestIds: [],
+    cypressStructure: {
+      detected: false,
+      hasCommandsFile: false,
+      existingE2eFiles: [],
+      existingComponentFiles: [],
+    },
+    automationMaturity: {
+      computedAt: new Date().toISOString(),
+      repoPath: '/tmp/repo',
+      overallScore: 30,
+      level: 2,
+      label: 'L2 — emerging coverage',
+      dimensions: [
+        {
+          dimension: 'component-test-ratio',
+          score: 0,
+          weight: 0.08,
+          evidence: ['no cypress'],
+          recommendations: [],
+          applicability: 'not_applicable',
+          reason: 'No Cypress (e2e or component) tests detected.',
+          guidance: 'No Cypress component test setup detected. Add cypress/component/ tests and a component config to enable this dimension.',
+        },
+        {
+          dimension: 'test-coverage-breadth',
+          score: 80,
+          weight: 0.28,
+          evidence: ['8/10 routes covered'],
+          recommendations: [],
+          applicability: 'applicable',
+        },
+      ],
+      topRecommendations: [],
+      scoreFormula: 'overallScore = ...',
+    },
+  };
+  const out = summarizeAnalyzeResult(r, false) as {
+    automationMaturitySummary?: {
+      dimensions: Array<{ dimension: string; applicability: string; guidance?: string }>;
+    };
+  };
+
+  const summary = out.automationMaturitySummary;
+  assert.ok(summary, 'automationMaturitySummary should be present');
+  assert.ok(Array.isArray(summary.dimensions), 'dimensions array should be present');
+
+  const compDim = summary.dimensions.find((d) => d.dimension === 'component-test-ratio');
+  assert.ok(compDim, 'component-test-ratio dimension should be in summary');
+  assert.equal(compDim.applicability, 'not_applicable');
+  assert.ok(
+    typeof compDim.guidance === 'string' && compDim.guidance.length > 0,
+    'guidance should be carried through to the summary'
+  );
+
+  const breadthDim = summary.dimensions.find((d) => d.dimension === 'test-coverage-breadth');
+  assert.ok(breadthDim, 'test-coverage-breadth dimension should be in summary');
+  assert.equal(breadthDim.applicability, 'applicable');
+  assert.equal(breadthDim.guidance, undefined, 'applicable dimension without guidance should omit the field');
+});
+
 test('summarizeAnalyzeResult returns the full repoInventory when includeFullReport is true', () => {
   const r = minimalResult();
   r.repoInventory = {

--- a/packages/mcp/src/summarize-analyze-result.ts
+++ b/packages/mcp/src/summarize-analyze-result.ts
@@ -113,6 +113,12 @@ export function summarizeAnalyzeResult(result: AnalyzeResult, includeFullReport:
         level: repo.automationMaturity.level,
         label: repo.automationMaturity.label,
         topRecommendations: repo.automationMaturity.topRecommendations,
+        dimensions: repo.automationMaturity.dimensions.map((d) => ({
+          dimension: d.dimension,
+          score: d.score,
+          applicability: d.applicability ?? 'applicable',
+          ...(d.guidance !== undefined && { guidance: d.guidance }),
+        })),
       },
     }),
     repoInventorySummary,


### PR DESCRIPTION
## Summary

This PR is **v0.5.0 PR 3** in the train. It upgrades automation maturity SKIP semantics from "not scored" to **actionable guidance**, then surfaces that guidance through MCP compact summaries.

## Why

Qulib already marks dimensions as `not_applicable` / `unknown`, but consumers still had to infer next steps from scattered reasoning text. This PR makes those paths explicit and structured.

## Changes

### 1) Additive schema extension

File: `packages/core/src/schemas/automation-maturity.schema.ts`

- `AutomationMaturityDimensionSchema` now includes:
  - `guidance?: string`

This is additive and optional, so existing consumers remain compatible.

### 2) Populate guidance in scoring engine

File: `packages/core/src/tools/scoring/automation-maturity.ts`

Added guidance strings at every current non-applicable / unknown site:

- `test-id-hygiene` (`unknown`):
  - "Qulib could not collect enough signal..."
- `auth-test-coverage` (`not_applicable`):
  - "No auth signal detected... run with storage-state if auth exists..."
- `component-test-ratio` (`not_applicable`):
  - "No Cypress component test setup detected..."

### 3) Surface guidance in MCP compact output

File: `packages/mcp/src/summarize-analyze-result.ts`

`automationMaturitySummary` now includes:

- `dimensions: [{ dimension, score, applicability, guidance? }]`

This keeps summary payload compact while exposing precise UI hints for SKIP/unknown dimensions.

## Tests

### Core tests
File: `packages/core/src/tools/scoring/__tests__/automation-maturity.test.ts`

Added assertions that:

1. `not_applicable` dimensions carry non-empty `guidance`
2. guidance text is actionable (`Add` / `Run` / `No`)

### MCP tests
File: `packages/mcp/src/__tests__/summarize-analyze-result.test.ts`

Added case verifying compact summary includes dimension applicability and carries guidance for `not_applicable`, while omitting it when undefined.

## Validation

- `npm run build` ✅
- `packages/core npm test` ✅ `72/72`
- `packages/mcp npm test` ✅ `7/7`

## Compatibility / risk

- No breaking API changes (optional field only)
- No dependency changes
- Low risk: deterministic scoring metadata + summary shaping

## Follow-up

PR 4 (docs) will explain these semantics and how to interpret guidance in CLI/MCP workflows.