### PR TITLE
feat(adapters): generate Playwright specs from scaffold scenarios

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "analyze": "tsx src/cli/index.ts analyze",
     "clean": "tsx src/cli/index.ts clean",
     "build": "tsc",
-    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/agent-summary.test.ts src/__tests__/cli-agent-summary.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts",
+    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/agent-summary.test.ts src/__tests__/cli-agent-summary.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts src/adapters/__tests__/playwright-adapter.test.ts",
     "test:integration": "node --import tsx/esm --test src/__tests__/analyze.integration.test.ts",
     "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral",
     "cost-doctor": "tsx src/cli/index.ts cost doctor"

--- a/packages/core/src/adapters/__tests__/playwright-adapter.test.ts
+++ b/packages/core/src/adapters/__tests__/playwright-adapter.test.ts
@@ -1,0 +1,199 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import ts from 'typescript';
+import { PlaywrightAdapter } from '../playwright-adapter.js';
+import type { NeutralScenario } from '../../schemas/gap-analysis.schema.js';
+
+const adapter = new PlaywrightAdapter();
+
+/**
+ * Transpile the generated spec as a standalone module and fail if the
+ * TypeScript parser reports any syntactic error. `transpileModule` does
+ * single-file syntax transformation only (no type-checking, no module
+ * resolution), so a clean run means the string is a syntactically valid spec.
+ */
+function assertValidPlaywrightSpec(code: string): void {
+  const result = ts.transpileModule(code, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    reportDiagnostics: true,
+  });
+  const errors = (result.diagnostics ?? []).filter(
+    (d) => d.category === ts.DiagnosticCategory.Error
+  );
+  const messages = errors.map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'));
+  assert.equal(
+    errors.length,
+    0,
+    `generated spec has syntax errors:\n${messages.join('\n')}\n--- spec ---\n${code}`
+  );
+  assert.ok(result.outputText.length > 0, 'transpile produced no output');
+}
+
+const loginScenario: NeutralScenario = {
+  id: 'scn-login-001',
+  title: 'User Login Flow',
+  description: 'User can submit the login form and reach the dashboard',
+  targetPath: '/login',
+  steps: [
+    { action: 'navigate', target: '/login', description: 'go to the login page' },
+    { action: 'type', target: '#email', value: 'user@example.com', description: 'enter email' },
+    { action: 'type', target: '#password', value: 'hunter2', description: 'enter password' },
+    { action: 'click', target: '#login-submit', description: 'submit the form' },
+    { action: 'assert-visible', target: '.welcome-banner', description: 'welcome banner shows' },
+    { action: 'assert-text', target: 'h1', value: 'Dashboard', description: 'heading reads Dashboard' },
+    { action: 'assert-disabled', target: '#resend', description: 'resend button disabled' },
+    { action: 'assert-hidden', target: '.error-toast', description: 'no error toast' },
+    { action: 'assert-count', target: '.nav-item', value: '4', description: 'four nav items' },
+    { action: 'wait', value: '500', description: 'let the page settle' },
+    { action: 'api-call', target: '/api/session', description: 'session endpoint is healthy' },
+  ],
+  tags: ['auth', 'smoke'],
+  recommendations: [],
+  sourceGapIds: ['gap-1'],
+};
+
+test('render: GeneratedTest metadata identifies the playwright template', () => {
+  const r = adapter.render(loginScenario);
+  assert.equal(r.adapter, 'playwright');
+  assert.equal(r.source, 'template');
+  assert.equal(r.scenarioId, 'scn-login-001');
+  assert.equal(r.filename, 'user-login-flow.spec.ts');
+  assert.equal(r.outputPath, 'tests/user-login-flow.spec.ts');
+});
+
+test('render: wraps steps in a Playwright test.describe / test scaffold', () => {
+  const { code } = adapter.render(loginScenario);
+  assert.ok(
+    code.includes(`import { test, expect } from '@playwright/test';`),
+    'must import test + expect from @playwright/test'
+  );
+  assert.ok(
+    code.includes('test.describe("User Login Flow", () => {'),
+    'must open a describe block titled after the scenario'
+  );
+  assert.ok(
+    code.includes('test("User can submit the login form and reach the dashboard", async ({ page }) => {'),
+    'must open a test using the page fixture'
+  );
+  assert.ok(code.includes('// qulib-generated — scenario: scn-login-001'), 'must stamp the scenario id');
+});
+
+test('render: every step targets the real scenario routes and selectors', () => {
+  const { code } = adapter.render(loginScenario);
+  const expected = [
+    'await page.goto("/login");',
+    'await page.locator("#email").fill("user@example.com");',
+    'await page.locator("#password").fill("hunter2");',
+    'await page.locator("#login-submit").click();',
+    'await expect(page.locator(".welcome-banner")).toBeVisible();',
+    'await expect(page.locator("h1")).toContainText("Dashboard");',
+    'await expect(page.locator("#resend")).toBeDisabled();',
+    'await expect(page.locator(".error-toast")).toBeHidden();',
+    'expect(await page.locator(".nav-item").count()).toBeGreaterThanOrEqual(4);',
+    'await page.waitForTimeout(500);',
+    'expect((await page.request.get("/api/session")).status()).toBe(200);',
+  ];
+  for (const line of expected) {
+    assert.ok(code.includes(line), `expected generated spec to contain: ${line}\n--- spec ---\n${code}`);
+  }
+});
+
+test('render: the generated spec is a syntactically valid Playwright spec', () => {
+  const { code } = adapter.render(loginScenario);
+  assertValidPlaywrightSpec(code);
+});
+
+test('render: selectors with embedded quotes are escaped, not broken', () => {
+  const scenario: NeutralScenario = {
+    id: 'scn-search-001',
+    title: 'Search Box',
+    description: 'typing into the search input works',
+    targetPath: '/',
+    steps: [
+      { action: 'click', target: 'input[name="q"]', description: 'focus the search input' },
+      { action: 'type', target: 'input[name="q"]', value: 'qulib', description: 'type a query' },
+    ],
+    tags: [],
+    recommendations: [],
+    sourceGapIds: [],
+  };
+  const { code } = adapter.render(scenario);
+  assert.ok(code.includes(`await page.locator(${JSON.stringify('input[name="q"]')}).click();`));
+  assert.ok(
+    code.includes(`await page.locator(${JSON.stringify('input[name="q"]')}).fill(${JSON.stringify('qulib')});`)
+  );
+  assertValidPlaywrightSpec(code);
+});
+
+test('render: steps missing a target fall back to safe defaults / comments', () => {
+  const scenario: NeutralScenario = {
+    id: 'scn-degenerate-001',
+    title: 'Degenerate Steps',
+    description: 'steps without targets degrade gracefully',
+    targetPath: '/x',
+    steps: [
+      { action: 'assert-visible', description: 'something is visible' },
+      { action: 'click', description: 'click something undescribed' },
+      { action: 'assert-text', description: 'some text exists' },
+    ],
+    tags: [],
+    recommendations: [],
+    sourceGapIds: [],
+  };
+  const { code } = adapter.render(scenario);
+  assert.ok(
+    code.includes(`await expect(page.locator('body')).toBeVisible();`),
+    'target-less assert-visible falls back to body'
+  );
+  assert.ok(code.includes('// click: click something undescribed'), 'target-less click becomes a comment');
+  assert.ok(code.includes('// assert-text: some text exists'), 'target-less assert-text becomes a comment');
+  assertValidPlaywrightSpec(code);
+});
+
+test('render: a scenario with no steps still yields a valid spec with a placeholder', () => {
+  const scenario: NeutralScenario = {
+    id: 'scn-empty-001',
+    title: 'Empty Scenario',
+    description: 'no steps yet',
+    targetPath: '/pending',
+    steps: [],
+    tags: [],
+    recommendations: [],
+    sourceGapIds: [],
+  };
+  const { code } = adapter.render(scenario);
+  assert.ok(code.includes('// no steps — add assertions for: /pending'));
+  assertValidPlaywrightSpec(code);
+});
+
+test('renderAll: maps each scenario to its own valid playwright GeneratedTest', () => {
+  const second: NeutralScenario = {
+    id: 'scn-logout-002',
+    title: 'User Logout',
+    description: 'user can log out',
+    targetPath: '/logout',
+    steps: [{ action: 'navigate', target: '/logout', description: 'open logout' }],
+    tags: [],
+    recommendations: [],
+    sourceGapIds: [],
+  };
+  const results = adapter.renderAll([loginScenario, second]);
+  assert.equal(results.length, 2);
+  assert.deepEqual(
+    results.map((r) => r.filename),
+    ['user-login-flow.spec.ts', 'user-logout.spec.ts']
+  );
+  for (const r of results) {
+    assert.equal(r.adapter, 'playwright');
+    assert.equal(r.source, 'template');
+    assert.ok(r.outputPath.startsWith('tests/'));
+    assertValidPlaywrightSpec(r.code);
+  }
+});
+
+test('adapterType exposes the playwright identifier', () => {
+  assert.equal(adapter.adapterType, 'playwright');
+});

