### PR TITLE
feat(core): add toAgentSummary — versioned agent-facing gate summary (QLIB-001 chunk 1/3)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "analyze": "tsx src/cli/index.ts analyze",
     "clean": "tsx src/cli/index.ts clean",
     "build": "tsc",
-    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts",
+    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/agent-summary.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts",
     "test:integration": "node --import tsx/esm --test src/__tests__/analyze.integration.test.ts",
     "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral",
     "cost-doctor": "tsx src/cli/index.ts cost doctor"

--- a/packages/core/src/__tests__/agent-summary.test.ts
+++ b/packages/core/src/__tests__/agent-summary.test.ts
@@ -1,0 +1,211 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { toAgentSummary } from '../agent-summary.js';
+import type { AnalyzeResult } from '../analyze.js';
+import type { Gap } from '../schemas/gap-analysis.schema.js';
+import type { CostIntelligence } from '../schemas/cost-intelligence.schema.js';
+
+const isoNow = (): string => new Date().toISOString();
+
+interface FixtureOverrides {
+  status?: AnalyzeResult['status'];
+  releaseConfidence?: number | null;
+  gaps?: Gap[];
+  mode?: AnalyzeResult['gapAnalysis']['mode'];
+  coverageWarning?: AnalyzeResult['gapAnalysis']['coverageWarning'];
+  coveragePagesScanned?: number;
+  coverageBudgetExceeded?: boolean;
+  costIntelligence?: CostIntelligence;
+}
+
+function makeResult(overrides: FixtureOverrides = {}): AnalyzeResult {
+  const gaps = overrides.gaps ?? [];
+  const releaseConfidence = overrides.releaseConfidence ?? 90;
+  return {
+    status: overrides.status ?? 'complete',
+    coverageScore: 100,
+    releaseConfidence,
+    gaps,
+    gapAnalysis: {
+      analyzedAt: isoNow(),
+      mode: overrides.mode ?? 'url-only',
+      releaseConfidence,
+      coveragePagesScanned: overrides.coveragePagesScanned ?? 10,
+      coverageBudgetExceeded: overrides.coverageBudgetExceeded ?? false,
+      ...(overrides.coverageWarning !== undefined && { coverageWarning: overrides.coverageWarning }),
+      gaps,
+      scenarios: [],
+      generatedTests: [],
+      ...(overrides.costIntelligence !== undefined && {
+        costIntelligence: overrides.costIntelligence,
+      }),
+    },
+    routeInventory: {
+      scannedAt: isoNow(),
+      baseUrl: 'https://example.com',
+      routes: [],
+      pagesSkipped: 0,
+      budgetExceeded: false,
+    },
+    repoInventory: null,
+    decisionLog: [],
+    publicSurface: null,
+  };
+}
+
+function gap(severity: Gap['severity'], category: Gap['category'] = 'a11y'): Gap {
+  return {
+    id: `${severity}-${category}-${Math.random().toString(36).slice(2, 8)}`,
+    path: '/x',
+    severity,
+    reason: `${severity} ${category} finding`,
+    category,
+  };
+}
+
+const costIntelligenceFixture = (): CostIntelligence => ({
+  maxOutputTokensPerLlmCall: 2048,
+  budgetRole: 'max-output-tokens-per-llm-call',
+  records: [],
+  budgetWarnings: ['warning A'],
+  usageSummary: { totalInputTokens: 100, totalOutputTokens: 200, dataQuality: 'actual' },
+  repeatedOperations: [],
+  deterministicMaturity: { level: 2, label: 'L2', rationale: 'fixture' },
+  conversionRecommendations: ['Convert flow X to deterministic check', 'Capture step Y in CI'],
+});
+
+test('toAgentSummary: high confidence, no major risks → pass', () => {
+  const r = makeResult({ releaseConfidence: 92, gaps: [gap('low')] });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'pass');
+  assert.equal(s.coverageStatus, 'ok');
+  assert.equal(s.releaseConfidence, 92);
+  assert.ok(s.honestyNotes.length >= 1, 'always at least one honesty note');
+});
+
+test('toAgentSummary: low coverage → warn with thin coverage note', () => {
+  const r = makeResult({
+    releaseConfidence: 60,
+    coverageWarning: 'low-coverage',
+    coveragePagesScanned: 1,
+  });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'warn');
+  assert.equal(s.coverageStatus, 'thin');
+  assert.ok(s.honestyNotes.some((n) => /below the confidence threshold/i.test(n)));
+  assert.ok(s.recommendedNextChecks.some((c) => /crawl budget|deeper entry/i.test(c)));
+});
+
+test('toAgentSummary: auth-required blocks meaningful scan → fail by default', () => {
+  const r = makeResult({
+    releaseConfidence: 0,
+    mode: 'auth-required',
+    coverageWarning: 'auth-required',
+    coveragePagesScanned: 0,
+  });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'fail');
+  assert.equal(s.coverageStatus, 'blocked-by-auth');
+  assert.ok(s.topRisks.some((r2) => /auth blocked/i.test(r2)));
+  assert.ok(s.honestyNotes.some((n) => /authenticated surface/i.test(n)));
+});
+
+test('toAgentSummary: auth-required with authRequiredGate=warn yields warn', () => {
+  const r = makeResult({
+    releaseConfidence: 0,
+    mode: 'auth-required',
+    coverageWarning: 'auth-required',
+  });
+  const s = toAgentSummary(r, { authRequiredGate: 'warn' });
+  assert.equal(s.gate, 'warn');
+});
+
+test('toAgentSummary: critical issue → fail regardless of confidence', () => {
+  const r = makeResult({ releaseConfidence: 95, gaps: [gap('critical', 'a11y')] });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'fail');
+  assert.equal(s.topRisks[0], '[critical] a11y — /x');
+});
+
+test('toAgentSummary: cost intelligence present → costSummary and deterministicFollowUps included', () => {
+  const ci = costIntelligenceFixture();
+  const r = makeResult({ releaseConfidence: 88, costIntelligence: ci });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'pass');
+  assert.ok(s.costSummary, 'costSummary should be present');
+  assert.equal(s.costSummary?.budgetWarningCount, 1);
+  assert.equal(s.costSummary?.maturityLevel, 2);
+  assert.deepEqual(s.deterministicFollowUps, ci.conversionRecommendations);
+});
+
+test('toAgentSummary: missing cost intelligence → costSummary null and empty follow-ups', () => {
+  const s = toAgentSummary(makeResult({ releaseConfidence: 85 }));
+  assert.equal(s.costSummary, null);
+  assert.deepEqual(s.deterministicFollowUps, []);
+});
+
+test('toAgentSummary: high-severity gap with otherwise-pass conditions → warn', () => {
+  const r = makeResult({ releaseConfidence: 90, gaps: [gap('high', 'console-error')] });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'warn');
+});
+
+test('toAgentSummary: status=blocked → fail', () => {
+  const r = makeResult({ status: 'blocked', releaseConfidence: null });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'fail');
+  assert.ok(s.honestyNotes.some((n) => /blocked before producing/i.test(n)));
+});
+
+test('toAgentSummary: status=partial → warn', () => {
+  const r = makeResult({ status: 'partial', releaseConfidence: 85 });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'warn');
+});
+
+test('toAgentSummary: confidence below pass threshold (but above fail) → warn', () => {
+  const r = makeResult({ releaseConfidence: 60 });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'warn');
+});
+
+test('toAgentSummary: confidence below fail threshold → fail', () => {
+  const r = makeResult({ releaseConfidence: 10 });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'fail');
+});
+
+test('toAgentSummary: custom pass threshold respected', () => {
+  const r = makeResult({ releaseConfidence: 75 });
+  assert.equal(toAgentSummary(r).gate, 'warn');
+  assert.equal(toAgentSummary(r, { passConfidenceThreshold: 70 }).gate, 'pass');
+});
+
+test('toAgentSummary: schemaVersion is 1 and shape contains all documented fields', () => {
+  const s = toAgentSummary(makeResult());
+  assert.equal(s.schemaVersion, 1);
+  for (const k of [
+    'gate',
+    'releaseConfidence',
+    'coverageStatus',
+    'topRisks',
+    'recommendedNextChecks',
+    'honestyNotes',
+    'costSummary',
+    'deterministicFollowUps',
+  ]) {
+    assert.ok(k in s, `missing field: ${k}`);
+  }
+});
+
+test('toAgentSummary: topRisks sorted critical → high → medium → low', () => {
+  const r = makeResult({
+    gaps: [gap('low'), gap('critical'), gap('medium'), gap('high')],
+    releaseConfidence: 50,
+  });
+  const s = toAgentSummary(r);
+  const severities = s.topRisks
+    .filter((t) => t.startsWith('['))
+    .map((t) => t.slice(1, t.indexOf(']')));
+  assert.deepEqual(severities, ['critical', 'high', 'medium', 'low']);
+});

