### PR TITLE
feat(mcp): add agentSummary flag to analyze_app — returns compact gate JSON

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "npm --prefix ../.. run build -w @qulib/core && tsc && chmod +x dist/index.js",
     "dev": "tsx src/index.ts",
-    "test": "node --import tsx/esm --test src/__tests__/summarize-analyze-result.test.ts"
+    "test": "node --import tsx/esm --test src/__tests__/summarize-analyze-result.test.ts src/__tests__/analyze-app-mcp-payload.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp/src/__tests__/analyze-app-mcp-payload.test.ts
+++ b/packages/mcp/src/__tests__/analyze-app-mcp-payload.test.ts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAnalyzeAppMcpPayload } from '../analyze-app-mcp-payload.js';
+import type { AnalyzeResult } from '@qulib/core';
+
+const minimalAnalyzeResult = (): AnalyzeResult => {
+  const gaps = [
+    {
+      id: '1',
+      path: '/a',
+      severity: 'high' as const,
+      reason: 'console',
+      category: 'console-error' as const,
+    },
+  ];
+  return {
+    status: 'complete',
+    coverageScore: 100,
+    releaseConfidence: 85,
+    gaps,
+    gapAnalysis: {
+      analyzedAt: new Date().toISOString(),
+      mode: 'url-only',
+      releaseConfidence: 85,
+      coveragePagesScanned: 5,
+      coverageBudgetExceeded: false,
+      gaps,
+      scenarios: [],
+      generatedTests: [],
+    },
+    routeInventory: {
+      scannedAt: new Date().toISOString(),
+      baseUrl: 'https://example.com',
+      routes: [],
+      pagesSkipped: 0,
+      budgetExceeded: false,
+    },
+    repoInventory: null,
+    decisionLog: [],
+    publicSurface: null,
+  };
+};
+
+test('buildAnalyzeAppMcpPayload default matches summarize-first (no agentSummary)', () => {
+  const r = minimalAnalyzeResult();
+  const out = buildAnalyzeAppMcpPayload(r, {}) as Record<string, unknown>;
+  assert.equal(out.includeFullReport, false);
+  assert.ok('summary' in out);
+  assert.ok('topGaps' in out);
+});
+
+test('buildAnalyzeAppMcpPayload agentSummary returns only toAgentSummary shape', () => {
+  const r = minimalAnalyzeResult();
+  const out = buildAnalyzeAppMcpPayload(r, { agentSummary: true }) as Record<string, unknown>;
+  assert.equal(out.schemaVersion, 1);
+  assert.ok('gate' in out);
+  assert.ok('coverageStatus' in out);
+  assert.ok(Array.isArray(out.topRisks));
+  assert.ok(Array.isArray(out.honestyNotes));
+  assert.ok(!('summary' in out));
+  assert.ok(!('topGaps' in out));
+});
+
+test('buildAnalyzeAppMcpPayload agentSummary overrides includeFullReport', () => {
+  const r = minimalAnalyzeResult();
+  const out = buildAnalyzeAppMcpPayload(r, { agentSummary: true, includeFullReport: true }) as Record<string, unknown>;
+  assert.equal(out.schemaVersion, 1);
+  assert.ok(!('gapAnalysis' in out));
+});