--- a/packages/core/src/adapters/playwright-adapter.ts
+++ b/packages/core/src/adapters/playwright-adapter.ts
@@ -1,14 +1,87 @@
 import type { TestAdapter } from './adapter.interface.js';
-import type { NeutralScenario, GeneratedTest } from '../schemas/gap-analysis.schema.js';
+import type { NeutralScenario, GeneratedTest, TestStep } from '../schemas/gap-analysis.schema.js';
+
+function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function renderStep(step: TestStep): string {
+  const t = step.target != null ? JSON.stringify(step.target) : null;
+  const v = step.value != null ? JSON.stringify(step.value) : null;
+
+  switch (step.action) {
+    case 'navigate':
+      return `    await page.goto(${JSON.stringify(step.target ?? step.value ?? '/')});`;
+    case 'click':
+      return t ? `    await page.locator(${t}).click();` : `    // click: ${step.description}`;
+    case 'type':
+      return t && v ? `    await page.locator(${t}).fill(${v});` : `    // type: ${step.description}`;
+    case 'assert-visible':
+      return t
+        ? `    await expect(page.locator(${t})).toBeVisible();`
+        : `    await expect(page.locator('body')).toBeVisible();`;
+    case 'assert-hidden':
+      return t
+        ? `    await expect(page.locator(${t})).toBeHidden();`
+        : `    // assert-hidden: ${step.description}`;
+    case 'assert-text':
+      if (t && v) return `    await expect(page.locator(${t})).toContainText(${v});`;
+      if (t) return `    await expect(page.locator(${t})).not.toBeEmpty();`;
+      return `    // assert-text: ${step.description}`;
+    case 'assert-disabled':
+      return t
+        ? `    await expect(page.locator(${t})).toBeDisabled();`
+        : `    // assert-disabled: ${step.description}`;
+    case 'assert-count':
+      return t
+        ? `    expect(await page.locator(${t}).count()).toBeGreaterThanOrEqual(${parseInt(step.value ?? '1', 10)});`
+        : `    // assert-count: ${step.description}`;
+    case 'wait':
+      return `    await page.waitForTimeout(${parseInt(step.value ?? '1000', 10)});`;
+    case 'api-call':
+      return `    expect((await page.request.get(${JSON.stringify(step.target ?? step.value ?? '/')})).status()).toBe(200);`;
+    default:
+      return `    // TODO: ${step.description}`;
+  }
+}
 
 export class PlaywrightAdapter implements TestAdapter {
   readonly adapterType = 'playwright';
 
   render(scenario: NeutralScenario): GeneratedTest {
-    throw new Error('Not implemented');
+    const slug = slugify(scenario.title);
+    const filename = `${slug}.spec.ts`;
+
+    const stepLines = scenario.steps.map(renderStep).join('\n');
+
+    const code = [
+      `// ${scenario.description}`,
+      `// qulib-generated — scenario: ${scenario.id}`,
+      ``,
+      `import { test, expect } from '@playwright/test';`,
+      ``,
+      `test.describe(${JSON.stringify(scenario.title)}, () => {`,
+      `  test(${JSON.stringify(scenario.description)}, async ({ page }) => {`,
+      stepLines || `    // no steps — add assertions for: ${scenario.targetPath}`,
+      `  });`,
+      `});`,
+      ``,
+    ].join('\n');
+
+    return {
+      scenarioId: scenario.id,
+      adapter: 'playwright',
+      filename,
+      code,
+      source: 'template',
+      outputPath: `tests/${filename}`,
+    };
   }
 
   renderAll(scenarios: NeutralScenario[]): GeneratedTest[] {
-    throw new Error('Not implemented');
+    return scenarios.map((s) => this.render(s));
   }
 }


