### PR TITLE
fix: CTA false-positive guard in auth probe + gap UUID in scenario prompt

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "analyze": "tsx src/cli/index.ts analyze",
     "clean": "tsx src/cli/index.ts clean",
     "build": "tsc",
-    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts",
+    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts",
     "test:integration": "node --import tsx/esm --test src/__tests__/analyze.integration.test.ts",
     "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral",
     "cost-doctor": "tsx src/cli/index.ts cost doctor"

--- a/packages/core/src/llm/__tests__/context-builder.test.ts
+++ b/packages/core/src/llm/__tests__/context-builder.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildGapPrompt } from '../context-builder.js';
+import type { Gap } from '../../schemas/gap-analysis.schema.js';
+
+test('buildGapPrompt includes gap id in formatted line, not positional number', () => {
+  const gaps = [
+    {
+      id: 'gap-uuid-001',
+      severity: 'high',
+      category: 'test-coverage',
+      path: '/login',
+      reason: 'no tests for login flow',
+    },
+  ] as Gap[];
+
+  const prompt = buildGapPrompt(gaps, 10);
+
+  assert.ok(prompt.includes('id:gap-uuid-001'), 'prompt must contain the gap UUID');
+  assert.ok(!prompt.includes('1. [high]'), 'prompt must not use positional numbering');
+});
+
+test('buildGapPrompt sourceGapIds description references gap id format', () => {
+  const gaps = [
+    { id: 'gap-abc', severity: 'medium', category: 'ci-integration', path: '/', reason: 'no CI' },
+  ] as Gap[];
+  const prompt = buildGapPrompt(gaps, 10);
+  assert.ok(prompt.includes('id:'), 'sourceGapIds hint should reference id: prefix');
+});

--- a/packages/core/src/llm/context-builder.ts
+++ b/packages/core/src/llm/context-builder.ts
@@ -9,7 +9,7 @@ export function buildGapPrompt(gaps: Gap[], limit: number): string {
     .slice(0, limit);
 
   const gapList = topGaps
-    .map((g, i) => `${i + 1}. [${g.severity}] ${g.category} at ${g.path}: ${g.reason}`)
+    .map((g) => `- id:${g.id} [${g.severity}] ${g.category} at ${g.path}: ${g.reason}`)
     .join('\n');
 
   return `You are a QA engineer. Given these quality gaps found in a web application, generate test scenarios.
@@ -32,6 +32,6 @@ Each item must match this exact shape:
   "recommendations": [
     { "adapter": "playwright|cypress-e2e|cypress-component|api|accessibility", "reason": "string", "confidence": "high|medium|low" }
   ],
-  "sourceGapIds": ["string"]
+  "sourceGapIds": ["<one or more gap ids from the list, copied exactly as id:xxxx>"]
 }`;
 }

--- a/packages/core/src/tools/auth/detect.ts
+++ b/packages/core/src/tools/auth/detect.ts
@@ -73,6 +73,10 @@ function debugAuth(): boolean {
   return process.env.QULIB_DEBUG === '1';
 }
 
+function isLoginishPath(pathname: string): boolean {
+  return /login|sign[- ]?in|auth|sso|oauth|signin/i.test(pathname);
+}
+
 function slugify(label: string): string {
   const s = label
     .toLowerCase()
@@ -209,6 +213,7 @@ async function probeClickToRevealForms(
     candidateAttempts += 1;
 
     const originBefore = new URL(page.url()).origin;
+    const pathBefore = new URL(page.url()).pathname;
 
     if (debugAuth()) {
       progress?.debug(`detect_auth click-reveal try label="${label.slice(0, 80)}"`);
@@ -244,6 +249,16 @@ async function probeClickToRevealForms(
         progress?.debug(
           `detect_auth click-reveal aborted (cross-origin after click): was ${originBefore} now ${new URL(page.url()).origin}`
         );
+      }
+      await page.goto(loginUrl, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
+      await waitNetworkIdleBestEffort(page);
+      continue;
+    }
+
+    const afterUrl = new URL(page.url());
+    if (afterUrl.pathname !== pathBefore && !isLoginishPath(afterUrl.pathname)) {
+      if (debugAuth()) {
+        progress?.debug(`detect_auth click-reveal skip (CTA navigation to non-login path): ${afterUrl.pathname}`);
       }
       await page.goto(loginUrl, { timeout: timeoutMs, waitUntil: 'domcontentloaded' });
       await waitNetworkIdleBestEffort(page);


### PR DESCRIPTION
## Summary
- `probeClickToRevealForms` now detects when a button click navigated to a non-login path (CTA navigation) and skips it. Only clicks that land on a login-ish path (`/login`, `/sign-in`, `/auth`, `/sso`, `/oauth`) continue to password-field detection. Fixes the "Launch →" false positive on marketing CTAs.
- `buildGapPrompt` now embeds each gap's real UUID (`id:xxxx`) in the formatted line instead of a positional number. The LLM can now return accurate `sourceGapIds` values instead of `["1"]`, `["2"]` positional placeholders.

## Test plan
- [x] All existing tests pass (79 core + 7 MCP)
- [x] 2 new context-builder tests pass (gap id in prompt, no positional numbering)

Made with [Cursor](https://cursor.com)