### PR TITLE
chore: release v0.6.0 — agent-summary gate output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Entries for **0.3.1 and earlier** were reconstructed from git tags (`v0.1.1` … `v0.2.2`) and release commits on `main`.
 
+## [0.6.0] — 2026-05-27
+
+### Added
+- **@qulib/core:** `toAgentSummary(result, policy?)` — a pure, no-I/O helper that projects an `AnalyzeResult` into a small versioned JSON shape (`schemaVersion: 1`) with `gate: 'pass' | 'warn' | 'fail'`, `coverageStatus`, `topRisks`, `recommendedNextChecks`, `honestyNotes`, `costSummary`, and `deterministicFollowUps`. Designed for orchestrators (CI gates, AI agents) that need a single small payload to decide whether a scan is good enough to ship. Conservative defaults — critical gaps, blocked status, or `auth-required` mode never silently pass.
+- **@qulib/core CLI:** `qulib analyze --agent-summary` — emits the agent-summary JSON on stdout and writes nothing to disk. Mutually exclusive with `--ephemeral`.
+- **@qulib/mcp:** `analyze_app` now accepts `agentSummary: true` to return the compact gate JSON instead of the summary-first envelope. Overrides `includeFullReport`.
+- **docs:** `docs/agent-summary-output.md` — public spec for the shape, gate-derivation rules, policy overrides, and the `schemaVersion: 1` stability contract. Also adds the QLIB-001 PRD, implementation chunk plan, and design note.
+
 ## [0.5.3] — 2026-05-27
 
 ### Fixed

--- a/docs/agent-summary-output.md
+++ b/docs/agent-summary-output.md
@@ -1,0 +1,91 @@
+# Agent-facing summary output
+
+This document defines a **desired** consolidated JSON shape for orchestrators and AI agents, and compares it to **what exists today**.
+
+---
+
+## Status: planned vs implemented
+
+| Aspect | Status |
+|--------|--------|
+| `toAgentSummary(result, policy?)` helper exported from `@qulib/core` | **Implemented (QLIB-001-C02)** — see `packages/core/src/agent-summary.ts` and [design/agent-summary-policy.md](./design/agent-summary-policy.md). |
+| CLI `analyze --agent-summary` | **Implemented (QLIB-001-C03)** — stdout is only agent summary JSON; incompatible with `--ephemeral`. |
+| MCP `analyze_app` with `agentSummary: true` | **Implemented (QLIB-001-C04)** — response is only `toAgentSummary(result)` JSON. |
+| Unified top-level object with `gate`, `topRisks`, `recommendedNextChecks`, `honestyNotes`, etc. | **Implemented** via `toAgentSummary` (`schemaVersion: 1`). Exposed from **CLI** (`--agent-summary`) and **MCP** (`agentSummary: true`). |
+| MCP `analyze_app` default (summary-first) | **Implemented** — see `@qulib/mcp` `summarizeAnalyzeResult` and [packages/mcp/README.md](../packages/mcp/README.md). |
+| Full `AnalyzeResult` / report JSON on disk or with `includeFullReport: true` | **Implemented** — see `GapAnalysis` in `@qulib/core` schemas. |
+
+Orchestrators may consume the stable object via **`toAgentSummary`**, **CLI `--agent-summary`**, or **MCP `analyze_app` with `agentSummary: true`**. For the default MCP summary-first envelope, continue to use `summarizeAnalyzeResult` fields unless you need the gate-shaped object.
+
+---
+
+## Desired shape (QLIB-001 target)
+
+Stable, versioned object for gates and orchestration (e.g. tap-agent, CI). Field names are indicative; final names may follow strict semver / schema export rules.
+
+```json
+{
+  "gate": "warn",
+  "releaseConfidence": 64,
+  "coverageStatus": "thin",
+  "topRisks": [
+    "Auth blocked key routes",
+    "Low crawl coverage",
+    "Accessibility violations found"
+  ],
+  "recommendedNextChecks": [
+    "Run authenticated scan",
+    "Verify checkout flow manually",
+    "Review axe violations"
+  ],
+  "honestyNotes": [
+    "This scan does not guarantee production readiness.",
+    "Coverage was below confidence threshold."
+  ],
+  "costSummary": null,
+  "deterministicFollowUps": []
+}
+```
+
+### Field notes (normative intent)
+
+| Field | Description |
+|-------|-------------|
+| `gate` | **`pass` \| `warn` \| `fail`** — derived by `toAgentSummary()` from Qulib signals and optional `AgentSummaryPolicy`. Must align with **honest** semantics: e.g. `auth-required` or thin coverage cannot imply `pass` without explicit policy (see [design/agent-summary-policy.md](./design/agent-summary-policy.md)). |
+| `releaseConfidence` | Number **0–100** or orchestrator mapping when source is `null` (document why). Mirrors `gapAnalysis.releaseConfidence`. |
+| `coverageStatus` | Coarse enum for agents (e.g. `ok` \| `thin` \| `blocked-by-auth`). Maps from `coveragePagesScanned`, `coverageWarning`, and `mode`. |
+| `topRisks` | Short strings; may mirror top severities from `gaps` plus mode/coverage/auth context. |
+| `recommendedNextChecks` | Human/agent actionable; can align with MCP `nextDeterministicChecks` and Cost Intelligence `conversionRecommendations` when present. |
+| `honestyNotes` | **Required** for brand-consistent messaging: limits of scan, coverage floor, auth wall, etc. |
+| `costSummary` | Optional subset when Cost Intelligence ran (tokens, budget warnings, maturity). **Planned** as a stable slice; today see `costIntelligenceSummary` in MCP compact response. |
+| `deterministicFollowUps` | Structured list (strings or objects) of checks to implement in CI/playwright/axe, etc. Overlaps MCP `nextDeterministicChecks`. |
+
+---
+
+## What exists today (mapping hints)
+
+Agents can **construct** the planned shape from:
+
+- **`gapAnalysis.releaseConfidence`**, **`gapAnalysis.mode`**, **`gapAnalysis.coverageWarning`**, **`gapAnalysis.coveragePagesScanned`**
+- **`gaps`** (severity-sorted top N)
+- MCP compact payload: **`summary`**, **`topGaps`**, **`nextDeterministicChecks`**, **`costIntelligenceSummary`**, **`routeInventorySummary`**, **`decisionLogPreview`**
+
+`AnalyzeResult.status`: `complete` | `blocked` | `partial` — use alongside `mode` for honesty.
+
+---
+
+## Versioning and schema changes
+
+When QLIB-001 is implemented:
+
+- Document **schema version** in the summary object.
+- Any **breaking** change to report JSON or this summary requires **migration notes** in the changelog and agent docs.
+
+---
+
+## Related
+
+- [agent-usage.md](./agent-usage.md)  
+- [design/agent-summary-policy.md](./design/agent-summary-policy.md)  
+- [prds/QLIB-001-agent-summary-and-gate-output.md](./prds/QLIB-001-agent-summary-and-gate-output.md)  
+- [chunks/QLIB-001-C01-agent-summary-format.md](./chunks/QLIB-001-C01-agent-summary-format.md)  