--- a/packages/mcp/src/analyze-app-mcp-payload.ts
+++ b/packages/mcp/src/analyze-app-mcp-payload.ts
@@ -1,0 +1,23 @@
+import type { AnalyzeResult } from '@qulib/core';
+import { toAgentSummary } from '@qulib/core';
+import { summarizeAnalyzeResult } from './summarize-analyze-result.js';
+
+export interface AnalyzeAppMcpPayloadOptions {
+  includeFullReport?: boolean;
+  /** When true, returns only `toAgentSummary(result)` JSON (QLIB-001). Ignores `includeFullReport`. */
+  agentSummary?: boolean;
+}
+
+/**
+ * Single place for analyze_app response shaping: default summary-first,
+ * optional full report, or compact agent gate summary.
+ */
+export function buildAnalyzeAppMcpPayload(
+  result: AnalyzeResult,
+  input: AnalyzeAppMcpPayloadOptions
+): unknown {
+  if (input.agentSummary === true) {
+    return toAgentSummary(result);
+  }
+  return summarizeAnalyzeResult(result, input.includeFullReport === true);
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -25,7 +25,7 @@ import {
 } from '@qulib/core';
 import type { HarnessConfig, AnalyzeProgressSink, TelemetrySink } from '@qulib/core';
 import { z } from 'zod';
-import { summarizeAnalyzeResult } from './summarize-analyze-result.js';
+import { buildAnalyzeAppMcpPayload } from './analyze-app-mcp-payload.js';
 import { log } from './logger.js';
 
 function toolError(code: string, message: string, detail?: unknown): {
@@ -87,6 +87,12 @@ const AnalyzeInputSchema = z.object({
   timeoutMs: z.number().int().positive().optional(),
   auth: z.discriminatedUnion('type', [FormLoginMcpAuthSchema, StorageStateMcpAuthSchema]).optional(),
   includeFullReport: z.boolean().optional(),
+  agentSummary: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, return only the versioned agent-summary JSON ({ schemaVersion: 1, gate, coverageStatus, topRisks, recommendedNextChecks, honestyNotes, costSummary, deterministicFollowUps }). Use this for CI gates and orchestrators that need a single small payload to decide pass/warn/fail. Overrides includeFullReport.'
+    ),
   llmTokenBudget: z.number().int().positive().optional(),
   llmMaxOutputTokensPerCall: z.number().int().positive().optional(),
   testGenerationLimit: z.number().int().positive().max(50).optional(),
@@ -201,7 +207,7 @@ mcpServer.registerTool(
   'analyze_app',
   {
     description:
-      'Analyze a deployed web app for quality gaps. Default response is summary-first (top gaps, cost summary, next checks). Set includeFullReport for the full gapAnalysis. Optional llmMaxOutputTokensPerCall / llmTokenBudget (legacy), testGenerationLimit, enableLlmScenarios align with @qulib/core HarnessConfig.',
+      'Analyze a deployed web app for quality gaps. Default response is summary-first (top gaps, cost summary, next checks). Set includeFullReport for the full gapAnalysis. Set agentSummary for the compact gate-decision payload (pass/warn/fail with honesty notes) — use this when calling from a CI gate or orchestrator. Optional llmMaxOutputTokensPerCall / llmTokenBudget (legacy), testGenerationLimit, enableLlmScenarios align with @qulib/core HarnessConfig.',
     inputSchema: AnalyzeInputSchema,
   },
   async (input) => {
@@ -257,7 +263,10 @@ mcpServer.registerTool(
         telemetry: telemetrySink,
       });
 
-      const payload = summarizeAnalyzeResult(result, input.includeFullReport === true);
+      const payload = buildAnalyzeAppMcpPayload(result, {
+        includeFullReport: input.includeFullReport,
+        agentSummary: input.agentSummary,
+      });
 
       return {
         content: [


### PR DESCRIPTION
## Summary

Stacked on the long-lived `feature/qlib-001-gate-summary` branch. **No version bump, no publish.** The release PR at the end of the chain bumps and ships everything.

This PR makes the gate summary actually reachable from MCP. After merge, an AI agent calling \`analyze_app\` can opt into the compact gate JSON by setting one input flag.

## What changed

- New \`buildAnalyzeAppMcpPayload(result, options)\` routes three response shapes through one place:
  - default → summary-first (unchanged)
  - \`{ includeFullReport: true }\` → full report (unchanged)
  - \`{ agentSummary: true }\` → \`toAgentSummary\` shape (new — overrides \`includeFullReport\`)
- \`analyze_app\` MCP input schema gains an optional \`agentSummary: boolean\` (Zod-validated, additive)
- Tool description updated so the LLM knows when to set the flag (CI gates, orchestrator decisions)
- 3 new unit tests covering each routing path

## Behavior contract

| Flag | Returns |
|---|---|
| neither set | \`{ summary, topGaps, costSummary, ... }\` — same as before |
| \`includeFullReport: true\` | Full \`AnalyzeResult\` — same as before |
| \`agentSummary: true\` | \`{ schemaVersion: 1, gate, coverageStatus, topRisks, honestyNotes, ... }\` — new |
| both flags true | agentSummary wins |

## Release chain

\`\`\`
main
  └── feature/qlib-001-gate-summary
        ├── ✅ #70 — toAgentSummary core (merged)
        ├── ◀️ THIS PR — MCP wiring
        ├── ⏳ #72 — CLI flag + spec doc
        └── ⏳ chore/release-0.6.0 → main (single publish)
\`\`\`

PRD: [docs/prds/QLIB-001-agent-summary-and-gate-output.md](docs/prds/QLIB-001-agent-summary-and-gate-output.md)

## Test plan
- [x] \`npm run build\` green
- [x] \`npm test\` green — 107 core + 10 mcp tests (was 7, +3 new for buildAnalyzeAppMcpPayload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)