### PR TITLE
fix: probe user-local provider buttons for click-to-reveal forms

### DIFF
--- a/packages/core/src/cli/auth-login-resolve.ts
+++ b/packages/core/src/cli/auth-login-resolve.ts
@@ -33,7 +33,7 @@ export function parseCredentialsJsonString(json: string): Record<string, string>
 
 export function resolveFormLoginPath(baseUrl: string, authOptions: AuthPath[] | undefined, authPathId?: string): AuthPath {
   const formPaths = (authOptions ?? []).filter(
-    (o) => o.type === 'form-login' && o.requirements.method === 'credentials'
+    (o) => (o.type === 'form-login' || o.type === 'form-multi') && o.requirements.method === 'credentials'
   );
   if (formPaths.length === 0) {
     throw new Error(

--- a/packages/core/src/cli/auth-login-run.ts
+++ b/packages/core/src/cli/auth-login-run.ts
@@ -22,7 +22,11 @@ function sleep(ms: number): Promise<void> {
 }
 
 export function authPathNeedsClickReveal(path: AuthPath): boolean {
-  return path.type === 'form-login' && path.source === 'heuristic' && !builtInOAuthIds.has(path.id);
+  return (
+    (path.type === 'form-login' || path.type === 'form-multi') &&
+    (path.source === 'heuristic' || path.source === 'user-local') &&
+    !builtInOAuthIds.has(path.id)
+  );
 }
 
 export async function runAutomatedAuthLogin(params: {

--- a/packages/core/src/tools/auth/__tests__/detect.test.ts
+++ b/packages/core/src/tools/auth/__tests__/detect.test.ts
@@ -9,6 +9,9 @@ import {
   preflightStorageStateFile,
   waitForReturnToOrigin,
 } from '../detect.js';
+import { resolveFormLoginPath } from '../../../cli/auth-login-resolve.js';
+import { authPathNeedsClickReveal } from '../../../cli/auth-login-run.js';
+import type { AuthPath } from '../../../schemas/config.schema.js';
 
 test('evaluateStorageStateValidity flags wrong-origin when final URL origin differs from expected', () => {
   const r = evaluateStorageStateValidity({
@@ -256,4 +259,90 @@ test('waitForReturnToOrigin treats subdomain as foreign (strict origin)', async 
   } as unknown as Page;
   const r = await waitForReturnToOrigin(page, 'https://app.example/', 600);
   assert.equal(r.returned, false);
+});
+
+// --- resolveFormLoginPath + authPathNeedsClickReveal tests ---
+
+test('resolveFormLoginPath selects form-multi path when type is form-multi', () => {
+  const option: AuthPath = {
+    id: 'scholastic-sync',
+    label: 'Scholastic Sync',
+    type: 'form-multi',
+    provider: null,
+    source: 'user-local',
+    automatable: true,
+    confidence: 'medium',
+    requirements: {
+      method: 'credentials',
+      fields: [
+        { name: 'username', label: 'Username', type: 'text', observedOptions: [] },
+        { name: 'password', label: 'Password', type: 'password', observedOptions: [] },
+        { name: 'datasource', label: 'District', type: 'select', observedOptions: ['NYC', 'LA'] },
+      ],
+    },
+  };
+  const result = resolveFormLoginPath('https://example.com', [option]);
+  assert.equal(result, option);
+});
+
+test('resolveFormLoginPath rejects form-multi when requirements.method is storage-state', () => {
+  const option: AuthPath = {
+    id: 'sso-form',
+    label: 'SSO Form',
+    type: 'form-multi',
+    provider: null,
+    source: 'heuristic',
+    automatable: false,
+    confidence: 'low',
+    requirements: {
+      method: 'storage-state',
+      instruction: 'Use qulib auth init',
+    },
+  };
+  assert.throws(
+    () => resolveFormLoginPath('https://example.com', [option]),
+    /No automatable form-login path/
+  );
+});
+
+test('authPathNeedsClickReveal returns true for user-local form-login', () => {
+  const path: AuthPath = {
+    id: 'scholastic-sync',
+    label: 'Scholastic Sync',
+    type: 'form-login',
+    provider: null,
+    source: 'user-local',
+    automatable: true,
+    confidence: 'medium',
+    requirements: { method: 'credentials', fields: [] },
+  };
+  assert.equal(authPathNeedsClickReveal(path), true);
+});
+
+test('authPathNeedsClickReveal returns true for user-local form-multi', () => {
+  const path: AuthPath = {
+    id: 'scholastic-sync',
+    label: 'Scholastic Sync',
+    type: 'form-multi',
+    provider: null,
+    source: 'user-local',
+    automatable: true,
+    confidence: 'medium',
+    requirements: { method: 'credentials', fields: [] },
+  };
+  assert.equal(authPathNeedsClickReveal(path), true);
+});
+
+test('authPathNeedsClickReveal returns false for built-in oauth id', () => {
+  const path: AuthPath = {
+    id: 'google',
+    label: 'Sign in with Google',
+    type: 'form-login',
+    provider: 'google',
+    source: 'heuristic',
+    automatable: false,
+    confidence: 'high',
+    requirements: { method: 'credentials', fields: [] },
+  };
+  assert.equal(authPathNeedsClickReveal(path), false);
 });

--- a/packages/core/src/tools/auth/detect.ts
+++ b/packages/core/src/tools/auth/detect.ts
@@ -193,7 +193,7 @@ async function probeClickToRevealForms(
   progress?: AnalyzeProgressSink
 ): Promise<AuthPath[]> {
   const out: AuthPath[] = [];
-  const buttons = page.locator('button');
+  const buttons = page.locator('button, [role="button"]');
   const n = await buttons.count();
   const seenLabels = new Set<string>();
   const SUBMIT_RE = /^(sign in|log in|submit|continue|next|cancel|close)$/i;
@@ -250,8 +250,10 @@ async function probeClickToRevealForms(
       continue;
     }
 
+    await waitNetworkIdleBestEffort(page);
+
     try {
-      await page.locator('input[type="password"]:visible').first().waitFor({ state: 'visible', timeout: 2000 });
+      await page.locator('input[type="password"]:visible').first().waitFor({ state: 'visible', timeout: 5000 });
     } catch {
       await page.goto(loginUrl, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
       await waitNetworkIdleBestEffort(page);

--- a/packages/core/src/tools/auth/explore.ts
+++ b/packages/core/src/tools/auth/explore.ts
@@ -214,6 +214,48 @@ async function buildFormPaths(page: Page): Promise<AuthPath[]> {
   ];
 }
 
+async function probeUserLocalProviderClick(
+  page: Page,
+  providerLabel: string,
+  loginUrl: string,
+  timeoutMs: number
+): Promise<AuthPath[]> {
+  const originBefore = new URL(page.url()).origin;
+  let clicked = false;
+  try {
+    await page.getByRole('button', { name: providerLabel, exact: true }).first().click({ timeout: 3000 });
+    clicked = true;
+  } catch {
+    try {
+      const escaped = providerLabel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      await page
+        .locator('button, [role="button"]')
+        .filter({ hasText: new RegExp(`^\\s*${escaped}\\s*$`, 'i') })
+        .first()
+        .click({ timeout: 3000 });
+      clicked = true;
+    } catch {
+      /* skip */
+    }
+  }
+  if (!clicked) return [];
+
+  try {
+    await page.waitForLoadState('domcontentloaded', { timeout: 5000 });
+  } catch { /* best-effort */ }
+  await waitNetworkIdleBestEffort(page);
+
+  if (new URL(page.url()).origin !== originBefore) {
+    await page.goto(loginUrl, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
+    return [];
+  }
+
+  const formPaths = await buildFormPaths(page);
+  await page.goto(loginUrl, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
+  await waitNetworkIdleBestEffort(page);
+  return formPaths;
+}
+
 export async function exploreAuth(
   url: string,
   timeoutMs = 20000,
@@ -288,6 +330,23 @@ export async function exploreAuth(
           continue;
         }
         consumed.add(id);
+
+        if (p.source === 'user-local') {
+          const probed = await probeUserLocalProviderClick(page, p.label, finalUrl, timeoutMs);
+          if (probed.length > 0) {
+            for (const fp of probed) {
+              authPaths.push({
+                ...fp,
+                id: p.id,
+                label: p.label,
+                source: 'user-local',
+              });
+              progress?.info(`explore_auth path id=${p.id} type=${fp.type} automatable=${fp.automatable} (user-local probe)`);
+            }
+            continue;
+          }
+        }
+
         authPaths.push({
           id,
           label: p.label,


### PR DESCRIPTION
## Summary

Fixes four connected gaps that prevented user-registered custom providers (e.g. "Scholastic Sync") from being detected as automatable form-login paths:

- **detect.ts** `probeClickToRevealForms`: broadened selector to `button, [role="button"]`; added `waitNetworkIdleBestEffort` after origin-check navigation; increased password-wait timeout from 2s → 5s
- **explore.ts**: new `probeUserLocalProviderClick` helper click-probes user-local provider buttons before classifying as non-automatable OAuth; when clicking reveals a form, the path is returned as `automatable: true` with discovered field names and types
- **auth-login-resolve.ts** `resolveFormLoginPath`: now accepts `form-multi` paths (3+ fields such as username/password/district)
- **auth-login-run.ts** `authPathNeedsClickReveal`: extended to handle `user-local` source and `form-multi` type

## Test plan

- [x] 5 new unit tests in `detect.test.ts` covering `resolveFormLoginPath` with form-multi, `authPathNeedsClickReveal` for user-local/form-multi/built-in-oauth
- [x] `npm run build` passes
- [x] `npm test` — all 77 core + 7 MCP tests pass

Made with [Cursor](https://cursor.com)