### PR TITLE
docs: copy-paste examples + scan walkthroughs (v0.5.0 PR 4)

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -277,6 +277,107 @@ npm run analyze -- --url https://example.com --ephemeral > report.bundle.json
 npm run clean
 ```
 
+## Minimum config
+
+Smallest legal `qulib.config.ts`:
+
+```ts
+import type { HarnessConfig } from './src/schemas/config.schema.js';
+
+const config: HarnessConfig = {
+  maxPagesToScan: 20,
+  maxDepth: 3,
+  timeoutMs: 30000,
+};
+
+export default config;
+```
+
+All other fields inherit from schema defaults or CLI/runtime defaults.
+
+## Scan walkthroughs (copy-paste)
+
+### 1) Public scan
+
+```bash
+npx @qulib/core analyze --url https://yourapp.com
+```
+
+### 2) Auth-blocked scan (honest blocked mode)
+
+```bash
+npx @qulib/core analyze --url https://yourapp.com/auth
+```
+
+When auth blocks access and no auth config is supplied, Qulib reports `status: "blocked"` (or `partial` if it could still crawl some public pages). This is intentional honesty, not a failure mode.
+
+### 3) Authenticated scan with storage state
+
+```bash
+# Capture once (manual OAuth/SSO-safe flow)
+qulib auth init --base-url https://yourapp.com
+
+# Reuse saved session
+qulib analyze --url https://yourapp.com --auth-storage-state ./qulib-storage-state.json
+```
+
+## Sample report (fixture baseline)
+
+From the local fixture baseline used in v0.5.0 PR 1/2:
+
+```json
+{
+  "status": "complete",
+  "releaseConfidence": 68,
+  "gaps": [
+    "... 4 total gap items ..."
+  ]
+}
+```
+
+Use these as conservative reference numbers:
+- public fixture (`/`): `releaseConfidence: 68/100`, `gaps: 4`
+- auth-wall fixture (`/auth`): `releaseConfidence: 24/100`, `gaps: 2`
+- broken fixture (`/broken`): `releaseConfidence: 0/100`, `gaps: 6`
+
+## MCP tools quick map
+
+| Tool | When to use | Key input |
+|---|---|---|
+| `analyze_app` | Main QA scan for release confidence + gaps | `url`, optional `auth`, optional LLM knobs |
+| `detect_auth` | Fast single-pass auth pattern guess | `url`, optional `timeoutMs` |
+| `explore_auth` | Deeper auth-path discovery on unfamiliar apps | `url`, optional `timeoutMs` |
+| `qulib_score_automation` | Score local repo automation maturity | absolute `repoPath`, optional `includeFullDimensions` |
+
+## Output directories
+
+Qulib writes runtime artifacts to:
+
+- `.scan-state/` — intermediate state (discovered routes, gap analysis snapshots, decision log)
+- `output/` — final `report.json` and `report.md`
+
+Both are gitignored and safe to delete; Qulib recreates them on the next non-ephemeral run.
+
+## ANTHROPIC_API_KEY (LLM scenarios)
+
+For MCP-hosted usage, set `ANTHROPIC_API_KEY` in your host's `env` block:
+
+```json
+{
+  "mcpServers": {
+    "qulib": {
+      "command": "npx",
+      "args": ["@qulib/mcp"],
+      "env": {
+        "ANTHROPIC_API_KEY": "sk-ant-..."
+      }
+    }
+  }
+}
+```
+
+Without this key, Qulib still runs deterministic checks (crawl, a11y, links, console, scoring) and falls back to template scenarios instead of LLM-generated ones.
+
 ## Playwright browsers
 
 ```bash

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -24,6 +24,25 @@ To enable LLM-powered scenario generation, add your Anthropic API key to the
 Without this key, qulib still runs but uses built-in template scenarios only.
 Your key is never stored by qulib — it is read from your local config at runtime.
 
+After updating this config, restart your MCP host (Claude Desktop / Claude Code / Cursor) so the new environment variables are picked up.
+
+For verbose server-side stderr logs while troubleshooting host wiring, add:
+
+```json
+{
+  "mcpServers": {
+    "qulib": {
+      "command": "npx",
+      "args": ["@qulib/mcp"],
+      "env": {
+        "ANTHROPIC_API_KEY": "sk-ant-...",
+        "QULIB_DEBUG": "1"
+      }
+    }
+  }
+}
+```
+
 ## What it does
 
 Tools:


### PR DESCRIPTION
## Summary

This PR is **v0.5.0 PR 4** in the train. It focuses on contributor and user clarity with copy-paste-ready docs, using fixture-based numbers from PR 1/2 and the project principle from `CLAUDE.md`: output must be honest.

No code changes. Docs-only.

## What changed

### `packages/core/README.md`

Added a practical onboarding block after Usage examples:

1. **Minimum config**
   - Smallest legal `qulib.config.ts` with 3 required fields
   - Explicit note that remaining fields come from defaults

2. **Three scan walkthroughs**
   - Public scan
   - Auth-blocked scan (explains `blocked` / `partial` as honest reporting)
   - Authenticated scan (`auth init` then `--auth-storage-state`)

3. **Sample report + fixture baseline values**
   - Public fixture: RC `68/100`, gaps `4`
   - Auth-wall fixture: RC `24/100`, gaps `2`
   - Broken fixture: RC `0/100`, gaps `6`

4. **MCP tool quick map**
   - `analyze_app`, `detect_auth`, `explore_auth`, `qulib_score_automation`
   - Includes when-to-use and key input focus for each

5. **Output directory behavior**
   - `.scan-state/` and `output/`
   - Both gitignored, both safe to delete, recreated on next run

6. **`ANTHROPIC_API_KEY` setup note**
   - Host `env` block example for MCP setups
   - Clarifies deterministic checks still run without key (template scenarios)

### `packages/mcp/README.md`

Expanded setup/troubleshooting guidance:

- Explicitly tells users to restart MCP host after env changes
- Adds `QULIB_DEBUG=1` example in MCP server env block for verbose stderr debugging

## Why this improves quality

- Makes first-run path actually copy-pasteable
- Sets realistic expectations with fixture-grounded reference numbers
- Reduces confusion around auth-blocked output by explicitly framing it as honest reporting
- Shortens MCP onboarding and env troubleshooting loops

## Scope boundaries respected

- No changes to analyzer logic
- No schema changes
- No CLI flag/tooling changes
- No MCP server implementation changes

## Follow-up

PR 5 (`chore/release-0.5.0`) will bump versions + changelog after this docs PR merges.

Made with [Cursor](https://cursor.com)