### PR DESCRIPTION
## What

Implements `PlaywrightAdapter`, which was a not-implemented stub — both `render()` and `renderAll()` threw `Error('Not implemented')`. As a result `scaffoldTests(url, { framework: 'playwright' })` and `qulib scaffold --framework playwright` could not generate any specs; only `cypress-e2e` worked.

The adapter now renders real Playwright specs from `NeutralScenario[]`, mirroring the structure of the working `CypressE2EAdapter` (`slugify` → per-step `renderStep` switch → spec template → `renderAll` map). The factory and `scaffold-tests.ts` (`buildPlaywrightProjectConfig`) were already wired for `'playwright'`, so only the renderer was missing.

## Action → Playwright API mapping

| `TestStep.action` | Generated |
|---|---|
| `navigate` | `await page.goto(target)` |
| `click` | `await page.locator(target).click()` |
| `type` | `await page.locator(target).fill(value)` |
| `assert-visible` | `await expect(page.locator(target)).toBeVisible()` (falls back to `body`) |
| `assert-hidden` | `await expect(page.locator(target)).toBeHidden()` |
| `assert-text` | `.toContainText(value)` / `.not.toBeEmpty()` |
| `assert-disabled` | `await expect(page.locator(target)).toBeDisabled()` |
| `assert-count` | `expect(await page.locator(target).count()).toBeGreaterThanOrEqual(n)` |
| `wait` | `await page.waitForTimeout(n)` |
| `api-call` | `expect((await page.request.get(url)).status()).toBe(200)` |