--- a/docs/chunks/QLIB-001-C01-agent-summary-format.md
+++ b/docs/chunks/QLIB-001-C01-agent-summary-format.md
@@ -1,0 +1,42 @@
+# Work chunk: QLIB-001-C01 — Agent summary format (docs/spec only)
+
+**Initiative:** QLIB-001  
+**Type:** Documentation / specification  
+**Implementation code:** Out of scope for this chunk unless explicitly approved later.
+
+---
+
+## Objective
+
+Lock the **intended** machine-readable agent summary so Composer and orchestrators can implement against a stable target.
+
+---
+
+## Deliverables (done when this chunk merges)
+
+- [x] `docs/agent-summary-output.md` defines planned JSON shape vs current MCP/core fields.
+- [x] Mapping notes from `AnalyzeResult` / MCP compact payload to future fields (`gate`, `coverageStatus`, `topRisks`, etc.).
+- [x] Explicit statement: **`gate` is not emitted by core today**; orchestrators may derive interim gates from documented rules.
+
+---
+
+## Out of scope (next chunks)
+
+- TypeScript types + exported builder `toAgentSummary(result, policy)`.
+- CLI flag (e.g. `--agent-summary`) or MCP field to request summary-only artifact.
+- Golden tests for summary mapping.
+
+---
+
+## Acceptance criteria
+
+- A new contributor can read **only** `agent-summary-output.md` and know what is **shipped** vs **planned**.
+- Honesty requirements (`auth-required`, `low-coverage`) are reflected in field descriptions.
+
+---
+
+## References
+
+- [../prds/QLIB-001-agent-summary-and-gate-output.md](../prds/QLIB-001-agent-summary-and-gate-output.md)  
+- `packages/mcp/src/summarize-analyze-result.ts`  
+- `packages/core/src/schemas/gap-analysis.schema.ts`  

--- a/docs/design/agent-summary-policy.md
+++ b/docs/design/agent-summary-policy.md
@@ -1,0 +1,66 @@
+# Design note: default gate policy for `toAgentSummary`
+
+**Initiative:** QLIB-001  
+**Chunk:** C02 (helper + tests)  
+**Status:** Implemented for the pure helper. CLI and MCP surfaces are out of scope until C03/C04.
+
+---
+
+## Goal
+
+Provide a small, **honest**, **deterministic** mapping from `AnalyzeResult` to an agent-facing JSON summary, with a default gate (`pass | warn | fail`) that orchestrators can rely on without rewriting policy from scratch.
+
+---
+
+## Default policy (helper)
+
+Evaluated **in order**; first match wins.
+
+1. **`fail`** when any of:
+   - any **critical** gap exists,
+   - `result.status === 'blocked'`,
+   - `releaseConfidence` is `null`,
+   - `releaseConfidence < failConfidenceThreshold` (default `30`),
+   - `gapAnalysis.mode === 'auth-required'` **and** `authRequiredGate === 'fail'` (default).
+2. **`warn`** when any of:
+   - any **high** severity gap exists,
+   - `result.status === 'partial'`,
+   - coverage is **thin** / **budget-exceeded** / **navigation-failures**,
+   - `releaseConfidence < passConfidenceThreshold` (default `80`).
+3. **`pass`** otherwise.
+
+---
+
+## Why these defaults
+
+- **Honesty over fake confidence.** An `auth-required` scan never silently `pass`es by default; the deployment was not exercised past the auth boundary. Callers that *intentionally* run anonymous-only scans on protected products can override with `authRequiredGate: 'warn'` — explicit, not silent.
+- **Critical fails are always blocking.** Even at 100 release confidence, a critical accessibility or console finding outweighs the scalar score.
+- **Coverage warnings always degrade the gate.** `low-coverage`, `budget-exceeded`, and `navigation-failures` cannot promote to `pass`; they at least drop to `warn`.
+- **`null` confidence fails.** No score → no green light.
+- **Thresholds are policy.** `80 / 30` are conservative defaults; orchestrators that have measured their own product can lower them via `AgentSummaryPolicy`.
+
+---
+
+## What the helper does **not** do
+
+- Read or write files.
+- Hit the network.
+- Mutate the input.
+- Decide whether to publish, deploy, or merge — that is the orchestrator’s job.
+
+---
+
+## Forward compatibility
+
+- The summary carries `schemaVersion: 1`. Any breaking change to fields, gate semantics, or default policy bumps the version and is documented in CHANGELOG + `docs/agent-summary-output.md`.
+- New optional fields can be added at `schemaVersion: 1` only if existing consumers can ignore them safely.
+
+---
+
+## Related
+
+- [../agent-summary-output.md](../agent-summary-output.md)
+- [../prds/QLIB-001-agent-summary-and-gate-output.md](../prds/QLIB-001-agent-summary-and-gate-output.md)
+- [../chunks/QLIB-001-C01-agent-summary-format.md](../chunks/QLIB-001-C01-agent-summary-format.md)
+- `packages/core/src/agent-summary.ts`
+- `packages/core/src/__tests__/agent-summary.test.ts`

