### PR TITLE
feat(core): add --agent-summary CLI flag and spec doc

### DIFF
--- a/docs/agent-summary-output.md
+++ b/docs/agent-summary-output.md
@@ -1,0 +1,91 @@
+# Agent-facing summary output
+
+This document defines a **desired** consolidated JSON shape for orchestrators and AI agents, and compares it to **what exists today**.
+
+---
+
+## Status: planned vs implemented
+
+| Aspect | Status |
+|--------|--------|
+| `toAgentSummary(result, policy?)` helper exported from `@qulib/core` | **Implemented (QLIB-001-C02)** — see `packages/core/src/agent-summary.ts` and [design/agent-summary-policy.md](./design/agent-summary-policy.md). |
+| CLI `analyze --agent-summary` | **Implemented (QLIB-001-C03)** — stdout is only agent summary JSON; incompatible with `--ephemeral`. |
+| MCP `analyze_app` with `agentSummary: true` | **Implemented (QLIB-001-C04)** — response is only `toAgentSummary(result)` JSON. |
+| Unified top-level object with `gate`, `topRisks`, `recommendedNextChecks`, `honestyNotes`, etc. | **Implemented** via `toAgentSummary` (`schemaVersion: 1`). Exposed from **CLI** (`--agent-summary`) and **MCP** (`agentSummary: true`). |
+| MCP `analyze_app` default (summary-first) | **Implemented** — see `@qulib/mcp` `summarizeAnalyzeResult` and [packages/mcp/README.md](../packages/mcp/README.md). |
+| Full `AnalyzeResult` / report JSON on disk or with `includeFullReport: true` | **Implemented** — see `GapAnalysis` in `@qulib/core` schemas. |
+
+Orchestrators may consume the stable object via **`toAgentSummary`**, **CLI `--agent-summary`**, or **MCP `analyze_app` with `agentSummary: true`**. For the default MCP summary-first envelope, continue to use `summarizeAnalyzeResult` fields unless you need the gate-shaped object.
+
+---
+
+## Desired shape (QLIB-001 target)
+
+Stable, versioned object for gates and orchestration (e.g. tap-agent, CI). Field names are indicative; final names may follow strict semver / schema export rules.
+
+```json
+{
+  "gate": "warn",
+  "releaseConfidence": 64,
+  "coverageStatus": "thin",
+  "topRisks": [
+    "Auth blocked key routes",
+    "Low crawl coverage",
+    "Accessibility violations found"
+  ],
+  "recommendedNextChecks": [
+    "Run authenticated scan",
+    "Verify checkout flow manually",
+    "Review axe violations"
+  ],
+  "honestyNotes": [
+    "This scan does not guarantee production readiness.",
+    "Coverage was below confidence threshold."
+  ],
+  "costSummary": null,
+  "deterministicFollowUps": []
+}
+```
+
+### Field notes (normative intent)
+
+| Field | Description |
+|-------|-------------|
+| `gate` | **`pass` \| `warn` \| `fail`** — derived by `toAgentSummary()` from Qulib signals and optional `AgentSummaryPolicy`. Must align with **honest** semantics: e.g. `auth-required` or thin coverage cannot imply `pass` without explicit policy (see [design/agent-summary-policy.md](./design/agent-summary-policy.md)). |
+| `releaseConfidence` | Number **0–100** or orchestrator mapping when source is `null` (document why). Mirrors `gapAnalysis.releaseConfidence`. |
+| `coverageStatus` | Coarse enum for agents (e.g. `ok` \| `thin` \| `blocked-by-auth`). Maps from `coveragePagesScanned`, `coverageWarning`, and `mode`. |
+| `topRisks` | Short strings; may mirror top severities from `gaps` plus mode/coverage/auth context. |
+| `recommendedNextChecks` | Human/agent actionable; can align with MCP `nextDeterministicChecks` and Cost Intelligence `conversionRecommendations` when present. |
+| `honestyNotes` | **Required** for brand-consistent messaging: limits of scan, coverage floor, auth wall, etc. |
+| `costSummary` | Optional subset when Cost Intelligence ran (tokens, budget warnings, maturity). **Planned** as a stable slice; today see `costIntelligenceSummary` in MCP compact response. |
+| `deterministicFollowUps` | Structured list (strings or objects) of checks to implement in CI/playwright/axe, etc. Overlaps MCP `nextDeterministicChecks`. |
+
+---
+
+## What exists today (mapping hints)
+
+Agents can **construct** the planned shape from:
+
+- **`gapAnalysis.releaseConfidence`**, **`gapAnalysis.mode`**, **`gapAnalysis.coverageWarning`**, **`gapAnalysis.coveragePagesScanned`**
+- **`gaps`** (severity-sorted top N)
+- MCP compact payload: **`summary`**, **`topGaps`**, **`nextDeterministicChecks`**, **`costIntelligenceSummary`**, **`routeInventorySummary`**, **`decisionLogPreview`**
+
+`AnalyzeResult.status`: `complete` | `blocked` | `partial` — use alongside `mode` for honesty.
+
+---
+
+## Versioning and schema changes
+
+When QLIB-001 is implemented:
+
+- Document **schema version** in the summary object.
+- Any **breaking** change to report JSON or this summary requires **migration notes** in the changelog and agent docs.
+
+---
+
+## Related
+
+- [agent-usage.md](./agent-usage.md)  
+- [design/agent-summary-policy.md](./design/agent-summary-policy.md)  
+- [prds/QLIB-001-agent-summary-and-gate-output.md](./prds/QLIB-001-agent-summary-and-gate-output.md)  
+- [chunks/QLIB-001-C01-agent-summary-format.md](./chunks/QLIB-001-C01-agent-summary-format.md)  