Specs are wrapped in `import { test, expect } from '@playwright/test'` + `test.describe(...)` / `test(..., async ({ page }) => { ... })`. Each `GeneratedTest` sets `adapter: 'playwright'`, `source: 'template'`, `filename: <slug>.spec.ts`, `outputPath: tests/<slug>.spec.ts`.

## Sample output

```ts
// a guest can add an item and see the cart update
// qulib-generated — scenario: scn-cart-007

import { test, expect } from '@playwright/test';

test.describe("Add To Cart", () => {
  test("a guest can add an item and see the cart update", async ({ page }) => {
    await page.goto("/shop");
    await page.locator(".product-card:first-child .add-to-cart").click();
    await expect(page.locator("[data-test=\"cart-count\"]")).toContainText("1");
    await expect(page.locator(".mini-cart")).toBeVisible();
    expect((await page.request.get("/api/cart")).status()).toBe(200);
  });
});
```

## Tests

New `node:test` file (`src/adapters/__tests__/playwright-adapter.test.ts`, 9 tests), wired into the core `test` script. Coverage: GeneratedTest metadata, the describe/test scaffold, every action rendering the real route/selector verbatim, embedded-quote escaping, target-less fallbacks/comments, the empty-steps placeholder, `renderAll`, and `adapterType`. Each rendered spec is validated as **syntactically valid** by transpiling it through the TypeScript compiler API (`ts.transpileModule` with `reportDiagnostics`).

## Gates

- `npm run build` (tsc): **PASS**
- `npm test` (full core suite): **PASS — 117/117, 0 fail** (108 baseline + 9 new)
- IP blocklist scan of staged diff: **0 matches**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