--- a/docs/prds/QLIB-001-agent-summary-and-gate-output.md
+++ b/docs/prds/QLIB-001-agent-summary-and-gate-output.md
@@ -1,0 +1,61 @@
+# PRD (draft): QLIB-001 — Agent summary and gate output
+
+**Status:** Implemented on `feature/qlib-001-agent-summary-gate` (C01–C04).  
+**Owner:** Maintainers / Composer via approved chunks.
+
+---
+
+## Problem
+
+Orchestrators and AI agents need a **small, stable, honest** summary of a Qulib run for gates and automation. Today:
+
+- MCP `analyze_app` returns a useful **summary-first** payload (implemented).
+- There is **no** first-party, versioned **unified JSON** with explicit `gate`, `coverageStatus`, and required **`honestyNotes`** for all consumers (planned).
+
+Fragmented interpretation risks **overclaiming** readiness.
+
+---
+
+## Goals
+
+1. Define (and optionally emit) a **versioned agent summary** aligned with [../agent-summary-output.md](../agent-summary-output.md).
+2. Support **orchestrator-owned** or **Qulib-bundled** gate policy (decision: document in implementation phase; default is honest mapping rules).
+3. Preserve **auth-required** and **low-coverage** semantics: they cannot silently map to “pass” without explicit policy documentation.
+
+---
+
+## Non-goals
+
+- Building a full multi-agent orchestrator in this repo.
+- Changing npm publish process.
+- Replacing the full `AnalyzeResult` report—summary is additive or a documented projection.
+
+---
+
+## Users
+
+- External orchestrators (CI, custom agents).
+- MCP clients that want one JSON blob for decisions.
+
+---
+
+## Acceptance criteria (draft)
+
+- [x] Spec in `docs/agent-summary-output.md` matches implemented fields.
+- [x] Summary includes **`honestyNotes`** when any limit applies (coverage, auth, budget, partial status).
+- [x] **`gate`** derivation rules documented; forbidden combinations tested (e.g. `auth-required` + `pass` unless explicit override flag).
+- [x] CLI (`--agent-summary`) and MCP (`agentSummary: true`) emit the summary.
+- [x] `schemaVersion: 1` on summary object; no breaking renames in this initiative.
+- [x] Tests for mapping from fixture `AnalyzeResult` → summary (`agent-summary.test.ts`).
+
+---
+
+## Risks
+
+- Gate semantics are **policy-sensitive**; wrong defaults damage trust. Mitigation: conservative defaults, explicit override, loud docs.
+
+---
+
+## Related chunks
+
+- [../chunks/QLIB-001-C01-agent-summary-format.md](../chunks/QLIB-001-C01-agent-summary-format.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2029,7 +2029,7 @@
     },
     "packages/core": {
       "name": "@qulib/core",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "^4.9.0",
@@ -2049,11 +2049,11 @@
     },
     "packages/mcp": {
       "name": "@qulib/mcp",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@qulib/core": "0.5.3",
+        "@qulib/core": "0.6.0",
         "zod": "^3.23.0"
       },
       "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "analyze": "tsx src/cli/index.ts analyze",
     "clean": "tsx src/cli/index.ts clean",
     "build": "tsc",
-    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts",
+    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/agent-summary.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts",
     "test:integration": "node --import tsx/esm --test src/__tests__/analyze.integration.test.ts",
     "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral",
     "cost-doctor": "tsx src/cli/index.ts cost doctor"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "analyze": "tsx src/cli/index.ts analyze",
     "clean": "tsx src/cli/index.ts clean",
     "build": "tsc",
-    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/agent-summary.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts",
+    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/agent-summary.test.ts src/__tests__/cli-agent-summary.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts",
     "test:integration": "node --import tsx/esm --test src/__tests__/analyze.integration.test.ts",
     "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral",
     "cost-doctor": "tsx src/cli/index.ts cost doctor"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/core",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Qulib — analyze deployed web apps for honest quality gaps (CLI + programmatic API)",
   "license": "MIT",
   "author": "Tapesh Nagarwal",

