### PR TITLE
fix(core): export toAgentSummary and AgentSummary from public API

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,6 @@
 export { analyzeApp } from './analyze.js';
+export { toAgentSummary } from './agent-summary.js';
+export type { AgentSummary } from './agent-summary.js';
 export {
   detectAuth,
   validateStorageState,


### PR DESCRIPTION
## Summary
- Adds missing `toAgentSummary` and `AgentSummary` exports to `@qulib/core`'s public `index.ts`
- Fixes build failure in `@qulib/mcp` which imports `toAgentSummary` from `@qulib/core`

## Test plan
- [ ] `npm run build && npm run test` green after merge
- [ ] Unblocks v0.5.3 npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)