### PR TITLE
feat: add proposal-approve and proposal-refine workflows

### DIFF
--- a/.github/workflows/proposal-approve.yml
+++ b/.github/workflows/proposal-approve.yml
@@ -1,0 +1,56 @@
+name: Proposal — Approve
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  approve:
+    name: Approve proposal (ORCH-013)
+    if: |
+      startsWith(github.event.comment.body, '/approve') &&
+      contains(github.event.issue.labels.*.name, 'proposal')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Checkout Tap-Agent
+        uses: actions/checkout@v4
+        with:
+          repository: TapeshN/Tap-Agent
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Resolve project number from repo
+        id: project
+        run: |
+          case "${{ github.repository }}" in
+            TapeshN/qulib)           echo "number=3" >> "$GITHUB_OUTPUT" ;;
+            TapeshN/notquality-app)  echo "number=4" >> "$GITHUB_OUTPUT" ;;
+            *)                       echo "number=3" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Fetch issue node ID
+        id: issue_meta
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          NODE_ID=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }} --jq '.node_id')
+          echo "node_id=$NODE_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Run approve script
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          ISSUE_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NODE_ID: ${{ steps.issue_meta.outputs.node_id }}
+          PROJECT_NUMBER: ${{ steps.project.outputs.number }}
+          SLACK_WEBHOOK_URL_PROPOSALS: ${{ secrets.SLACK_WEBHOOK_URL_PROPOSALS }}
+        run: python scripts/proposal_approve.py

--- a/.github/workflows/proposal-refine.yml
+++ b/.github/workflows/proposal-refine.yml
@@ -1,0 +1,50 @@
+name: Proposal — Refine
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  refine:
+    name: Refine proposal (ORCH-013)
+    if: |
+      startsWith(github.event.comment.body, '/refine') &&
+      contains(github.event.issue.labels.*.name, 'proposal')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Checkout Tap-Agent
+        uses: actions/checkout@v4
+        with:
+          repository: TapeshN/Tap-Agent
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install anthropic
+
+      - name: Extract feedback from comment
+        id: feedback
+        run: |
+          COMMENT="${{ github.event.comment.body }}"
+          FEEDBACK="${COMMENT#/refine}"
+          FEEDBACK="${FEEDBACK#" "}"
+          echo "text=$FEEDBACK" >> "$GITHUB_OUTPUT"
+
+      - name: Run refine script
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          ISSUE_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REFINE_FEEDBACK: ${{ steps.feedback.outputs.text }}
+          SLACK_WEBHOOK_URL_PROPOSALS: ${{ secrets.SLACK_WEBHOOK_URL_PROPOSALS }}
+        run: python scripts/proposal_refine.py


### PR DESCRIPTION
Adds the Tap-Agent lifecycle workflows so `/approve` and `/refine` comments on proposal issues in this repo actually trigger.

## What this enables
- Comment `/approve` on any issue labeled `proposal` → moves to Plans column, swaps label to `approved`, notifies Slack
- Comment `/refine <feedback>` → Claude rewrites the proposal body with your feedback

## How it works
Both workflows checkout `TapeshN/Tap-Agent` to run the scripts — the logic lives there, not here. Secrets required (see below).

## Secrets needed on this repo
- `GH_TOKEN` — PAT with repo + project scopes
- `SLACK_WEBHOOK_URL_PROPOSALS` — #proposals webhook URL
- `ANTHROPIC_API_KEY` — needed by proposal-refine only

🤖 Generated with [Claude Code](https://claude.com/claude-code)