--- a/packages/core/src/__tests__/agent-summary.test.ts
+++ b/packages/core/src/__tests__/agent-summary.test.ts
@@ -1,0 +1,211 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { toAgentSummary } from '../agent-summary.js';
+import type { AnalyzeResult } from '../analyze.js';
+import type { Gap } from '../schemas/gap-analysis.schema.js';
+import type { CostIntelligence } from '../schemas/cost-intelligence.schema.js';
+
+const isoNow = (): string => new Date().toISOString();
+
+interface FixtureOverrides {
+  status?: AnalyzeResult['status'];
+  releaseConfidence?: number | null;
+  gaps?: Gap[];
+  mode?: AnalyzeResult['gapAnalysis']['mode'];
+  coverageWarning?: AnalyzeResult['gapAnalysis']['coverageWarning'];
+  coveragePagesScanned?: number;
+  coverageBudgetExceeded?: boolean;
+  costIntelligence?: CostIntelligence;
+}
+
+function makeResult(overrides: FixtureOverrides = {}): AnalyzeResult {
+  const gaps = overrides.gaps ?? [];
+  const releaseConfidence = overrides.releaseConfidence ?? 90;
+  return {
+    status: overrides.status ?? 'complete',
+    coverageScore: 100,
+    releaseConfidence,
+    gaps,
+    gapAnalysis: {
+      analyzedAt: isoNow(),
+      mode: overrides.mode ?? 'url-only',
+      releaseConfidence,
+      coveragePagesScanned: overrides.coveragePagesScanned ?? 10,
+      coverageBudgetExceeded: overrides.coverageBudgetExceeded ?? false,
+      ...(overrides.coverageWarning !== undefined && { coverageWarning: overrides.coverageWarning }),
+      gaps,
+      scenarios: [],
+      generatedTests: [],
+      ...(overrides.costIntelligence !== undefined && {
+        costIntelligence: overrides.costIntelligence,
+      }),
+    },
+    routeInventory: {
+      scannedAt: isoNow(),
+      baseUrl: 'https://example.com',
+      routes: [],
+      pagesSkipped: 0,
+      budgetExceeded: false,
+    },
+    repoInventory: null,
+    decisionLog: [],
+    publicSurface: null,
+  };
+}
+
+function gap(severity: Gap['severity'], category: Gap['category'] = 'a11y'): Gap {
+  return {
+    id: `${severity}-${category}-${Math.random().toString(36).slice(2, 8)}`,
+    path: '/x',
+    severity,
+    reason: `${severity} ${category} finding`,
+    category,
+  };
+}
+
+const costIntelligenceFixture = (): CostIntelligence => ({
+  maxOutputTokensPerLlmCall: 2048,
+  budgetRole: 'max-output-tokens-per-llm-call',
+  records: [],
+  budgetWarnings: ['warning A'],
+  usageSummary: { totalInputTokens: 100, totalOutputTokens: 200, dataQuality: 'actual' },
+  repeatedOperations: [],
+  deterministicMaturity: { level: 2, label: 'L2', rationale: 'fixture' },
+  conversionRecommendations: ['Convert flow X to deterministic check', 'Capture step Y in CI'],
+});
+
+test('toAgentSummary: high confidence, no major risks → pass', () => {
+  const r = makeResult({ releaseConfidence: 92, gaps: [gap('low')] });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'pass');
+  assert.equal(s.coverageStatus, 'ok');
+  assert.equal(s.releaseConfidence, 92);
+  assert.ok(s.honestyNotes.length >= 1, 'always at least one honesty note');
+});
+
+test('toAgentSummary: low coverage → warn with thin coverage note', () => {
+  const r = makeResult({
+    releaseConfidence: 60,
+    coverageWarning: 'low-coverage',
+    coveragePagesScanned: 1,
+  });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'warn');
+  assert.equal(s.coverageStatus, 'thin');
+  assert.ok(s.honestyNotes.some((n) => /below the confidence threshold/i.test(n)));
+  assert.ok(s.recommendedNextChecks.some((c) => /crawl budget|deeper entry/i.test(c)));
+});
+
+test('toAgentSummary: auth-required blocks meaningful scan → fail by default', () => {
+  const r = makeResult({
+    releaseConfidence: 0,
+    mode: 'auth-required',
+    coverageWarning: 'auth-required',
+    coveragePagesScanned: 0,
+  });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'fail');
+  assert.equal(s.coverageStatus, 'blocked-by-auth');
+  assert.ok(s.topRisks.some((r2) => /auth blocked/i.test(r2)));
+  assert.ok(s.honestyNotes.some((n) => /authenticated surface/i.test(n)));
+});
+
+test('toAgentSummary: auth-required with authRequiredGate=warn yields warn', () => {
+  const r = makeResult({
+    releaseConfidence: 0,
+    mode: 'auth-required',
+    coverageWarning: 'auth-required',
+  });
+  const s = toAgentSummary(r, { authRequiredGate: 'warn' });
+  assert.equal(s.gate, 'warn');
+});
+
+test('toAgentSummary: critical issue → fail regardless of confidence', () => {
+  const r = makeResult({ releaseConfidence: 95, gaps: [gap('critical', 'a11y')] });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'fail');
+  assert.equal(s.topRisks[0], '[critical] a11y — /x');
+});
+
+test('toAgentSummary: cost intelligence present → costSummary and deterministicFollowUps included', () => {
+  const ci = costIntelligenceFixture();
+  const r = makeResult({ releaseConfidence: 88, costIntelligence: ci });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'pass');
+  assert.ok(s.costSummary, 'costSummary should be present');
+  assert.equal(s.costSummary?.budgetWarningCount, 1);
+  assert.equal(s.costSummary?.maturityLevel, 2);
+  assert.deepEqual(s.deterministicFollowUps, ci.conversionRecommendations);
+});
+
+test('toAgentSummary: missing cost intelligence → costSummary null and empty follow-ups', () => {
+  const s = toAgentSummary(makeResult({ releaseConfidence: 85 }));
+  assert.equal(s.costSummary, null);
+  assert.deepEqual(s.deterministicFollowUps, []);
+});
+
+test('toAgentSummary: high-severity gap with otherwise-pass conditions → warn', () => {
+  const r = makeResult({ releaseConfidence: 90, gaps: [gap('high', 'console-error')] });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'warn');
+});
+
+test('toAgentSummary: status=blocked → fail', () => {
+  const r = makeResult({ status: 'blocked', releaseConfidence: null });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'fail');
+  assert.ok(s.honestyNotes.some((n) => /blocked before producing/i.test(n)));
+});
+
+test('toAgentSummary: status=partial → warn', () => {
+  const r = makeResult({ status: 'partial', releaseConfidence: 85 });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'warn');
+});
+
+test('toAgentSummary: confidence below pass threshold (but above fail) → warn', () => {
+  const r = makeResult({ releaseConfidence: 60 });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'warn');
+});
+
+test('toAgentSummary: confidence below fail threshold → fail', () => {
+  const r = makeResult({ releaseConfidence: 10 });
+  const s = toAgentSummary(r);
+  assert.equal(s.gate, 'fail');
+});
+
+test('toAgentSummary: custom pass threshold respected', () => {
+  const r = makeResult({ releaseConfidence: 75 });
+  assert.equal(toAgentSummary(r).gate, 'warn');
+  assert.equal(toAgentSummary(r, { passConfidenceThreshold: 70 }).gate, 'pass');
+});
+
+test('toAgentSummary: schemaVersion is 1 and shape contains all documented fields', () => {
+  const s = toAgentSummary(makeResult());
+  assert.equal(s.schemaVersion, 1);
+  for (const k of [
+    'gate',
+    'releaseConfidence',
+    'coverageStatus',
+    'topRisks',
+    'recommendedNextChecks',
+    'honestyNotes',
+    'costSummary',
+    'deterministicFollowUps',
+  ]) {
+    assert.ok(k in s, `missing field: ${k}`);
+  }
+});
+
+test('toAgentSummary: topRisks sorted critical → high → medium → low', () => {
+  const r = makeResult({
+    gaps: [gap('low'), gap('critical'), gap('medium'), gap('high')],
+    releaseConfidence: 50,
+  });
+  const s = toAgentSummary(r);
+  const severities = s.topRisks
+    .filter((t) => t.startsWith('['))
+    .map((t) => t.slice(1, t.indexOf(']')));
+  assert.deepEqual(severities, ['critical', 'high', 'medium', 'low']);
+});

