### PR TITLE
fix(core): credential field name no longer derived from placeholder example values

### DIFF
--- a/packages/core/src/tools/auth/__tests__/detect.test.ts
+++ b/packages/core/src/tools/auth/__tests__/detect.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import type { Page } from '@playwright/test';
 import {
   evaluateStorageStateValidity,
+  pickCredentialFieldName,
   preflightStorageStateFile,
   waitForReturnToOrigin,
 } from '../detect.js';
@@ -345,4 +346,69 @@ test('authPathNeedsClickReveal returns false for built-in oauth id', () => {
     requirements: { method: 'credentials', fields: [] },
   };
   assert.equal(authPathNeedsClickReveal(path), false);
+});
+
+// --- pickCredentialFieldName tests ---
+
+test('pickCredentialFieldName returns name attribute when present', () => {
+  assert.equal(pickCredentialFieldName({ name: 'email', type: 'text' }), 'email');
+});
+
+test('pickCredentialFieldName falls back to slugified id when name is missing', () => {
+  assert.equal(pickCredentialFieldName({ id: 'user-email-input', type: 'text' }), 'user-email-input');
+});
+
+test('pickCredentialFieldName uses autocomplete=email when no name or id', () => {
+  assert.equal(pickCredentialFieldName({ autocomplete: 'email', type: 'text' }), 'email');
+});
+
+test('pickCredentialFieldName uses autocomplete=username when no name or id', () => {
+  assert.equal(pickCredentialFieldName({ autocomplete: 'username', type: 'text' }), 'username');
+});
+
+test('pickCredentialFieldName maps autocomplete=current-password to "password"', () => {
+  assert.equal(pickCredentialFieldName({ autocomplete: 'current-password' }), 'password');
+});
+
+test('pickCredentialFieldName falls back to type=email semantic default', () => {
+  assert.equal(pickCredentialFieldName({ type: 'email' }), 'email');
+});
+
+test('pickCredentialFieldName falls back to type=password semantic default', () => {
+  assert.equal(pickCredentialFieldName({ type: 'password' }), 'password');
+});
+
+test('pickCredentialFieldName skips placeholder that looks like an example email', () => {
+  // Regression: placeholder "you@notquality.com" must not become "younotqualitycom"
+  assert.equal(pickCredentialFieldName({ type: 'email', placeholder: 'you@notquality.com' }), 'email');
+});
+
+test('pickCredentialFieldName skips placeholder that looks like a URL example', () => {
+  assert.equal(pickCredentialFieldName({ placeholder: 'https://your-site.com' }), 'field');
+});
+
+test('pickCredentialFieldName uses placeholder when it looks like a field-name hint', () => {
+  // "District" has no @ or :// — safe to slugify
+  assert.equal(pickCredentialFieldName({ placeholder: 'District' }), 'district');
+});
+
+test('pickCredentialFieldName uses aria-label as last resort before "field"', () => {
+  assert.equal(pickCredentialFieldName({ ariaLabel: 'Choose your school' }), 'choose-your-school');
+});
+
+test('pickCredentialFieldName returns "field" when no usable signal exists', () => {
+  assert.equal(pickCredentialFieldName({}), 'field');
+});
+
+test('pickCredentialFieldName prefers name attribute over all other signals', () => {
+  assert.equal(
+    pickCredentialFieldName({
+      name: 'real_name',
+      id: 'i-am-ignored',
+      autocomplete: 'email',
+      type: 'password',
+      placeholder: 'ignored',
+    }),
+    'real_name'
+  );
 });

--- a/packages/core/src/tools/auth/detect.ts
+++ b/packages/core/src/tools/auth/detect.ts
@@ -107,16 +107,45 @@ async function resolveVisibleFieldLabel(page: Page, el: import('@playwright/test
   return typ && typ !== 'select' ? typ : 'text';
 }
 
-async function deriveCredentialFieldName(el: import('@playwright/test').Locator): Promise<string> {
-  const name = (await el.getAttribute('name'))?.trim();
+function looksLikeExampleValue(s: string): boolean {
+  return /@|:\/\//.test(s);
+}
+
+export function pickCredentialFieldName(attrs: {
+  name?: string | null;
+  id?: string | null;
+  autocomplete?: string | null;
+  type?: string | null;
+  placeholder?: string | null;
+  ariaLabel?: string | null;
+}): string {
+  const name = attrs.name?.trim();
   if (name) return name;
-  const placeholder = (await el.getAttribute('placeholder'))?.trim();
-  if (placeholder) return slugify(placeholder);
-  const aria = (await el.getAttribute('aria-label'))?.trim();
-  if (aria) return slugify(aria);
-  const id = (await el.getAttribute('id'))?.trim();
+  const id = attrs.id?.trim();
   if (id) return slugify(id);
+  const autocomplete = attrs.autocomplete?.trim().toLowerCase();
+  if (autocomplete === 'username' || autocomplete === 'email') return autocomplete;
+  if (autocomplete === 'current-password' || autocomplete === 'new-password') return 'password';
+  const type = attrs.type?.trim().toLowerCase();
+  if (type === 'email') return 'email';
+  if (type === 'password') return 'password';
+  const placeholder = attrs.placeholder?.trim();
+  if (placeholder && !looksLikeExampleValue(placeholder)) return slugify(placeholder);
+  const aria = attrs.ariaLabel?.trim();
+  if (aria && !looksLikeExampleValue(aria)) return slugify(aria);
   return 'field';
+}
+
+async function deriveCredentialFieldName(el: import('@playwright/test').Locator): Promise<string> {
+  const [name, id, autocomplete, type, placeholder, ariaLabel] = await Promise.all([
+    el.getAttribute('name'),
+    el.getAttribute('id'),
+    el.getAttribute('autocomplete'),
+    el.getAttribute('type'),
+    el.getAttribute('placeholder'),
+    el.getAttribute('aria-label'),
+  ]);
+  return pickCredentialFieldName({ name, id, autocomplete, type, placeholder, ariaLabel });
 }
 
 async function buildCredentialFieldsFromVisibleForm(page: Page): Promise<


### PR DESCRIPTION
## Summary
- Fixes a real bug surfaced by scanning notquality.com: an email input with `placeholder=\"you@notquality.com\"` and no `name` attribute produced a credential field named `\"younotqualitycom\"` (the @ and . stripped during slugification)
- Reorders `deriveCredentialFieldName`'s fallback chain to prefer stable identifiers (id → autocomplete → input type) over user-facing placeholder text
- Guards placeholder/aria-label fallbacks against values that look like example data (contain `@` or `://`)
- Extracts pure logic into exported `pickCredentialFieldName` for unit testability
- Adds 13 unit tests covering the bug regression and the new fallback chain

## Before
```json
"fields": [{ "name": "younotqualitycom", "label": "Email", "type": "email" }]
```

## After
```json
"fields": [{ "name": "email", "label": "Email", "type": "email" }]
```

## Test plan
- [x] 13 new unit tests for `pickCredentialFieldName` pass
- [x] All 92 existing core tests + 7 mcp tests still pass
- [x] End-to-end verified: `qulib detect-auth --url https://notquality.com` now returns `name: \"email\"` / `name: \"password\"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)