### PR TITLE
fix: route workflow notifications to #qulib channel

### DIFF
--- a/.github/workflows/proposal-approve.yml
+++ b/.github/workflows/proposal-approve.yml
@@ -28,13 +28,22 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Resolve project number from repo
+      - name: Resolve project number and Slack channel from repo
         id: project
         run: |
           case "${{ github.repository }}" in
-            TapeshN/qulib)           echo "number=3" >> "$GITHUB_OUTPUT" ;;
-            TapeshN/notquality-app)  echo "number=4" >> "$GITHUB_OUTPUT" ;;
-            *)                       echo "number=3" >> "$GITHUB_OUTPUT" ;;
+            TapeshN/qulib)
+              echo "number=3" >> "$GITHUB_OUTPUT"
+              echo "webhook=${{ secrets.SLACK_WEBHOOK_URL_QULIB }}" >> "$GITHUB_OUTPUT"
+              ;;
+            TapeshN/notquality-app)
+              echo "number=4" >> "$GITHUB_OUTPUT"
+              echo "webhook=${{ secrets.SLACK_WEBHOOK_URL_NOTQUALITY }}" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "number=3" >> "$GITHUB_OUTPUT"
+              echo "webhook=${{ secrets.SLACK_WEBHOOK_URL_PROPOSALS }}" >> "$GITHUB_OUTPUT"
+              ;;
           esac
 
       - name: Fetch issue node ID
@@ -52,5 +61,5 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_NODE_ID: ${{ steps.issue_meta.outputs.node_id }}
           PROJECT_NUMBER: ${{ steps.project.outputs.number }}
-          SLACK_WEBHOOK_URL_PROPOSALS: ${{ secrets.SLACK_WEBHOOK_URL_PROPOSALS }}
+          SLACK_WEBHOOK_URL_PROPOSALS: ${{ steps.project.outputs.webhook }}
         run: python scripts/proposal_approve.py

--- a/.github/workflows/proposal-refine.yml
+++ b/.github/workflows/proposal-refine.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Install dependencies
         run: pip install anthropic
 
+      - name: Resolve Slack channel from repo
+        id: channel
+        run: |
+          case "${{ github.repository }}" in
+            TapeshN/qulib)          echo "webhook=${{ secrets.SLACK_WEBHOOK_URL_QULIB }}" >> "$GITHUB_OUTPUT" ;;
+            TapeshN/notquality-app) echo "webhook=${{ secrets.SLACK_WEBHOOK_URL_NOTQUALITY }}" >> "$GITHUB_OUTPUT" ;;
+            *)                      echo "webhook=${{ secrets.SLACK_WEBHOOK_URL_PROPOSALS }}" >> "$GITHUB_OUTPUT" ;;
+          esac
+
       - name: Extract feedback from comment
         id: feedback
         run: |
@@ -46,5 +55,5 @@ jobs:
           ISSUE_REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REFINE_FEEDBACK: ${{ steps.feedback.outputs.text }}
-          SLACK_WEBHOOK_URL_PROPOSALS: ${{ secrets.SLACK_WEBHOOK_URL_PROPOSALS }}
+          SLACK_WEBHOOK_URL_PROPOSALS: ${{ steps.channel.outputs.webhook }}
         run: python scripts/proposal_refine.py


### PR DESCRIPTION
Updates `proposal-approve` and `proposal-refine` workflows to post to `#qulib` instead of `#proposals` when triggered from this repo.

The `SLACK_WEBHOOK_URL_QULIB` secret is already set on this repo.

Depends on [Tap-Agent#18](https://github.com/TapeshN/Tap-Agent/pull/18) being merged first (contains the SSL + GraphQL fixes to the script itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)