### PR TITLE
chore: release v0.5.1 — auth probe fix for user-local providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Entries for **0.3.1 and earlier** were reconstructed from git tags (`v0.1.1` … `v0.2.2`) and release commits on `main`.
 
+## [0.5.1] — 2026-05-14
+
+### Fixed
+
+- **@qulib/core:** `detect-auth` now probes `[role="button"]` elements in addition to `<button>` tags, and waits up to 5 s for a password field after navigation (was 2 s), so custom SSO providers that navigate to a dedicated login page are correctly detected.
+- **@qulib/core:** `explore-auth` now click-probes user-local provider buttons (registered via `qulib auth providers add`) before classifying them as non-automatable OAuth. When clicking reveals a form, the path is returned as `automatable: true` with discovered field names and types.
+- **@qulib/core:** `qulib auth login` now accepts `form-multi` paths (3+ fields such as username/password/district) and triggers click-reveal navigation for `user-local` source paths, completing the `qulib auth providers add` → `qulib auth login --auth-path <id>` workflow.
+
 ## [0.5.0] — 2026-05-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -2029,7 +2029,7 @@
     },
     "packages/core": {
       "name": "@qulib/core",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "^4.9.0",
@@ -2049,11 +2049,11 @@
     },
     "packages/mcp": {
       "name": "@qulib/mcp",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@qulib/core": "0.5.0",
+        "@qulib/core": "0.5.1",
         "zod": "^3.23.0"
       },
       "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Qulib — analyze deployed web apps for honest quality gaps (CLI + programmatic API)",
   "license": "MIT",
   "author": "Tapesh Nagarwal",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "MCP server for Qulib — AI-callable QA gap analysis",
   "license": "MIT",
   "author": "Tapesh Nagarwal",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@qulib/core": "0.5.0",
+    "@qulib/core": "0.5.1",
     "zod": "^3.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Bumps `@qulib/core` and `@qulib/mcp` to **0.5.1**
- Aligns MCP's `@qulib/core` dependency to `0.5.1`
- Adds CHANGELOG entry for the auth probe fix (PR #36)

Version-only + changelog PR — no source changes.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 77 core + 7 MCP tests pass

Made with [Cursor](https://cursor.com)