--- a/packages/core/src/agent-summary.ts
+++ b/packages/core/src/agent-summary.ts
@@ -1,0 +1,262 @@
+import type { AnalyzeResult } from './analyze.js';
+import type { Gap } from './schemas/gap-analysis.schema.js';
+import type { CostIntelligence } from './schemas/cost-intelligence.schema.js';
+
+/**
+ * Agent-readable summary of an AnalyzeResult. Intended for orchestrators
+ * (CI gates, external agent loops) that need a small, stable JSON shape.
+ *
+ * QLIB-001 spec: see docs/agent-summary-output.md.
+ * C02 helper; exposed via CLI (`--agent-summary`) and MCP (`agentSummary: true`).
+ * Field names below are the v1 contract for `toAgentSummary`.
+ */
+
+export type AgentGate = 'pass' | 'warn' | 'fail';
+
+export type CoverageStatus =
+  | 'ok'
+  | 'thin'
+  | 'blocked-by-auth'
+  | 'budget-exceeded'
+  | 'navigation-failures'
+  | 'unknown';
+
+export interface AgentSummaryCostSummary {
+  maxOutputTokensPerLlmCall: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  budgetWarningCount: number;
+  dataQuality: CostIntelligence['usageSummary']['dataQuality'];
+  maturityLevel: number;
+  maturityLabel: string;
+}
+
+export interface AgentSummary {
+  schemaVersion: 1;
+  gate: AgentGate;
+  releaseConfidence: number | null;
+  coverageStatus: CoverageStatus;
+  topRisks: string[];
+  recommendedNextChecks: string[];
+  honestyNotes: string[];
+  costSummary: AgentSummaryCostSummary | null;
+  deterministicFollowUps: string[];
+}
+
+export interface AgentSummaryPolicy {
+  /** Confidence at or above this number is required for `pass`. Default 80. */
+  passConfidenceThreshold?: number;
+  /** Confidence below this triggers `fail` (when no harder failure already applies). Default 30. */
+  failConfidenceThreshold?: number;
+  /** Max risks/checks/notes to include in each list. Default 5. */
+  maxListLength?: number;
+  /**
+   * Treat `mode === 'auth-required'` as `fail` (default) or `warn`.
+   * Honest default: a deployment that was never exercised past auth cannot pass.
+   */
+  authRequiredGate?: 'fail' | 'warn';
+}
+
+interface ResolvedPolicy {
+  passConfidenceThreshold: number;
+  failConfidenceThreshold: number;
+  maxListLength: number;
+  authRequiredGate: 'fail' | 'warn';
+}
+
+const DEFAULT_POLICY: ResolvedPolicy = {
+  passConfidenceThreshold: 80,
+  failConfidenceThreshold: 30,
+  maxListLength: 5,
+  authRequiredGate: 'fail',
+};
+
+const severityOrder = { critical: 0, high: 1, medium: 2, low: 3 } as const;
+
+function resolvePolicy(p: AgentSummaryPolicy | undefined): ResolvedPolicy {
+  return {
+    passConfidenceThreshold: p?.passConfidenceThreshold ?? DEFAULT_POLICY.passConfidenceThreshold,
+    failConfidenceThreshold: p?.failConfidenceThreshold ?? DEFAULT_POLICY.failConfidenceThreshold,
+    maxListLength: p?.maxListLength ?? DEFAULT_POLICY.maxListLength,
+    authRequiredGate: p?.authRequiredGate ?? DEFAULT_POLICY.authRequiredGate,
+  };
+}
+
+function countBySeverity(gaps: Gap[]): Record<Gap['severity'], number> {
+  const counts: Record<Gap['severity'], number> = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const g of gaps) counts[g.severity]++;
+  return counts;
+}
+
+function deriveCoverageStatus(result: AnalyzeResult): CoverageStatus {
+  const g = result.gapAnalysis;
+  if (g.mode === 'auth-required' || g.coverageWarning === 'auth-required') {
+    return 'blocked-by-auth';
+  }
+  if (g.coverageWarning === 'budget-exceeded' || g.coverageBudgetExceeded) {
+    return 'budget-exceeded';
+  }
+  if (g.coverageWarning === 'navigation-failures') {
+    return 'navigation-failures';
+  }
+  if (g.coverageWarning === 'low-coverage') {
+    return 'thin';
+  }
+  if (g.coveragePagesScanned === 0) {
+    return 'unknown';
+  }
+  return 'ok';
+}
+
+function buildTopRisks(result: AnalyzeResult, limit: number): string[] {
+  const risks: string[] = [];
+  const status = deriveCoverageStatus(result);
+  if (status === 'blocked-by-auth') {
+    risks.push('Auth blocked the scan; protected routes were not exercised.');
+  } else if (status === 'thin') {
+    risks.push('Crawl coverage was below the confidence floor.');
+  } else if (status === 'budget-exceeded') {
+    risks.push('Crawl budget exceeded; coverage is partial.');
+  } else if (status === 'navigation-failures') {
+    risks.push('Navigation errors limited what could be scanned.');
+  }
+
+  const sorted = [...result.gaps].sort(
+    (a, b) => severityOrder[a.severity] - severityOrder[b.severity]
+  );
+  for (const g of sorted) {
+    if (risks.length >= limit) break;
+    risks.push(`[${g.severity}] ${g.category} — ${g.path}`);
+  }
+  return risks.slice(0, limit);
+}
+
+function buildRecommendedNextChecks(result: AnalyzeResult, limit: number): string[] {
+  const out: string[] = [];
+  const status = deriveCoverageStatus(result);
+  if (status === 'blocked-by-auth') {
+    out.push('Provide auth (form login or storage state) and re-run, or use explore_auth.');
+  }
+  if (status === 'thin') {
+    out.push('Increase crawl budget or supply deeper entry URLs to raise coverage above the floor.');
+  }
+  if (status === 'budget-exceeded') {
+    out.push('Increase maxPagesToScan or narrow scope to bring the crawl under budget.');
+  }
+
+  const byCat = new Map<string, number>();
+  for (const g of result.gaps) byCat.set(g.category, (byCat.get(g.category) ?? 0) + 1);
+  const topCats = [...byCat.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3);
+  for (const [cat, n] of topCats) {
+    if (out.length >= limit) break;
+    out.push(`Add or tighten deterministic coverage for ${cat} (${n} gap(s) this scan).`);
+  }
+  return out.slice(0, limit);
+}
+
+function buildHonestyNotes(result: AnalyzeResult): string[] {
+  const notes: string[] = ['This scan does not guarantee production readiness.'];
+  const g = result.gapAnalysis;
+  if (g.mode === 'auth-required' || g.coverageWarning === 'auth-required') {
+    notes.push('Authenticated surface was not exercised: confidence does not reflect protected routes.');
+  }
+  if (g.coverageWarning === 'low-coverage') {
+    notes.push('Coverage was below the confidence threshold; treat the score as a ceiling.');
+  }
+  if (g.coverageBudgetExceeded || g.coverageWarning === 'budget-exceeded') {
+    notes.push('Crawl budget was exceeded; some routes were not scanned.');
+  }
+  if (g.coverageWarning === 'navigation-failures') {
+    notes.push('Navigation failures reduced effective coverage.');
+  }
+  if (result.status === 'partial') {
+    notes.push('Scan completed only partially; signals are derived from a subset of intended work.');
+  }
+  if (result.status === 'blocked') {
+    notes.push('Scan was blocked before producing a meaningful evaluation.');
+  }
+  return notes;
+}
+
+function buildCostSummary(ci: CostIntelligence | undefined): AgentSummaryCostSummary | null {
+  if (!ci) return null;
+  return {
+    maxOutputTokensPerLlmCall: ci.maxOutputTokensPerLlmCall,
+    totalInputTokens: ci.usageSummary.totalInputTokens,
+    totalOutputTokens: ci.usageSummary.totalOutputTokens,
+    budgetWarningCount: ci.budgetWarnings.length,
+    dataQuality: ci.usageSummary.dataQuality,
+    maturityLevel: ci.deterministicMaturity.level,
+    maturityLabel: ci.deterministicMaturity.label,
+  };
+}
+
+function buildDeterministicFollowUps(ci: CostIntelligence | undefined, limit: number): string[] {
+  if (!ci) return [];
+  return ci.conversionRecommendations.slice(0, limit);
+}
+
+/**
+ * Default gate policy:
+ *   - fail when: any critical gap, status === 'blocked', releaseConfidence is null,
+ *                releaseConfidence < failConfidenceThreshold, or mode === 'auth-required'
+ *                under the default authRequiredGate.
+ *   - warn when: any high-severity gap, status === 'partial', coverage is thin /
+ *                budget-exceeded / navigation-failures, or confidence is below
+ *                passConfidenceThreshold (but at or above failConfidenceThreshold).
+ *   - pass when: confidence >= passConfidenceThreshold AND no blocking conditions.
+ *
+ * Honesty rule: an `auth-required` scan never silently `pass`es under defaults.
+ */
+function deriveGate(result: AnalyzeResult, policy: ResolvedPolicy): AgentGate {
+  const g = result.gapAnalysis;
+  const counts = countBySeverity(result.gaps);
+
+  if (counts.critical > 0) return 'fail';
+  if (result.status === 'blocked') return 'fail';
+  if (g.mode === 'auth-required' || g.coverageWarning === 'auth-required') {
+    return policy.authRequiredGate;
+  }
+  if (result.releaseConfidence === null) return 'fail';
+  if (result.releaseConfidence < policy.failConfidenceThreshold) return 'fail';
+
+  const hasCoverageIssue =
+    g.coverageWarning === 'low-coverage' ||
+    g.coverageWarning === 'budget-exceeded' ||
+    g.coverageWarning === 'navigation-failures' ||
+    g.coverageBudgetExceeded;
+
+  if (counts.high > 0) return 'warn';
+  if (result.status === 'partial') return 'warn';
+  if (hasCoverageIssue) return 'warn';
+  if (result.releaseConfidence < policy.passConfidenceThreshold) return 'warn';
+
+  return 'pass';
+}
+
+/**
+ * Convert an `AnalyzeResult` into a small agent-facing summary.
+ *
+ * Pure function. No I/O. CLI / MCP wiring belongs to QLIB-001-C03 and -C04.
+ */
+export function toAgentSummary(
+  result: AnalyzeResult,
+  policy?: AgentSummaryPolicy
+): AgentSummary {
+  const resolved = resolvePolicy(policy);
+  const limit = resolved.maxListLength;
+  return {
+    schemaVersion: 1,
+    gate: deriveGate(result, resolved),
+    releaseConfidence: result.releaseConfidence,
+    coverageStatus: deriveCoverageStatus(result),
+    topRisks: buildTopRisks(result, limit),
+    recommendedNextChecks: buildRecommendedNextChecks(result, limit),
+    honestyNotes: buildHonestyNotes(result),
+    costSummary: buildCostSummary(result.gapAnalysis.costIntelligence),
+    deterministicFollowUps: buildDeterministicFollowUps(
+      result.gapAnalysis.costIntelligence,
+      limit
+    ),
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,12 @@
 export { analyzeApp } from './analyze.js';
+export { toAgentSummary } from './agent-summary.js';
+export type {
+  AgentSummary,
+  AgentSummaryPolicy,
+  AgentGate,
+  CoverageStatus,
+  AgentSummaryCostSummary,
+} from './agent-summary.js';
 export {
   detectAuth,
   validateStorageState,


### PR DESCRIPTION
## Summary

First of three chunks landing on the long-lived `feature/qlib-001-gate-summary` branch. **This PR does NOT bump any version and does NOT publish to npm.** All chunks accumulate on the feature branch; one final release PR will bump versions, write the CHANGELOG entry, and trigger a single `npm publish` cycle.

**What's in this chunk:** the pure function and its tests only. No consumer-facing behavior change.

- New `toAgentSummary(result, policy?)` in `@qulib/core` (pure, no I/O)
- Versioned shape with `gate: 'pass' | 'warn' | 'fail'`, `coverageStatus`, `topRisks`, `recommendedNextChecks`, `honestyNotes`, `costSummary`, `deterministicFollowUps`
- Conservative gate derivation: critical gaps, blocked status, or `auth-required` mode never silently pass
- `honestyNotes` always surfaces coverage / auth / budget limits
- Policy is overridable (`passConfidenceThreshold`, `failConfidenceThreshold`, `maxListLength`, `authRequiredGate`)
- 15 unit tests
- Public exports added to `@qulib/core/index.ts` so chunks 2/3 can wire them in

## Release chain
```
main
  └── feature/qlib-001-gate-summary  ◄── long-lived target for all chunks
        ├── PR #70 — chunk 1: toAgentSummary core  ◄── THIS PR
        ├── PR — chunk 2: MCP wiring (analyze_app → agentSummary flag)
        ├── PR — chunk 3: CLI flag + docs/agent-summary-output.md
        └── (then) chore/release-0.6.0 — bumps versions, CHANGELOG, publishes
```

## Test plan
- [x] `npm run build` green (full repo)
- [x] `npm test` green — 107 core tests (+15 new for toAgentSummary) + 7 mcp tests
- [x] No behavior change for existing consumers (function is additive only, not yet called from MCP/CLI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)