--- a/docs/chunks/QLIB-001-C01-agent-summary-format.md
+++ b/docs/chunks/QLIB-001-C01-agent-summary-format.md
@@ -1,0 +1,42 @@
+# Work chunk: QLIB-001-C01 — Agent summary format (docs/spec only)
+
+**Initiative:** QLIB-001  
+**Type:** Documentation / specification  
+**Implementation code:** Out of scope for this chunk unless explicitly approved later.
+
+---
+
+## Objective
+
+Lock the **intended** machine-readable agent summary so Composer and orchestrators can implement against a stable target.
+
+---
+
+## Deliverables (done when this chunk merges)
+
+- [x] `docs/agent-summary-output.md` defines planned JSON shape vs current MCP/core fields.
+- [x] Mapping notes from `AnalyzeResult` / MCP compact payload to future fields (`gate`, `coverageStatus`, `topRisks`, etc.).
+- [x] Explicit statement: **`gate` is not emitted by core today**; orchestrators may derive interim gates from documented rules.
+
+---
+
+## Out of scope (next chunks)
+
+- TypeScript types + exported builder `toAgentSummary(result, policy)`.
+- CLI flag (e.g. `--agent-summary`) or MCP field to request summary-only artifact.
+- Golden tests for summary mapping.
+
+---
+
+## Acceptance criteria
+
+- A new contributor can read **only** `agent-summary-output.md` and know what is **shipped** vs **planned**.
+- Honesty requirements (`auth-required`, `low-coverage`) are reflected in field descriptions.
+
+---
+
+## References
+
+- [../prds/QLIB-001-agent-summary-and-gate-output.md](../prds/QLIB-001-agent-summary-and-gate-output.md)  
+- `packages/mcp/src/summarize-analyze-result.ts`  
+- `packages/core/src/schemas/gap-analysis.schema.ts`  