--- a/packages/core/src/__tests__/cli-agent-summary.test.ts
+++ b/packages/core/src/__tests__/cli-agent-summary.test.ts
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const corePkgRoot = resolve(__dirname, '..', '..');
+const cliEntry = resolve(__dirname, '..', 'cli', 'index.ts');
+
+function runCli(args: string[], cwd: string): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, ['--import', 'tsx/esm', cliEntry, ...args], {
+    encoding: 'utf8',
+    cwd,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+test('analyze rejects --agent-summary together with --ephemeral', () => {
+  const { status, stderr } = runCli(
+    ['analyze', '--url', 'https://example.com', '--agent-summary', '--ephemeral'],
+    corePkgRoot
+  );
+  assert.notEqual(status, 0, `expected failure, stderr: ${stderr}`);
+  assert.match(stderr, /Use either --agent-summary or --ephemeral/i);
+});

--- a/packages/core/src/agent-summary.ts
+++ b/packages/core/src/agent-summary.ts
@@ -1,0 +1,262 @@
+import type { AnalyzeResult } from './analyze.js';
+import type { Gap } from './schemas/gap-analysis.schema.js';
+import type { CostIntelligence } from './schemas/cost-intelligence.schema.js';
+
+/**
+ * Agent-readable summary of an AnalyzeResult. Intended for orchestrators
+ * (CI gates, external agent loops) that need a small, stable JSON shape.
+ *
+ * QLIB-001 spec: see docs/agent-summary-output.md.
+ * C02 helper; exposed via CLI (`--agent-summary`) and MCP (`agentSummary: true`).
+ * Field names below are the v1 contract for `toAgentSummary`.
+ */
+
+export type AgentGate = 'pass' | 'warn' | 'fail';
+
+export type CoverageStatus =
+  | 'ok'
+  | 'thin'
+  | 'blocked-by-auth'
+  | 'budget-exceeded'
+  | 'navigation-failures'
+  | 'unknown';
+
+export interface AgentSummaryCostSummary {
+  maxOutputTokensPerLlmCall: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  budgetWarningCount: number;
+  dataQuality: CostIntelligence['usageSummary']['dataQuality'];
+  maturityLevel: number;
+  maturityLabel: string;
+}
+
+export interface AgentSummary {
+  schemaVersion: 1;
+  gate: AgentGate;
+  releaseConfidence: number | null;
+  coverageStatus: CoverageStatus;
+  topRisks: string[];
+  recommendedNextChecks: string[];
+  honestyNotes: string[];
+  costSummary: AgentSummaryCostSummary | null;
+  deterministicFollowUps: string[];
+}
+
+export interface AgentSummaryPolicy {
+  /** Confidence at or above this number is required for `pass`. Default 80. */
+  passConfidenceThreshold?: number;
+  /** Confidence below this triggers `fail` (when no harder failure already applies). Default 30. */
+  failConfidenceThreshold?: number;
+  /** Max risks/checks/notes to include in each list. Default 5. */
+  maxListLength?: number;
+  /**
+   * Treat `mode === 'auth-required'` as `fail` (default) or `warn`.
+   * Honest default: a deployment that was never exercised past auth cannot pass.
+   */
+  authRequiredGate?: 'fail' | 'warn';
+}
+
+interface ResolvedPolicy {
+  passConfidenceThreshold: number;
+  failConfidenceThreshold: number;
+  maxListLength: number;
+  authRequiredGate: 'fail' | 'warn';
+}
+
+const DEFAULT_POLICY: ResolvedPolicy = {
+  passConfidenceThreshold: 80,
+  failConfidenceThreshold: 30,
+  maxListLength: 5,
+  authRequiredGate: 'fail',
+};
+
+const severityOrder = { critical: 0, high: 1, medium: 2, low: 3 } as const;
+
+function resolvePolicy(p: AgentSummaryPolicy | undefined): ResolvedPolicy {
+  return {
+    passConfidenceThreshold: p?.passConfidenceThreshold ?? DEFAULT_POLICY.passConfidenceThreshold,
+    failConfidenceThreshold: p?.failConfidenceThreshold ?? DEFAULT_POLICY.failConfidenceThreshold,
+    maxListLength: p?.maxListLength ?? DEFAULT_POLICY.maxListLength,
+    authRequiredGate: p?.authRequiredGate ?? DEFAULT_POLICY.authRequiredGate,
+  };
+}
+
+function countBySeverity(gaps: Gap[]): Record<Gap['severity'], number> {
+  const counts: Record<Gap['severity'], number> = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const g of gaps) counts[g.severity]++;
+  return counts;
+}
+
+function deriveCoverageStatus(result: AnalyzeResult): CoverageStatus {
+  const g = result.gapAnalysis;
+  if (g.mode === 'auth-required' || g.coverageWarning === 'auth-required') {
+    return 'blocked-by-auth';
+  }
+  if (g.coverageWarning === 'budget-exceeded' || g.coverageBudgetExceeded) {
+    return 'budget-exceeded';
+  }
+  if (g.coverageWarning === 'navigation-failures') {
+    return 'navigation-failures';
+  }
+  if (g.coverageWarning === 'low-coverage') {
+    return 'thin';
+  }
+  if (g.coveragePagesScanned === 0) {
+    return 'unknown';
+  }
+  return 'ok';
+}
+
+function buildTopRisks(result: AnalyzeResult, limit: number): string[] {
+  const risks: string[] = [];
+  const status = deriveCoverageStatus(result);
+  if (status === 'blocked-by-auth') {
+    risks.push('Auth blocked the scan; protected routes were not exercised.');
+  } else if (status === 'thin') {
+    risks.push('Crawl coverage was below the confidence floor.');
+  } else if (status === 'budget-exceeded') {
+    risks.push('Crawl budget exceeded; coverage is partial.');
+  } else if (status === 'navigation-failures') {
+    risks.push('Navigation errors limited what could be scanned.');
+  }
+
+  const sorted = [...result.gaps].sort(
+    (a, b) => severityOrder[a.severity] - severityOrder[b.severity]
+  );
+  for (const g of sorted) {
+    if (risks.length >= limit) break;
+    risks.push(`[${g.severity}] ${g.category} — ${g.path}`);
+  }
+  return risks.slice(0, limit);
+}
+
+function buildRecommendedNextChecks(result: AnalyzeResult, limit: number): string[] {
+  const out: string[] = [];
+  const status = deriveCoverageStatus(result);
+  if (status === 'blocked-by-auth') {
+    out.push('Provide auth (form login or storage state) and re-run, or use explore_auth.');
+  }
+  if (status === 'thin') {
+    out.push('Increase crawl budget or supply deeper entry URLs to raise coverage above the floor.');
+  }
+  if (status === 'budget-exceeded') {
+    out.push('Increase maxPagesToScan or narrow scope to bring the crawl under budget.');
+  }
+
+  const byCat = new Map<string, number>();
+  for (const g of result.gaps) byCat.set(g.category, (byCat.get(g.category) ?? 0) + 1);
+  const topCats = [...byCat.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3);
+  for (const [cat, n] of topCats) {
+    if (out.length >= limit) break;
+    out.push(`Add or tighten deterministic coverage for ${cat} (${n} gap(s) this scan).`);
+  }
+  return out.slice(0, limit);
+}
+
+function buildHonestyNotes(result: AnalyzeResult): string[] {
+  const notes: string[] = ['This scan does not guarantee production readiness.'];
+  const g = result.gapAnalysis;
+  if (g.mode === 'auth-required' || g.coverageWarning === 'auth-required') {
+    notes.push('Authenticated surface was not exercised: confidence does not reflect protected routes.');
+  }
+  if (g.coverageWarning === 'low-coverage') {
+    notes.push('Coverage was below the confidence threshold; treat the score as a ceiling.');
+  }
+  if (g.coverageBudgetExceeded || g.coverageWarning === 'budget-exceeded') {
+    notes.push('Crawl budget was exceeded; some routes were not scanned.');
+  }
+  if (g.coverageWarning === 'navigation-failures') {
+    notes.push('Navigation failures reduced effective coverage.');
+  }
+  if (result.status === 'partial') {
+    notes.push('Scan completed only partially; signals are derived from a subset of intended work.');
+  }
+  if (result.status === 'blocked') {
+    notes.push('Scan was blocked before producing a meaningful evaluation.');
+  }
+  return notes;
+}
+
+function buildCostSummary(ci: CostIntelligence | undefined): AgentSummaryCostSummary | null {
+  if (!ci) return null;
+  return {
+    maxOutputTokensPerLlmCall: ci.maxOutputTokensPerLlmCall,
+    totalInputTokens: ci.usageSummary.totalInputTokens,
+    totalOutputTokens: ci.usageSummary.totalOutputTokens,
+    budgetWarningCount: ci.budgetWarnings.length,
+    dataQuality: ci.usageSummary.dataQuality,
+    maturityLevel: ci.deterministicMaturity.level,
+    maturityLabel: ci.deterministicMaturity.label,
+  };
+}
+
+function buildDeterministicFollowUps(ci: CostIntelligence | undefined, limit: number): string[] {
+  if (!ci) return [];
+  return ci.conversionRecommendations.slice(0, limit);
+}
+
+/**
+ * Default gate policy:
+ *   - fail when: any critical gap, status === 'blocked', releaseConfidence is null,
+ *                releaseConfidence < failConfidenceThreshold, or mode === 'auth-required'
+ *                under the default authRequiredGate.
+ *   - warn when: any high-severity gap, status === 'partial', coverage is thin /
+ *                budget-exceeded / navigation-failures, or confidence is below
+ *                passConfidenceThreshold (but at or above failConfidenceThreshold).
+ *   - pass when: confidence >= passConfidenceThreshold AND no blocking conditions.
+ *
+ * Honesty rule: an `auth-required` scan never silently `pass`es under defaults.
+ */
+function deriveGate(result: AnalyzeResult, policy: ResolvedPolicy): AgentGate {
+  const g = result.gapAnalysis;
+  const counts = countBySeverity(result.gaps);
+
+  if (counts.critical > 0) return 'fail';
+  if (result.status === 'blocked') return 'fail';
+  if (g.mode === 'auth-required' || g.coverageWarning === 'auth-required') {
+    return policy.authRequiredGate;
+  }
+  if (result.releaseConfidence === null) return 'fail';
+  if (result.releaseConfidence < policy.failConfidenceThreshold) return 'fail';
+
+  const hasCoverageIssue =
+    g.coverageWarning === 'low-coverage' ||
+    g.coverageWarning === 'budget-exceeded' ||
+    g.coverageWarning === 'navigation-failures' ||
+    g.coverageBudgetExceeded;
+
+  if (counts.high > 0) return 'warn';
+  if (result.status === 'partial') return 'warn';
+  if (hasCoverageIssue) return 'warn';
+  if (result.releaseConfidence < policy.passConfidenceThreshold) return 'warn';
+
+  return 'pass';
+}
+
+/**
+ * Convert an `AnalyzeResult` into a small agent-facing summary.
+ *
+ * Pure function. No I/O. CLI / MCP wiring belongs to QLIB-001-C03 and -C04.
+ */
+export function toAgentSummary(
+  result: AnalyzeResult,
+  policy?: AgentSummaryPolicy
+): AgentSummary {
+  const resolved = resolvePolicy(policy);
+  const limit = resolved.maxListLength;
+  return {
+    schemaVersion: 1,
+    gate: deriveGate(result, resolved),
+    releaseConfidence: result.releaseConfidence,
+    coverageStatus: deriveCoverageStatus(result),
+    topRisks: buildTopRisks(result, limit),
+    recommendedNextChecks: buildRecommendedNextChecks(result, limit),
+    honestyNotes: buildHonestyNotes(result),
+    costSummary: buildCostSummary(result.gapAnalysis.costIntelligence),
+    deterministicFollowUps: buildDeterministicFollowUps(
+      result.gapAnalysis.costIntelligence,
+      limit
+    ),
+  };
+}

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -9,6 +9,7 @@ const requirePkg = createRequire(import.meta.url);
 const pkg = requirePkg('../../package.json') as { version: string };
 import { HarnessConfigSchema, type HarnessConfig } from '../schemas/config.schema.js';
 import { analyzeApp } from '../analyze.js';
