### PR TITLE
chore: release v0.5.0 — Runtime QA Intelligence Baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Entries for **0.3.1 and earlier** were reconstructed from git tags (`v0.1.1` … `v0.2.2`) and release commits on `main`.
 
+## [0.5.0] — 2026-05-14
+
+### Added
+
+- **PR #30** — local HTML fixtures + deterministic fixture server for offline integration baselines (`packages/core/fixtures/*`, `fixture-server.ts`, `analyze.fixtures.test.ts`).
+- **PR #32** — offline CI smoke path using fixtures (`cli-smoke-fixture.ts`) plus a dedicated unit+fixture test job.
+- **PR #33** — SKIP semantics now include actionable guidance on non-applicable/unknown automation maturity dimensions, with guidance surfaced in MCP compact summaries.
+- **PR #31** — Claude 4 LLM scenario generation hardening: model default update, markdown fence stripping before JSON parse, and `--skip-auth-detection` CLI option.
+
+### Changed
+
+- `smoke-test-cli` CI workflow now runs offline against the local fixture server instead of a live `https://example.com` dependency.
+- Core and MCP docs now include copy-paste walkthroughs for public/auth-blocked/authenticated flows, MCP tool mapping, and host env setup/troubleshooting.
+
+### Fixed
+
+- LLM scenario generation no longer fails silently on Claude 4 API keys due to a stale default model and fenced JSON parse path.
+
+### Internal
+
+- v0.5.0 **Runtime QA Intelligence Baseline** — Phase 1 complete.
+
 ## [0.4.3] — 2026-05-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -2029,7 +2029,7 @@
     },
     "packages/core": {
       "name": "@qulib/core",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "^4.9.0",
@@ -2049,11 +2049,11 @@
     },
     "packages/mcp": {
       "name": "@qulib/mcp",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@qulib/core": "0.4.3",
+        "@qulib/core": "0.5.0",
         "zod": "^3.23.0"
       },
       "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/core",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Qulib — analyze deployed web apps for honest quality gaps (CLI + programmatic API)",
   "license": "MIT",
   "author": "Tapesh Nagarwal",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/mcp",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "MCP server for Qulib — AI-callable QA gap analysis",
   "license": "MIT",
   "author": "Tapesh Nagarwal",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@qulib/core": "0.4.3",
+    "@qulib/core": "0.5.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## v0.5.0 — Runtime QA Intelligence Baseline

This PR is the release wrapper after the v0.5.0 PR train merged:

- PR #30 — local fixture server + offline smoke fixtures
- PR #31 — Claude 4 LLM scenario generation fixes (model, fence-strip, skip-auth)
- PR #32 — offline CLI smoke + unit-test CI job
- PR #33 — SKIP semantics guidance + MCP summary dimensions
- PR #34 — docs walkthroughs and copy-paste examples

## Packages

- `@qulib/core@0.5.0`
- `@qulib/mcp@0.5.0`

## Release changes in this PR

- Bump `packages/core/package.json` version to `0.5.0`
- Bump `packages/mcp/package.json` version to `0.5.0`
- Align `@qulib/core` dependency in `packages/mcp/package.json` to `0.5.0`
- Refresh `package-lock.json` via `npm install`
- Add `CHANGELOG.md` entry:
  - `## [0.5.0] — 2026-05-14`
  - grouped sections: Added / Changed / Fixed / Internal

## Validation run on release branch

- `npm run build` ✅
- `npm publish --dry-run` in `packages/core` ✅ (`@qulib/core@0.5.0`)
- `npm publish --dry-run` in `packages/mcp` ✅ (`@qulib/mcp@0.5.0`)

## After merge (manual publish)

```bash
npm publish -w @qulib/core
npm publish -w @qulib/mcp
```

Then tag and release:

```bash
git tag -a v0.5.0 -m "v0.5.0"
git push origin v0.5.0
gh release create v0.5.0 --title "v0.5.0 — Runtime QA Intelligence Baseline" --notes-file <release-notes-file>
```

Made with [Cursor](https://cursor.com)