--- a/docs/design/agent-summary-policy.md
+++ b/docs/design/agent-summary-policy.md
@@ -1,0 +1,66 @@
+# Design note: default gate policy for `toAgentSummary`
+
+**Initiative:** QLIB-001  
+**Chunk:** C02 (helper + tests)  
+**Status:** Implemented for the pure helper. CLI and MCP surfaces are out of scope until C03/C04.
+
+---
+
+## Goal
+
+Provide a small, **honest**, **deterministic** mapping from `AnalyzeResult` to an agent-facing JSON summary, with a default gate (`pass | warn | fail`) that orchestrators can rely on without rewriting policy from scratch.
+
+---
+
+## Default policy (helper)
+
+Evaluated **in order**; first match wins.
+
+1. **`fail`** when any of:
+   - any **critical** gap exists,
+   - `result.status === 'blocked'`,
+   - `releaseConfidence` is `null`,
+   - `releaseConfidence < failConfidenceThreshold` (default `30`),
+   - `gapAnalysis.mode === 'auth-required'` **and** `authRequiredGate === 'fail'` (default).
+2. **`warn`** when any of:
+   - any **high** severity gap exists,
+   - `result.status === 'partial'`,
+   - coverage is **thin** / **budget-exceeded** / **navigation-failures**,
+   - `releaseConfidence < passConfidenceThreshold` (default `80`).
+3. **`pass`** otherwise.
+
+---
+
+## Why these defaults
+
+- **Honesty over fake confidence.** An `auth-required` scan never silently `pass`es by default; the deployment was not exercised past the auth boundary. Callers that *intentionally* run anonymous-only scans on protected products can override with `authRequiredGate: 'warn'` — explicit, not silent.
+- **Critical fails are always blocking.** Even at 100 release confidence, a critical accessibility or console finding outweighs the scalar score.
+- **Coverage warnings always degrade the gate.** `low-coverage`, `budget-exceeded`, and `navigation-failures` cannot promote to `pass`; they at least drop to `warn`.
+- **`null` confidence fails.** No score → no green light.
+- **Thresholds are policy.** `80 / 30` are conservative defaults; orchestrators that have measured their own product can lower them via `AgentSummaryPolicy`.
+
+---
+
+## What the helper does **not** do
+
+- Read or write files.
+- Hit the network.
+- Mutate the input.
+- Decide whether to publish, deploy, or merge — that is the orchestrator’s job.
+
+---
+
+## Forward compatibility
+
+- The summary carries `schemaVersion: 1`. Any breaking change to fields, gate semantics, or default policy bumps the version and is documented in CHANGELOG + `docs/agent-summary-output.md`.
+- New optional fields can be added at `schemaVersion: 1` only if existing consumers can ignore them safely.
+
+---
+
+## Related
+
+- [../agent-summary-output.md](../agent-summary-output.md)
+- [../prds/QLIB-001-agent-summary-and-gate-output.md](../prds/QLIB-001-agent-summary-and-gate-output.md)
+- [../chunks/QLIB-001-C01-agent-summary-format.md](../chunks/QLIB-001-C01-agent-summary-format.md)
+- `packages/core/src/agent-summary.ts`
+- `packages/core/src/__tests__/agent-summary.test.ts`

--- a/docs/prds/QLIB-001-agent-summary-and-gate-output.md
+++ b/docs/prds/QLIB-001-agent-summary-and-gate-output.md
@@ -1,0 +1,61 @@
+# PRD (draft): QLIB-001 — Agent summary and gate output
+
+**Status:** Implemented on `feature/qlib-001-agent-summary-gate` (C01–C04).  
+**Owner:** Maintainers / Composer via approved chunks.
+
+---
+
+## Problem
+
+Orchestrators and AI agents need a **small, stable, honest** summary of a Qulib run for gates and automation. Today:
+
+- MCP `analyze_app` returns a useful **summary-first** payload (implemented).
+- There is **no** first-party, versioned **unified JSON** with explicit `gate`, `coverageStatus`, and required **`honestyNotes`** for all consumers (planned).
+
+Fragmented interpretation risks **overclaiming** readiness.
+
+---
+
+## Goals
+
+1. Define (and optionally emit) a **versioned agent summary** aligned with [../agent-summary-output.md](../agent-summary-output.md).
+2. Support **orchestrator-owned** or **Qulib-bundled** gate policy (decision: document in implementation phase; default is honest mapping rules).
+3. Preserve **auth-required** and **low-coverage** semantics: they cannot silently map to “pass” without explicit policy documentation.
+
+---
+
+## Non-goals
+
+- Building a full multi-agent orchestrator in this repo.
+- Changing npm publish process.
+- Replacing the full `AnalyzeResult` report—summary is additive or a documented projection.
+
+---
+
+## Users
+
+- External orchestrators (CI, custom agents).
+- MCP clients that want one JSON blob for decisions.
+
+---
+
+## Acceptance criteria (draft)
+
+- [x] Spec in `docs/agent-summary-output.md` matches implemented fields.
+- [x] Summary includes **`honestyNotes`** when any limit applies (coverage, auth, budget, partial status).
+- [x] **`gate`** derivation rules documented; forbidden combinations tested (e.g. `auth-required` + `pass` unless explicit override flag).
+- [x] CLI (`--agent-summary`) and MCP (`agentSummary: true`) emit the summary.
+- [x] `schemaVersion: 1` on summary object; no breaking renames in this initiative.
+- [x] Tests for mapping from fixture `AnalyzeResult` → summary (`agent-summary.test.ts`).
+
+---
+
+## Risks
+
+- Gate semantics are **policy-sensitive**; wrong defaults damage trust. Mitigation: conservative defaults, explicit override, loud docs.
+
+---
+
+## Related chunks
+
+- [../chunks/QLIB-001-C01-agent-summary-format.md](../chunks/QLIB-001-C01-agent-summary-format.md)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "analyze": "tsx src/cli/index.ts analyze",
     "clean": "tsx src/cli/index.ts clean",
     "build": "tsc",
