### PR TITLE
docs: add public agent-usage docs, draft PRDs, and sync CLAUDE.md to v0.5.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ packages/mcp/src/    — MCP tool wrappers over core
 
 The release plan lives in `roadmap.json` at the repo root. Any agent planning work reads it first.
 
-**Current:** v0.5.2 on main, v0.5.1 on npm registry.
+**Current:** v0.5.3 on main and npm registry.
 
 **Target:** v1.0.0 — full auth intelligence, composable audit tools, CI integration.
 
@@ -208,7 +208,7 @@ When spawning subagents, include:
 When shipping multiple dependent changes:
 
 ```
-main (v0.5.2)
+main (v0.5.3)
   └── fix/thing           → PR, CI green, merge
         └── chore/release-0.5.3  → PR, CI green, merge, PUBLISH
               └── feature/next   → PR, CI green, merge

--- a/docs/agent-classes-for-qulib.md
+++ b/docs/agent-classes-for-qulib.md
@@ -1,0 +1,106 @@
+# Agent classes for Qulib
+
+Optional **taxonomy** for humans or external orchestrators working on the Qulib product. These are **not** runtime classes inside the Qulib npm packages; they describe **roles**, inputs/outputs, and handoffs so work stays scoped and honest to the product’s positioning.
+
+**Orchestration** (who invokes whom, in what order) lives **outside** this repo—see [orchestrator-integration.md](./orchestrator-integration.md).
+
+Notation: names like `Researcher<qulib>` mean “this role applied to the Qulib codebase/product.”
+
+---
+
+## `Researcher<qulib>`
+
+| | |
+|--|--|
+| **Purpose** | Discover what Qulib should become next: UX of README/CLI/MCP, positioning, competitor landscape, misunderstanding risks around confidence scores. |
+| **Inputs** | Public repo: README, docs, issue search, MCP README, sample outputs (redacted URLs if needed). |
+| **Outputs** | **Research Findings Handoff** (structured notes, no code changes). |
+| **Blocked** | Implementing features, editing production code “by the way,” claiming scan guarantees. |
+| **Handoff** | Findings document → **`Supervisor<qulib>`**. |
+
+---
+
+## `Supervisor<qulib>`
+
+| | |
+|--|--|
+| **Purpose** | Consolidate research into **initiative options**, impact/effort/risk, sequencing—**proposal packs** only. |
+| **Inputs** | Research Findings Handoff; maintainer priorities. |
+| **Outputs** | Proposal pack (e.g. Option A/B/C + recommendation). |
+| **Blocked** | Approving or merging work; writing PRDs in final form (unless your process merges Supervisor + Planner). |
+| **Handoff** | Proposal pack → **human decision** → **`Planner<qulib>`** when an initiative is approved. |
+
+---
+
+## `Planner<qulib>`
+
+| | |
+|--|--|
+| **Purpose** | Turn an approved initiative into a **PRD**, work chunks, acceptance criteria, QA plan, Composer-ready tasks. |
+| **Inputs** | Approved proposal; constraints (no schema break without migration, etc.). |
+| **Outputs** | PRD doc(s), chunk files, AC, test plan. |
+| **Blocked** | Large unreviewed code dumps; skipping honesty / coverage / auth semantics. |
+| **Handoff** | PRD + chunks → **`Composer<qulib>`**; parallel **`Reporter<qulib:report-stream>`** for human-readable status if desired. |
+
+---
+
+## `Composer<qulib>`
+
+| | |
+|--|--|
+| **Purpose** | Implement approved chunks: CLI, MCP, docs, report formats, tests, examples. |
+| **Inputs** | Approved chunk specs; `COMPOSER_REFERENCE`-style internal notes if your org maintains them (external to Qulib or in `.cursor/` as you prefer). |
+| **Outputs** | PR-ready code and doc updates. |
+| **Blocked** | Changing **public report schema** without **migration notes**; publishing npm or bumping versions without maintainer approval; building from vague ideas; marketing language that **overclaims** scan completeness. |
+| **Handoff** | Branch/PR → **`QA<qulib>`**. |
+
+---
+
+## `QA<qulib>`
+
+| | |
+|--|--|
+| **Purpose** | Validate before merge/release: correctness, docs accuracy, honesty of user-facing language. |
+| **Inputs** | PR diff; CLI/MCP examples; schema changelog if applicable. |
+| **Outputs** | QA notes, pass/fail, required fixes. |
+| **Checks** | Build/tests green; CLI smoke paths; MCP docs match tool payloads; schema changes documented; **low coverage** / **auth-required** never presented as “ready”; no overclaiming. |
+| **Handoff** | QA sign-off → maintainer merge / release process. |
+
+---
+
+## `Accountant<qulib>`
+
+| | |
+|--|--|
+| **Purpose** | Track **agent/orchestration cost** against shipped value (per PRD, chunk, feature class). Aligns with Qulib’s **Cost Intelligence** theme: prefer deterministic checks where LLM work repeats. |
+| **Inputs** | Token/cost logs from your orchestrator; optional Qulib `costIntelligence` blocks from runs. |
+| **Outputs** | Cost rollups, “determinize this next” candidates. |
+| **Blocked** | Replacing product Cost Intelligence docs with private financial data in this repo. |
+| **Handoff** | Metrics brief → **Supervisor** / **Planner** for prioritization. |
+
+---
+
+## `Reporter<qulib>`
+
+| | |
+|--|--|
+| **Purpose** | Make streams of findings readable: executive summaries, initiative dashboards, cost vs time, model velocity. |
+| **Instances (examples)** | `Reporter<qulib:cost-vs-time>`, `Reporter<qulib:model-velocity-vs-cost>`, `Reporter<qulib:workflow-efficiency>`, `Reporter<qulib:report-stream>` (aggregate research, QA, cost, proposals without noise). |
+| **Inputs** | Artifacts from other roles. |
+| **Outputs** | Digest docs or messages (format depends on orchestrator). |
+| **Blocked** | Silent rewriting of technical facts; dropping honesty notes. |
+| **Handoff** | Digests to humans or downstream automation. |
+
+---
+
+## Suggested workflow (external)
+
+Research → Supervisor proposal → **Human chooses** → Planner (PRD + chunks) → Composer → QA → release.
+
+---
+
+## Related
+
+- [agent-usage.md](./agent-usage.md)  
+- [deterministic-opportunities.md](./deterministic-opportunities.md)  
+- [prds/](./prds/)  

--- a/docs/agent-usage.md
+++ b/docs/agent-usage.md
@@ -1,0 +1,111 @@
+# Agent usage guide
+
+This document is for **AI agents and orchestrators** that consume Qulib (CLI, programmatic API, or MCP). Qulib answers: **“Is this app ready to ship?”** It prefers **honest uncertainty** over fake confidence when coverage is thin, auth blocks the crawl, or data is incomplete.
+
+Orchestration (Slack flows, PRDs, multi-agent routing) lives **outside** this repository. Qulib only provides scan intelligence, reports, and MCP tools.
+
+---
+
+## CLI (quick reference)
+
+From the published package:
+
+```bash
+npx @qulib/core analyze --url https://example.com
+```
+
+From a clone of this monorepo (repo root):
+
+```bash
+npm run analyze -w @qulib/core -- --url https://example.com
+```
+
+**Smoke (no disk writes, stdout JSON):**
+
+```bash
+npm run smoke
+```
+
+**Agent summary (writes `output/report.json`; stdout is only `toAgentSummary` JSON; progress on stderr):**
+
+```bash
+npm run analyze -w @qulib/core -- --url https://example.com --agent-summary
+```
+
+**Cost doctor** (after an analyze run that wrote `output/report.json` under `packages/core`):
+
+```bash
+cd packages/core && npx tsx src/cli/index.ts cost doctor
+```
+
+For full flags, artifact layout, and Cost Intelligence options, see [packages/core/README.md](../packages/core/README.md).
+
+---
+
+## MCP (quick reference)
+
+Configure your MCP host with `npx` / `npx -y` and the `@qulib/mcp` package. Optional `ANTHROPIC_API_KEY` enables LLM-backed scenario generation; without it, template scenarios still run.
+
+Main tools today:
+
+| Tool | Role |
+|------|------|
+| `explore_auth` | Discover sign-in paths and requirements before a deep scan. |
+| `detect_auth` | Lighter single-pattern auth hint. |
+| `analyze_app` | Full quality scan; **default response is summary-first**. |
+| `qulib_score_automation` | Score a **local** automation repo (requires absolute `repoPath` on the host). |
+
+For `analyze_app`, pass **`includeFullReport: true`** only when you need the full `gapAnalysis` (all scenarios, generated tests) and full `repoInventory` arrays. Default keeps context small: summary, top gaps, cost summary when present, `nextDeterministicChecks`, previews. Pass **`agentSummary: true`** when you need **only** the compact gate summary (`toAgentSummary`); that replaces the default envelope for that call (and ignores `includeFullReport` for the response shape).
+
+Details: [packages/mcp/README.md](../packages/mcp/README.md).
+
+---
+
+## How to interpret release confidence
+
+- **Release confidence** is a **0–100** score derived from prioritized gaps (see engine in `packages/core/src/tools/gap-engine.ts` and scoring in `packages/core/src/tools/scoring/gaps.ts`).
+- It reflects **evaluated pages**, not guaranteed production quality. **Never** present it as “the app is bug-free.”
+- If **`coverageWarning` is `low-coverage`**, fewer than `minPagesForConfidence` pages were scanned: confidence is **capped** (see root README and core README) so thin coverage does not read as “ready.”
+- If **`mode` is `auth-required`**, the deployment was **not** exercised past the auth boundary in that run: treat inventory and confidence accordingly (often **0** with no meaningful gap inventory for the protected surface).
+
+`AnalyzeResult.status` is `complete`, `blocked`, or `partial`—use it with `gapAnalysis.mode` and `coverageWarning`, not as a shipping gate by itself.
+
+---
+
+## Low coverage
+
+When `coverageWarning === 'low-coverage'` (or summary text mentions coverage floor):
+
+- State clearly that **conclusions are limited** by page count.
+- Recommend **more crawl budget**, **deeper entry URLs**, or **authenticated** scanning if the product surface is behind login.
+- Do **not** summarize as “high confidence” or “ready to ship” without qualifying coverage.
+
+---
+
+## Auth-required exits
+
+When `gapAnalysis.mode === 'auth-required'` (or `coverageWarning === 'auth-required'`):
+
+- The scan **did not** validate authenticated routes in that run.
+- Next steps for humans/agents: use documented **form login**, **storage state** (CLI), or MCP `explore_auth` / `detect_auth` guidance—**OAuth** flows still require human consent; Qulib does not automate third-party IdP consent.
+
+Do not invent gaps for pages that were never reached.
+
+---
+
+## Avoid overclaiming scan results
+
+- Qulib checks **crawl reachability**, **axe** rules on visited pages, **links**, **console** signals, and **navigation** failures within harness limits—not every user journey, payment edge case, or backend contract.
+- **Cost Intelligence** (when enabled) is about **LLM usage inside the gap-analysis harness**, not about your product’s cloud bill.
+- Prefer language such as: “Within this scan’s reach, …” and cite **`status`**, **`mode`**, **`coverageWarning`**, and **`releaseConfidence`**.
+
+For a **single machine-readable summary** with an explicit **`gate`** field, use [agent-summary-output.md](./agent-summary-output.md) (`toAgentSummary`, CLI `--agent-summary`, MCP `agentSummary: true`). For the default MCP envelope (top gaps, cost slice, next checks), use `summarizeAnalyzeResult` as described in the MCP README.
+
+---
+
+## Related docs
+
+- [agent-summary-output.md](./agent-summary-output.md) — agent summary schema and surfaces  
+- [orchestrator-integration.md](./orchestrator-integration.md) — external orchestrators, no coupling  
+- [agent-classes-for-qulib.md](./agent-classes-for-qulib.md) — optional role taxonomy for humans/agents  
+- [deterministic-opportunities.md](./deterministic-opportunities.md) — repeated reasoning → checks  

--- a/docs/deterministic-opportunities.md
+++ b/docs/deterministic-opportunities.md
@@ -1,0 +1,65 @@
+# Deterministic tooling opportunities
+
+Qulib’s design line: **deterministic checks scale**; **LLMs explore gaps**. Cost Intelligence exists to surface when repeated LLM reasoning should graduate into owned checks.
+
+This document lists **candidates** for automation (CI, validators, small CLIs)—some may already be partially covered by tests; others are **ideas** for QLIB-005–style work. Nothing here promises a shipped tool until implemented.
+
+---
+
+## Report and schema validation
+
+| Opportunity | Rationale |
+|-------------|-----------|
+| Validate full report JSON against `GapAnalysis` / `AnalyzeResult` shapes | Catch schema drift between core and MCP consumers early. |
+| Validate **agent summary** output (post–QLIB-001) | Ensure `gate` / `honestyNotes` / required fields present when orchestrators depend on them. |
+
+---
+
+## Gate and policy config
+
+| Opportunity | Rationale |
+|-------------|-----------|
+| Validate **gate policy** files (thresholds, forbidden `pass` when `auth-required`) | Prevents CI from green-lighting blocked states by misconfiguration. |
+
+*First-party gate defaults live in `toAgentSummary()` / `AgentSummaryPolicy`; orchestrators may still apply stricter rules.*
+
+---
+
+## Docs and examples
+
+| Opportunity | Rationale |
+|-------------|-----------|
+| Lint or test **CLI examples** in README/docs (copy-paste commands) | Reduces doc rot. |
+| Check MCP README **tool list** against registered tools in `@qulib/mcp` | Surfaces rename/add/remove drift. |
+
+---
+
+## Cost ledger summarization
+
+| Opportunity | Rationale |
+|-------------|-----------|
+| Summarize `costIntelligence` / usage records for regression (golden tests) | Stable expectations for token shape and budget warning counts in fixtures. |
+
+---
+
+## Scan-state detection
+
+| Opportunity | Rationale |
+|-------------|-----------|
+| Deterministic classification of **low coverage** vs **ok** vs **auth-required** | Same logic QLIB-001 would use for `coverageStatus` / `honestyNotes` templates—avoid LLM re-deriving each time. |
+
+Core already encodes much of this in `gapAnalysis.mode`, `coverageWarning`, and scoring; exposing a **single function** or export for orchestrators is a small API enhancement (spec in QLIB-001 chunk).
+
+---
+
+## Related initiatives
+
+- **QLIB-001** — Agent summary + gate output (see [prds/QLIB-001-agent-summary-and-gate-output.md](./prds/QLIB-001-agent-summary-and-gate-output.md)).  
+- **QLIB-005** (portfolio-level name) — Broader “deterministic tooling” program; can fold items above into chunks as needed.  
+
+---
+
+## Related docs
+
+- [agent-summary-output.md](./agent-summary-output.md)  
+- [agent-usage.md](./agent-usage.md)  

--- a/docs/orchestrator-integration.md
+++ b/docs/orchestrator-integration.md
@@ -1,0 +1,43 @@
+# Orchestrator integration
+
+Qulib is designed to be consumed by **external orchestrators** (for example a portfolio-level “tap-agent” style system) **without** embedding orchestration logic in this repository.
+
+---
+
+## What Qulib provides
+
+- **QA intelligence:** crawl-backed signals, accessibility (axe), broken links, console errors, navigation failures, prioritized gaps.
+- **Release-readiness signal:** `releaseConfidence`, coverage floors, explicit **`auth-required`** and **`low-coverage`** semantics.
+- **MCP surface:** `analyze_app`, auth helpers, optional automation repo scoring (`qulib_score_automation`).
+- **Optional Cost Intelligence:** token usage, budgets, fingerprints, maturity hints inside the harness (when enabled).
+
+---
+
+## How an orchestrator should use Qulib
+
+1. **As a signal, not a verdict**  
+   Combine Qulib output with policy (thresholds, required authenticated paths, manual sign-off). Qulib already avoids fake confidence when data is thin; orchestrators should preserve that.
+
+2. **As a release gate (policy layer)**  
+   Use **`toAgentSummary(result, policy?)`** from `@qulib/core` (CLI `--agent-summary`, MCP `agentSummary: true`) for a versioned object with `gate`, `coverageStatus`, and `honestyNotes`. Override thresholds via `AgentSummaryPolicy`; orchestrators may still apply stricter rules on top.
+
+3. **As a benchmark signal**  
+   Synthetic or seeded apps (e.g. notquality-style playgrounds) can compare runs over time: confidence trends, gap counts, and whether deterministic follow-ups reduced LLM cost.
+
+4. **Without repository coupling**  
+   Depend on **published packages** (`@qulib/core`, `@qulib/mcp`), CLI contracts, and documented JSON. Do not assume private monorepo paths or org-internal identifiers in this repo’s docs.
+
+---
+
+## What Qulib does not own
+
+- Multi-agent routing, Slack threads, PRD storage, cost accounting across unrelated tools.
+- **npm publish** or version bumps from agent sessions (human-maintained release process).
+
+---
+
+## Related docs
+
+- [agent-usage.md](./agent-usage.md)  
+- [agent-summary-output.md](./agent-summary-output.md)  
+- [agent-classes-for-qulib.md](./agent-classes-for-qulib.md)  

--- a/docs/prds/QLIB-002-ux-product-refresh.md
+++ b/docs/prds/QLIB-002-ux-product-refresh.md
@@ -1,0 +1,46 @@
+# PRD (draft): QLIB-002 — UX / product research refresh
+
+**Status:** Draft — research-led; no implementation commitment in this file.
+
+---
+
+## Problem
+
+README, CLI quick start, MCP onboarding, and release-confidence language must stay **clear**, **honest**, and **aligned** with what the harness actually measures. Without periodic refresh, agents and humans misread confidence or Cost Intelligence scope.
+
+---
+
+## Goals
+
+1. README / docs audit: first-run success, honest uncertainty, Cost Intelligence explained as **harness LLM cost**, not customer cloud spend unless stated.
+2. Identify misunderstanding hotspots (confidence vs coverage, `auth-required`, MCP `includeFullReport`).
+3. Produce a prioritized backlog of doc and UX fixes (may spawn small implementation PRs).
+
+---
+
+## Non-goals
+
+- Rebranding the product name or npm scope without maintainer decision.
+- Adding orchestration to Qulib.
+
+---
+
+## Suggested inputs
+
+- `Researcher<qulib>` findings (external process).
+- Support issues / discussions (if public).
+
+---
+
+## Acceptance criteria (draft)
+
+- [ ] Published doc set (root README, core README, MCP README, [../agent-usage.md](../agent-usage.md)) cross-linked without contradiction.
+- [ ] At least one **“common mistakes”** subsection or doc (location TBD).
+- [ ] Research notes stored per your portfolio process (not necessarily in this repo).
+
+---
+
+## Related
+
+- [../agent-classes-for-qulib.md](../agent-classes-for-qulib.md)  
+- [QLIB-004-mcp-agent-usage-guide.md](./QLIB-004-mcp-agent-usage-guide.md)  

--- a/docs/prds/QLIB-003-cost-intelligence-reporting.md
+++ b/docs/prds/QLIB-003-cost-intelligence-reporting.md
@@ -1,0 +1,45 @@
+# PRD (draft): QLIB-003 — Cost Intelligence reporting UX
+
+**Status:** Draft — Cost Intelligence exists in core/MCP; this PRD targets **how it is presented** to humans and agents.
+
+---
+
+## Background (implemented today)
+
+Core can attach **Cost Intelligence** to gap analysis: token usage, budget warnings, prompt fingerprints, deterministic maturity hints, conversion recommendations (when the harness runs LLM-backed phases). MCP compact responses expose `costIntelligenceSummary` and may include fuller `costIntelligence` depending on payload design—see `@qulib/mcp` implementation.
+
+---
+
+## Problem
+
+Dense JSON is hard for agents to summarize consistently; humans may confuse **harness LLM cost** with **application hosting cost**.
+
+---
+
+## Goals
+
+1. **Clarify semantics** in UI/docs: what is measured, when `costSummary` is null, what “maturity” implies.
+2. Improve **scan readability**: short human strings + stable machine fields (may overlap QLIB-001 `costSummary`).
+3. Optional: CLI `cost doctor` discoverability from main docs (already partially documented).
+
+---
+
+## Non-goals
+
+- Building a hosted billing product inside Qulib.
+- Storing API keys or user secrets (never).
+
+---
+
+## Acceptance criteria (draft)
+
+- [ ] Terminology glossary (tokens, budget warning, fingerprint, maturity) in docs or report appendix.
+- [ ] Agent-facing guidance: when to run full vs compact MCP for cost reasons.
+- [ ] No overclaiming: Cost Intelligence does not assert “you saved $X in production.”
+
+---
+
+## Related
+
+- [../deterministic-opportunities.md](../deterministic-opportunities.md)  
+- [../agent-summary-output.md](../agent-summary-output.md)  

--- a/docs/prds/QLIB-004-mcp-agent-usage-guide.md
+++ b/docs/prds/QLIB-004-mcp-agent-usage-guide.md
@@ -1,0 +1,38 @@
+# PRD (draft): QLIB-004 — MCP agent usage guide
+
+**Status:** Draft — much of the content already lives in [packages/mcp/README.md](../../packages/mcp/README.md) and [../agent-usage.md](../agent-usage.md); this PRD tracks **consolidation and gaps**.
+
+---
+
+## Problem
+
+MCP hosts differ (Cursor, Claude Desktop, Claude Code). Agents need a **single checklist**: tools, auth flow order, `includeFullReport`, env vars, Playwright install, and honesty rules.
+
+---
+
+## Goals
+
+1. Ensure [../agent-usage.md](../agent-usage.md) and MCP README **do not diverge** on tool names and defaults.
+2. Add **decision tree**: when `explore_auth` vs `detect_auth`; when compact vs full report; when `qulib_score_automation` applies.
+3. Document **privacy boundaries** (API keys in host env only; `repoPath` local absolute path requirement).
+
+---
+
+## Non-goals
+
+- Documenting proprietary orchestrators by name beyond generic “external orchestrator” examples.
+
+---
+
+## Acceptance criteria (draft)
+
+- [ ] Tool table in one canonical place with others linking to it.
+- [ ] Example JSON payloads for common agent turns (redacted URLs).
+- [ ] Troubleshooting: `QULIB_DEBUG`, Playwright chromium install.
+
+---
+
+## Related
+
+- [../agent-usage.md](../agent-usage.md)  
+- [../orchestrator-integration.md](../orchestrator-integration.md)  


### PR DESCRIPTION
## Summary

Cleans up the docs/ directory in preparation for making the repo public, and syncs `CLAUDE.md` to the current shipped version.

## What's added

**Public agent + integration docs:**
- \`docs/agent-usage.md\` — how AI agents and orchestrators consume qulib
- \`docs/agent-classes-for-qulib.md\` — optional taxonomy for external orchestrators
- \`docs/deterministic-opportunities.md\` — the deterministic-checks-scale design line
- \`docs/orchestrator-integration.md\` — how to consume qulib without embedding orchestration

**Draft PRDs (shows product direction):**
- \`docs/prds/QLIB-002-ux-product-refresh.md\` — research-led
- \`docs/prds/QLIB-003-cost-intelligence-reporting.md\` — existing feature UX
- \`docs/prds/QLIB-004-mcp-agent-usage-guide.md\` — doc consolidation

## What's updated

- \`CLAUDE.md\` current-version refs bumped from v0.5.2 / v0.5.1 → v0.5.3 on main and npm

## Not in this PR

- \`docs/agent-summary-output.md\` and the QLIB-001 PRD/chunk/design notes are in PR #72 (chunk 3 of the agent-summary feature) — they travel with that feature
- \`roadmap.json\` is gitignored (local-only state file) and not committed

## Test plan
- [x] No code change; docs-only PR
- [x] All committed docs verified clean of internal/employer references

🤖 Generated with [Claude Code](https://claude.com/claude-code)