### PR TITLE
Add npm publish workflow with provenance (OIDC trusted publishing)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,7 @@
 - [ ] Commit messages follow `type: short description`
 - [ ] No new dependencies added without justification in the PR description
 - [ ] Output remains honest (no features that hide failure modes or inflate confidence)
+- [ ] Labeled with an area label + assigned to the current milestone
 
 ## Related issues
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+name: Publish
+
+# Publishes @qulib/core then @qulib/mcp to npm WITH provenance (a signed build
+# attestation linking each tarball to this repo + commit + workflow run).
+#
+# Auth model: OIDC trusted publishing (tokenless) — no NPM_TOKEN secret stored.
+# One-time human setup on npmjs.com (see Maintainer's Guide): for BOTH @qulib/core
+# and @qulib/mcp -> package Settings -> Trusted Publisher -> GitHub Actions ->
+# repository TapeshN/qulib, workflow "publish.yml". Until that is configured this
+# job fails auth by design — it never falls back to an unverified publish.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # required for npm provenance + OIDC trusted publishing
+
+jobs:
+  publish:
+    name: Publish (core then mcp, with provenance)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      - name: Upgrade npm (OIDC trusted publishing needs npm >= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build all workspaces
+        run: npm run build
+
+      - name: Verify versions are aligned and match the release tag
+        run: |
+          CORE=$(node -p "require('./packages/core/package.json').version")
+          MCP=$(node -p "require('./packages/mcp/package.json').version")
+          TAG="${GITHUB_REF_NAME#v}"
+          echo "core=$CORE  mcp=$MCP  tag=$TAG"
+          if [ "$CORE" != "$MCP" ]; then echo "::error::core ($CORE) != mcp ($MCP)"; exit 1; fi
+          if [ "$CORE" != "$TAG" ]; then echo "::error::package version ($CORE) != release tag ($TAG)"; exit 1; fi
+
+      # Core MUST publish before MCP — MCP depends on @qulib/core at the published version.
+      - name: Publish @qulib/core
+        run: npm publish -w @qulib/core --provenance --access public
+
+      - name: Publish @qulib/mcp
+        run: npm publish -w @qulib/mcp --provenance --access public


### PR DESCRIPTION
## What this PR does

Adds `.github/workflows/publish.yml` — on a published GitHub Release, builds and publishes `@qulib/core` then `@qulib/mcp` to npm with `npm publish --provenance` via **OIDC trusted publishing** (tokenless; no `NPM_TOKEN` secret). Verifies core/mcp versions are aligned and equal the release tag before publishing; always publishes core before mcp.

Also adds one PR-template checklist line (labeled + assigned to a milestone) to close a repo-wide PR-hygiene gap.

## Why

qulib is published by hand today, so packages are signed but carry **no provenance attestation** — the 'verified built & published from this repo' supply-chain badge. Publishing from CI via OIDC adds that badge and removes the local-token publish path.

## Type

- [x] Chore (tooling)

## Checklist

- [x] Branched from `main`
- [ ] `npm run build` — N/A (CI/docs only, no source touched; PR CI validates)
- [x] Commit messages follow `type: short description`
- [x] No new dependencies
- [x] Output remains honest
- [x] Labeled + assigned to the current milestone

## One-time setup before the first release

Before cutting v0.8.0, configure the npm trusted publisher for **both** packages: npmjs.com → package Settings → Trusted Publisher → GitHub Actions → repo `TapeshN/qulib`, workflow `publish.yml`. Merging this PR is safe anytime — the workflow only runs on a published Release.