+import { toAgentSummary } from '../agent-summary.js';
 import { detectAuth } from '../tools/auth/detect.js';
 import { exploreAuth } from '../tools/auth/explore.js';
 import {
@@ -108,6 +109,7 @@ async function runAnalyze(options: {
   repo?: string;
   configFile?: string;
   ephemeral?: boolean;
+  agentSummary?: boolean;
   skipAuthDetection?: boolean;
   authStorageState?: string;
   authFormLogin?: boolean;
@@ -118,15 +120,21 @@ async function runAnalyze(options: {
   passwordSelector?: string;
   submitSelector?: string;
 }): Promise<void> {
+  if (options.ephemeral && options.agentSummary) {
+    throw new Error('Use either --agent-summary or --ephemeral, not both — pick one stdout output mode.');
+  }
   const validatedUrl = AnalyzeUrlSchema.parse(options.url);
   const mode: AnalyzeMode = options.repo ? 'url-repo' : 'url-only';
   const baseConfig = await loadConfigFile(options.configFile ?? 'qulib.config.ts');
   const config = mergeAuthFromCli(baseConfig, options);
   const ephemeral = options.ephemeral ?? false;
-  const writeArtifacts = !ephemeral;
+  const agentSummary = options.agentSummary ?? false;
+  const writeArtifacts = !ephemeral && !agentSummary;
 
   if (ephemeral) {
     console.error('[qulib] Ephemeral mode: no disk writes; full result JSON on stdout');
+  } else if (agentSummary) {
+    console.error('[qulib] Agent-summary mode: no disk writes; agent gate JSON on stdout');
   } else {
     console.log('[qulib] Detected mode:', mode);
     console.log('[qulib] Active config:', redactConfigForLog(config));
@@ -140,6 +148,10 @@ async function runAnalyze(options: {
     skipAuthDetection: options.skipAuthDetection,
   });
 
+  if (agentSummary) {
+    console.log(JSON.stringify(toAgentSummary(result), null, 2));
+    return;
+  }
   if (ephemeral) {
     console.log(
       JSON.stringify(
@@ -215,6 +227,7 @@ program
     'playwright'
   )
   .option('--ephemeral', 'Do not write to disk — return full report as JSON on stdout (use for MCP/CI)', false)
+  .option('--agent-summary', 'Do not write to disk — return the compact agent-summary gate JSON on stdout (pass/warn/fail with honesty notes). Mutually exclusive with --ephemeral.', false)
   .option('--skip-auth-detection', 'Crawl the public surface even if auth is detected (useful for sites with sign-in CTAs on public pages)', false)
   .option(
     '--auth-storage-state <path>',
@@ -241,6 +254,7 @@ program
       repo: options.repo,
       configFile: options.config,
       ephemeral: options.ephemeral,
+      agentSummary: options.agentSummary,
       skipAuthDetection: Boolean(options.skipAuthDetection),
       authStorageState: options.authStorageState,
       authFormLogin,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,12 @@
 export { analyzeApp } from './analyze.js';
+export { toAgentSummary } from './agent-summary.js';
+export type {
+  AgentSummary,
+  AgentSummaryPolicy,
+  AgentGate,
+  CoverageStatus,
+  AgentSummaryCostSummary,
+} from './agent-summary.js';
 export {
   detectAuth,
   validateStorageState,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "npm --prefix ../.. run build -w @qulib/core && tsc && chmod +x dist/index.js",
     "dev": "tsx src/index.ts",
-    "test": "node --import tsx/esm --test src/__tests__/summarize-analyze-result.test.ts"
+    "test": "node --import tsx/esm --test src/__tests__/summarize-analyze-result.test.ts src/__tests__/analyze-app-mcp-payload.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/mcp",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "MCP server for Qulib — AI-callable QA gap analysis",
   "license": "MIT",
   "author": "Tapesh Nagarwal",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@qulib/core": "0.5.3",
+    "@qulib/core": "0.6.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/mcp/src/__tests__/analyze-app-mcp-payload.test.ts
+++ b/packages/mcp/src/__tests__/analyze-app-mcp-payload.test.ts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAnalyzeAppMcpPayload } from '../analyze-app-mcp-payload.js';
+import type { AnalyzeResult } from '@qulib/core';
+
+const minimalAnalyzeResult = (): AnalyzeResult => {
+  const gaps = [
+    {
+      id: '1',
+      path: '/a',
+      severity: 'high' as const,
+      reason: 'console',
+      category: 'console-error' as const,
+    },
+  ];
+  return {
+    status: 'complete',
+    coverageScore: 100,
+    releaseConfidence: 85,
+    gaps,
+    gapAnalysis: {
+      analyzedAt: new Date().toISOString(),
+      mode: 'url-only',
+      releaseConfidence: 85,
+      coveragePagesScanned: 5,
+      coverageBudgetExceeded: false,
+      gaps,
+      scenarios: [],
+      generatedTests: [],
+    },
+    routeInventory: {
+      scannedAt: new Date().toISOString(),
+      baseUrl: 'https://example.com',
+      routes: [],
+      pagesSkipped: 0,
+      budgetExceeded: false,
+    },
+    repoInventory: null,
+    decisionLog: [],
+    publicSurface: null,
+  };
+};
+
+test('buildAnalyzeAppMcpPayload default matches summarize-first (no agentSummary)', () => {
+  const r = minimalAnalyzeResult();
+  const out = buildAnalyzeAppMcpPayload(r, {}) as Record<string, unknown>;
+  assert.equal(out.includeFullReport, false);
+  assert.ok('summary' in out);
+  assert.ok('topGaps' in out);
+});
+
+test('buildAnalyzeAppMcpPayload agentSummary returns only toAgentSummary shape', () => {
+  const r = minimalAnalyzeResult();
+  const out = buildAnalyzeAppMcpPayload(r, { agentSummary: true }) as Record<string, unknown>;
+  assert.equal(out.schemaVersion, 1);
+  assert.ok('gate' in out);
+  assert.ok('coverageStatus' in out);
+  assert.ok(Array.isArray(out.topRisks));
+  assert.ok(Array.isArray(out.honestyNotes));
+  assert.ok(!('summary' in out));
+  assert.ok(!('topGaps' in out));
+});
+
+test('buildAnalyzeAppMcpPayload agentSummary overrides includeFullReport', () => {
+  const r = minimalAnalyzeResult();
+  const out = buildAnalyzeAppMcpPayload(r, { agentSummary: true, includeFullReport: true }) as Record<string, unknown>;
+  assert.equal(out.schemaVersion, 1);
+  assert.ok(!('gapAnalysis' in out));
+});

--- a/packages/mcp/src/analyze-app-mcp-payload.ts
+++ b/packages/mcp/src/analyze-app-mcp-payload.ts
@@ -1,0 +1,23 @@
+import type { AnalyzeResult } from '@qulib/core';
+import { toAgentSummary } from '@qulib/core';
+import { summarizeAnalyzeResult } from './summarize-analyze-result.js';
+
+export interface AnalyzeAppMcpPayloadOptions {
+  includeFullReport?: boolean;
+  /** When true, returns only `toAgentSummary(result)` JSON (QLIB-001). Ignores `includeFullReport`. */
+  agentSummary?: boolean;
+}
+
+/**
+ * Single place for analyze_app response shaping: default summary-first,
+ * optional full report, or compact agent gate summary.
+ */
+export function buildAnalyzeAppMcpPayload(
+  result: AnalyzeResult,
+  input: AnalyzeAppMcpPayloadOptions
+): unknown {
+  if (input.agentSummary === true) {
+    return toAgentSummary(result);
+  }
+  return summarizeAnalyzeResult(result, input.includeFullReport === true);
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -25,7 +25,7 @@ import {
 } from '@qulib/core';
 import type { HarnessConfig, AnalyzeProgressSink, TelemetrySink } from '@qulib/core';
 import { z } from 'zod';
-import { summarizeAnalyzeResult } from './summarize-analyze-result.js';
+import { buildAnalyzeAppMcpPayload } from './analyze-app-mcp-payload.js';
 import { log } from './logger.js';
 
 function toolError(code: string, message: string, detail?: unknown): {
@@ -87,6 +87,12 @@ const AnalyzeInputSchema = z.object({
   timeoutMs: z.number().int().positive().optional(),
   auth: z.discriminatedUnion('type', [FormLoginMcpAuthSchema, StorageStateMcpAuthSchema]).optional(),
   includeFullReport: z.boolean().optional(),
+  agentSummary: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, return only the versioned agent-summary JSON ({ schemaVersion: 1, gate, coverageStatus, topRisks, recommendedNextChecks, honestyNotes, costSummary, deterministicFollowUps }). Use this for CI gates and orchestrators that need a single small payload to decide pass/warn/fail. Overrides includeFullReport.'
+    ),
   llmTokenBudget: z.number().int().positive().optional(),
   llmMaxOutputTokensPerCall: z.number().int().positive().optional(),
   testGenerationLimit: z.number().int().positive().max(50).optional(),
@@ -201,7 +207,7 @@ mcpServer.registerTool(
   'analyze_app',
   {
     description:
-      'Analyze a deployed web app for quality gaps. Default response is summary-first (top gaps, cost summary, next checks). Set includeFullReport for the full gapAnalysis. Optional llmMaxOutputTokensPerCall / llmTokenBudget (legacy), testGenerationLimit, enableLlmScenarios align with @qulib/core HarnessConfig.',
+      'Analyze a deployed web app for quality gaps. Default response is summary-first (top gaps, cost summary, next checks). Set includeFullReport for the full gapAnalysis. Set agentSummary for the compact gate-decision payload (pass/warn/fail with honesty notes) — use this when calling from a CI gate or orchestrator. Optional llmMaxOutputTokensPerCall / llmTokenBudget (legacy), testGenerationLimit, enableLlmScenarios align with @qulib/core HarnessConfig.',
     inputSchema: AnalyzeInputSchema,
   },
   async (input) => {
@@ -257,7 +263,10 @@ mcpServer.registerTool(
         telemetry: telemetrySink,
       });
 
-      const payload = summarizeAnalyzeResult(result, input.includeFullReport === true);
+      const payload = buildAnalyzeAppMcpPayload(result, {
+        includeFullReport: input.includeFullReport,
+        agentSummary: input.agentSummary,
+      });
 
       return {
         content: [


### PR DESCRIPTION
## Summary

Promotes the full agent-summary feature from the long-lived \`feature/qlib-001-gate-summary\` branch into main and bumps both packages to **v0.6.0**.

## What's shipping

A small, versioned JSON shape (\`schemaVersion: 1\`) that orchestrators and AI agents can use to decide whether a qulib scan is good enough to ship.

**Three reach points:**
- Programmatic — \`toAgentSummary(result, policy?)\` from \`@qulib/core\`
- CLI — \`qulib analyze --url <url> --agent-summary\`
- MCP — \`analyze_app({ agentSummary: true })\`

**Honest defaults:** critical gaps, blocked status, or \`auth-required\` mode never silently pass. \`honestyNotes\` always surfaces coverage/auth/budget limits.

**Spec:** [docs/agent-summary-output.md](docs/agent-summary-output.md)

## What's in the diff

- \`packages/core/src/agent-summary.ts\` — pure function + types (PR #70)
- \`packages/mcp/src/analyze-app-mcp-payload.ts\` + MCP wiring (PR #71)
- \`packages/core/src/cli/index.ts\` — \`--agent-summary\` flag (PR #72)
- \`docs/agent-summary-output.md\` + PRD/chunk/design notes (PRs #70–72)
- Version bumps to **0.6.0** across both packages
- CHANGELOG entry

## Test plan

- [x] \`npm ci && npm run build && npm test\` green locally — 108 core + 10 mcp = **118 tests**
- [x] Full CI green on this PR before merge to main
- [ ] After merge, publish to npm:
  \`\`\`bash
  npm publish -w @qulib/core --access public
  npm publish -w @qulib/mcp --access public
  npm view @qulib/core version  # should return 0.6.0
  \`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #41