-    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/agent-summary.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts",
+    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/agent-summary.test.ts src/__tests__/cli-agent-summary.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts",
     "test:integration": "node --import tsx/esm --test src/__tests__/analyze.integration.test.ts",
     "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral",
     "cost-doctor": "tsx src/cli/index.ts cost doctor"

--- a/packages/core/src/__tests__/cli-agent-summary.test.ts
+++ b/packages/core/src/__tests__/cli-agent-summary.test.ts
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const corePkgRoot = resolve(__dirname, '..', '..');
+const cliEntry = resolve(__dirname, '..', 'cli', 'index.ts');
+
+function runCli(args: string[], cwd: string): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, ['--import', 'tsx/esm', cliEntry, ...args], {
+    encoding: 'utf8',
+    cwd,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+test('analyze rejects --agent-summary together with --ephemeral', () => {
+  const { status, stderr } = runCli(
+    ['analyze', '--url', 'https://example.com', '--agent-summary', '--ephemeral'],
+    corePkgRoot
+  );
+  assert.notEqual(status, 0, `expected failure, stderr: ${stderr}`);
+  assert.match(stderr, /Use either --agent-summary or --ephemeral/i);
+});

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -9,6 +9,7 @@ const requirePkg = createRequire(import.meta.url);
 const pkg = requirePkg('../../package.json') as { version: string };
 import { HarnessConfigSchema, type HarnessConfig } from '../schemas/config.schema.js';
 import { analyzeApp } from '../analyze.js';
+import { toAgentSummary } from '../agent-summary.js';
 import { detectAuth } from '../tools/auth/detect.js';
 import { exploreAuth } from '../tools/auth/explore.js';
 import {
@@ -108,6 +109,7 @@ async function runAnalyze(options: {
   repo?: string;
   configFile?: string;
   ephemeral?: boolean;
+  agentSummary?: boolean;
   skipAuthDetection?: boolean;
   authStorageState?: string;
   authFormLogin?: boolean;
@@ -118,15 +120,21 @@ async function runAnalyze(options: {
   passwordSelector?: string;
   submitSelector?: string;
 }): Promise<void> {
+  if (options.ephemeral && options.agentSummary) {
+    throw new Error('Use either --agent-summary or --ephemeral, not both — pick one stdout output mode.');
+  }
   const validatedUrl = AnalyzeUrlSchema.parse(options.url);
   const mode: AnalyzeMode = options.repo ? 'url-repo' : 'url-only';
   const baseConfig = await loadConfigFile(options.configFile ?? 'qulib.config.ts');
   const config = mergeAuthFromCli(baseConfig, options);
   const ephemeral = options.ephemeral ?? false;
-  const writeArtifacts = !ephemeral;
+  const agentSummary = options.agentSummary ?? false;
+  const writeArtifacts = !ephemeral && !agentSummary;
 
   if (ephemeral) {
     console.error('[qulib] Ephemeral mode: no disk writes; full result JSON on stdout');
+  } else if (agentSummary) {
+    console.error('[qulib] Agent-summary mode: no disk writes; agent gate JSON on stdout');
   } else {
     console.log('[qulib] Detected mode:', mode);
     console.log('[qulib] Active config:', redactConfigForLog(config));
@@ -140,6 +148,10 @@ async function runAnalyze(options: {
     skipAuthDetection: options.skipAuthDetection,
   });
 
+  if (agentSummary) {
+    console.log(JSON.stringify(toAgentSummary(result), null, 2));
+    return;
+  }
   if (ephemeral) {
     console.log(
       JSON.stringify(
@@ -215,6 +227,7 @@ program
     'playwright'
   )
   .option('--ephemeral', 'Do not write to disk — return full report as JSON on stdout (use for MCP/CI)', false)
+  .option('--agent-summary', 'Do not write to disk — return the compact agent-summary gate JSON on stdout (pass/warn/fail with honesty notes). Mutually exclusive with --ephemeral.', false)
   .option('--skip-auth-detection', 'Crawl the public surface even if auth is detected (useful for sites with sign-in CTAs on public pages)', false)
   .option(
     '--auth-storage-state <path>',
@@ -241,6 +254,7 @@ program
       repo: options.repo,
       configFile: options.config,
       ephemeral: options.ephemeral,
+      agentSummary: options.agentSummary,
       skipAuthDetection: Boolean(options.skipAuthDetection),
       authStorageState: options.authStorageState,
       authFormLogin,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "npm --prefix ../.. run build -w @qulib/core && tsc && chmod +x dist/index.js",
     "dev": "tsx src/index.ts",
-    "test": "node --import tsx/esm --test src/__tests__/summarize-analyze-result.test.ts"
+    "test": "node --import tsx/esm --test src/__tests__/summarize-analyze-result.test.ts src/__tests__/analyze-app-mcp-payload.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp/src/__tests__/analyze-app-mcp-payload.test.ts
+++ b/packages/mcp/src/__tests__/analyze-app-mcp-payload.test.ts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAnalyzeAppMcpPayload } from '../analyze-app-mcp-payload.js';
+import type { AnalyzeResult } from '@qulib/core';
+
+const minimalAnalyzeResult = (): AnalyzeResult => {
+  const gaps = [
+    {
+      id: '1',
+      path: '/a',
+      severity: 'high' as const,
+      reason: 'console',
+      category: 'console-error' as const,
+    },
+  ];
+  return {
+    status: 'complete',
+    coverageScore: 100,
+    releaseConfidence: 85,
+    gaps,
+    gapAnalysis: {
+      analyzedAt: new Date().toISOString(),
+      mode: 'url-only',
+      releaseConfidence: 85,
+      coveragePagesScanned: 5,
+      coverageBudgetExceeded: false,
+      gaps,
+      scenarios: [],
+      generatedTests: [],
+    },
+    routeInventory: {
+      scannedAt: new Date().toISOString(),
+      baseUrl: 'https://example.com',
+      routes: [],
+      pagesSkipped: 0,
+      budgetExceeded: false,
+    },
+    repoInventory: null,
+    decisionLog: [],
+    publicSurface: null,
+  };
+};
+
+test('buildAnalyzeAppMcpPayload default matches summarize-first (no agentSummary)', () => {
+  const r = minimalAnalyzeResult();
+  const out = buildAnalyzeAppMcpPayload(r, {}) as Record<string, unknown>;
+  assert.equal(out.includeFullReport, false);
+  assert.ok('summary' in out);
+  assert.ok('topGaps' in out);
+});
+
+test('buildAnalyzeAppMcpPayload agentSummary returns only toAgentSummary shape', () => {
+  const r = minimalAnalyzeResult();
+  const out = buildAnalyzeAppMcpPayload(r, { agentSummary: true }) as Record<string, unknown>;
+  assert.equal(out.schemaVersion, 1);
+  assert.ok('gate' in out);
+  assert.ok('coverageStatus' in out);
+  assert.ok(Array.isArray(out.topRisks));
+  assert.ok(Array.isArray(out.honestyNotes));
+  assert.ok(!('summary' in out));
+  assert.ok(!('topGaps' in out));
+});
+
+test('buildAnalyzeAppMcpPayload agentSummary overrides includeFullReport', () => {
+  const r = minimalAnalyzeResult();
+  const out = buildAnalyzeAppMcpPayload(r, { agentSummary: true, includeFullReport: true }) as Record<string, unknown>;
+  assert.equal(out.schemaVersion, 1);
+  assert.ok(!('gapAnalysis' in out));
+});

--- a/packages/mcp/src/analyze-app-mcp-payload.ts
+++ b/packages/mcp/src/analyze-app-mcp-payload.ts
@@ -1,0 +1,23 @@
+import type { AnalyzeResult } from '@qulib/core';
+import { toAgentSummary } from '@qulib/core';
+import { summarizeAnalyzeResult } from './summarize-analyze-result.js';
+
+export interface AnalyzeAppMcpPayloadOptions {
+  includeFullReport?: boolean;
+  /** When true, returns only `toAgentSummary(result)` JSON (QLIB-001). Ignores `includeFullReport`. */
+  agentSummary?: boolean;
+}
+
+/**
+ * Single place for analyze_app response shaping: default summary-first,
+ * optional full report, or compact agent gate summary.
+ */
+export function buildAnalyzeAppMcpPayload(
+  result: AnalyzeResult,
+  input: AnalyzeAppMcpPayloadOptions
+): unknown {
+  if (input.agentSummary === true) {
+    return toAgentSummary(result);
+  }
+  return summarizeAnalyzeResult(result, input.includeFullReport === true);
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -25,7 +25,7 @@ import {
 } from '@qulib/core';
 import type { HarnessConfig, AnalyzeProgressSink, TelemetrySink } from '@qulib/core';
 import { z } from 'zod';
-import { summarizeAnalyzeResult } from './summarize-analyze-result.js';
+import { buildAnalyzeAppMcpPayload } from './analyze-app-mcp-payload.js';
 import { log } from './logger.js';
 
 function toolError(code: string, message: string, detail?: unknown): {
@@ -87,6 +87,12 @@ const AnalyzeInputSchema = z.object({
   timeoutMs: z.number().int().positive().optional(),
   auth: z.discriminatedUnion('type', [FormLoginMcpAuthSchema, StorageStateMcpAuthSchema]).optional(),
   includeFullReport: z.boolean().optional(),
+  agentSummary: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, return only the versioned agent-summary JSON ({ schemaVersion: 1, gate, coverageStatus, topRisks, recommendedNextChecks, honestyNotes, costSummary, deterministicFollowUps }). Use this for CI gates and orchestrators that need a single small payload to decide pass/warn/fail. Overrides includeFullReport.'
+    ),
   llmTokenBudget: z.number().int().positive().optional(),
   llmMaxOutputTokensPerCall: z.number().int().positive().optional(),
   testGenerationLimit: z.number().int().positive().max(50).optional(),
@@ -201,7 +207,7 @@ mcpServer.registerTool(
   'analyze_app',
   {
     description:
-      'Analyze a deployed web app for quality gaps. Default response is summary-first (top gaps, cost summary, next checks). Set includeFullReport for the full gapAnalysis. Optional llmMaxOutputTokensPerCall / llmTokenBudget (legacy), testGenerationLimit, enableLlmScenarios align with @qulib/core HarnessConfig.',
+      'Analyze a deployed web app for quality gaps. Default response is summary-first (top gaps, cost summary, next checks). Set includeFullReport for the full gapAnalysis. Set agentSummary for the compact gate-decision payload (pass/warn/fail with honesty notes) — use this when calling from a CI gate or orchestrator. Optional llmMaxOutputTokensPerCall / llmTokenBudget (legacy), testGenerationLimit, enableLlmScenarios align with @qulib/core HarnessConfig.',
     inputSchema: AnalyzeInputSchema,
   },
   async (input) => {
@@ -257,7 +263,10 @@ mcpServer.registerTool(
         telemetry: telemetrySink,
       });
 
-      const payload = summarizeAnalyzeResult(result, input.includeFullReport === true);
+      const payload = buildAnalyzeAppMcpPayload(result, {
+        includeFullReport: input.includeFullReport,
+        agentSummary: input.agentSummary,
+      });
 
       return {
         content: [


### PR DESCRIPTION
## Summary

Stacked on PR #71, which is stacked on the long-lived \`feature/qlib-001-gate-summary\` branch. **No version bump.** Final piece of the agent-summary feature — after this lands, the gate output is reachable from both consumer surfaces (MCP + CLI) and there's a public spec doc to point users at.

## What changed

- New CLI flag \`qulib analyze --url <url> --agent-summary\` — emits the versioned gate JSON on stdout, writes nothing to disk
- Mutually exclusive with \`--ephemeral\` (errors clearly if both are set)
- New \`docs/agent-summary-output.md\` — the public spec for shape, gate-derivation rules, policy overrides, and the \`schemaVersion: 1\` stability contract
- Test: spawn-based CLI test verifies the \`--agent-summary\` + \`--ephemeral\` mutex

## Usage

\`\`\`bash
qulib analyze --url https://notquality.com --agent-summary
# prints:
# {
#   \"schemaVersion\": 1,
#   \"gate\": \"warn\",
#   \"releaseConfidence\": 64,
#   \"coverageStatus\": \"thin\",
#   \"topRisks\": [...],
#   \"honestyNotes\": [...],
#   ...
# }
\`\`\`

## Release chain
\`\`\`
main
  └── feature/qlib-001-gate-summary
        ├── ✅ #70 — toAgentSummary core (merged)
        ├── #71 — MCP wiring
        └── ◀️ THIS PR — CLI flag + spec doc
              (then) chore/release-0.6.0 → main (single publish)
\`\`\`

PRD: [docs/prds/QLIB-001-agent-summary-and-gate-output.md](docs/prds/QLIB-001-agent-summary-and-gate-output.md)

## Test plan
- [x] \`npm run build\` green
- [x] \`npm test\` green — 108 core (+1 mutex test) + 10 mcp = 118 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)