### PR TITLE
chore: release v0.5.2 — auth CTA guard and gap UUID fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Entries for **0.3.1 and earlier** were reconstructed from git tags (`v0.1.1` … `v0.2.2`) and release commits on `main`.
 
+## [0.5.2] — 2026-05-14
+
+### Fixed
+- **@qulib/core:** `detect-auth` now skips click-probe candidates that navigate to a non-login path after click (e.g. a marketing CTA that happens to lead to a sign-up form). Only paths whose post-click URL contains `/login`, `/sign-in`, `/auth`, `/sso`, or `/oauth` are treated as click-to-reveal auth forms. Eliminates false-positive automatable paths from homepage CTA buttons.
+- **@qulib/core:** LLM scenario generation now receives each gap's real UUID in the prompt (prefixed `id:xxxx`) instead of a positional counter. Fixes `sourceGapIds` in generated scenarios returning `["1"]`, `["2"]` instead of actual gap UUIDs.
+
 ## [0.5.1] — 2026-05-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -2029,7 +2029,7 @@
     },
     "packages/core": {
       "name": "@qulib/core",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "^4.9.0",
@@ -2049,11 +2049,11 @@
     },
     "packages/mcp": {
       "name": "@qulib/mcp",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@qulib/core": "0.5.1",
+        "@qulib/core": "0.5.2",
         "zod": "^3.23.0"
       },
       "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/core",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Qulib — analyze deployed web apps for honest quality gaps (CLI + programmatic API)",
   "license": "MIT",
   "author": "Tapesh Nagarwal",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/mcp",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "MCP server for Qulib — AI-callable QA gap analysis",
   "license": "MIT",
   "author": "Tapesh Nagarwal",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@qulib/core": "0.5.1",
+    "@qulib/core": "0.5.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Bumps @qulib/core and @qulib/mcp to 0.5.2
- Records CHANGELOG entry for CTA false-positive guard and sourceGapIds fix

## Test plan
- [x] npm run build passes
- [x] npm test passes (79 core + 7 MCP)
- [x] Both packages at version 0.5.2

Made with [Cursor](https://cursor.com)