### PR TITLE
feat(api-toolshed): repo-first API discovery + api-test-coverage scoring + qulib_score_api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Entries for **0.3.1 and earlier** were reconstructed from git tags (`v0.1.1` … `v0.2.2`) and release commits on `main`.
 
+## [0.8.2] — 2026-06-01
+
+### Added
+- **@qulib/core:** repo-first API toolshed — `discoverApiSurface` (tiered, evidence-only discovery across OpenAPI/Swagger specs + Next/Express/Fastify/Hono/Nest routes), `computeApiCoverage` (new `api-test-coverage` dimension; the six existing dimensions rebalanced to sum 1.0; `untested-api-endpoint` gap category), and an `ApiAdapter` for supertest test generation.
+- **@qulib/mcp:** `qulib_score_api` — repo → API discovery → contextual coverage score.
+
+### Notes
+- Backward-compatible: `computeAutomationMaturity(repo)` without an API surface is unchanged; existing scores are stable.
+
 ## [0.7.0] — 2026-05-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -573,6 +573,13 @@
       "resolved": "packages/mcp",
       "link": true
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.40",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
@@ -628,6 +635,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/axe-core": {
       "version": "4.11.4",
@@ -1355,6 +1368,28 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -2036,12 +2071,14 @@
         "@playwright/test": "^1.44.0",
         "commander": "^12.1.0",
         "fast-glob": "^3.3.2",
+        "js-yaml": "^4.2.0",
         "zod": "^3.23.0"
       },
       "bin": {
         "qulib": "bin/qulib.js"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
         "tsx": "^4.11.0",
         "typescript": "^5.4.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "analyze": "tsx src/cli/index.ts analyze",
     "clean": "tsx src/cli/index.ts clean",
     "build": "tsc",
-    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/agent-summary.test.ts src/__tests__/cli-agent-summary.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts src/adapters/__tests__/playwright-adapter.test.ts",
+    "test": "node --import tsx/esm --test src/llm/__tests__/cost-intelligence.test.ts src/llm/__tests__/context-builder.test.ts src/tools/scoring/__tests__/gaps.test.ts src/tools/auth/__tests__/gaps.test.ts src/tools/auth/__tests__/detect.test.ts src/tools/scoring/__tests__/automation-maturity.test.ts src/tools/scoring/__tests__/api-coverage.test.ts src/tools/scoring/__tests__/automation-maturity-with-api.test.ts src/harness/__tests__/state-manager.test.ts src/telemetry/__tests__/redact-url.test.ts src/cli/__tests__/auth-login.test.ts src/cli/__tests__/cli-version.test.ts src/__tests__/agent-summary.test.ts src/__tests__/cli-agent-summary.test.ts src/__tests__/analyze.storage-state-invalid.test.ts src/__tests__/analyze.fixtures.test.ts src/adapters/__tests__/playwright-adapter.test.ts src/adapters/__tests__/api-adapter.test.ts src/tools/repo/__tests__/api-surface.test.ts",
     "test:integration": "node --import tsx/esm --test src/__tests__/analyze.integration.test.ts",
     "smoke": "tsx src/cli/index.ts analyze --url https://example.com --ephemeral",
     "cost-doctor": "tsx src/cli/index.ts cost doctor"
@@ -58,9 +58,11 @@
     "@playwright/test": "^1.44.0",
     "commander": "^12.1.0",
     "fast-glob": "^3.3.2",
+    "js-yaml": "^4.2.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
     "tsx": "^4.11.0",
     "typescript": "^5.4.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/core",
-  "version": "0.7.0",
+  "version": "0.8.2",
   "description": "Qulib — analyze deployed web apps for honest quality gaps (CLI + programmatic API)",
   "license": "MIT",
   "author": "Tapesh Nagarwal",

--- a/packages/core/src/__tests__/fixtures/api-fixture-repo/app/api/orders/route.ts
+++ b/packages/core/src/__tests__/fixtures/api-fixture-repo/app/api/orders/route.ts
@@ -1,0 +1,8 @@
+// Fixture: Next.js App Router API route for orders (DELETE only — high severity untested)
+// This file is a static analysis fixture only — not compiled.
+
+export async function DELETE(request: { url: string }) {
+  const url = new URL(request.url);
+  const id = url.searchParams.get('id');
+  return { deleted: true, id };
+}

--- a/packages/core/src/__tests__/fixtures/api-fixture-repo/app/api/users/route.ts
+++ b/packages/core/src/__tests__/fixtures/api-fixture-repo/app/api/users/route.ts
@@ -1,0 +1,11 @@
+// Fixture: Next.js App Router API route for users
+// This file is a static analysis fixture only — not compiled.
+
+export async function GET() {
+  return { users: [] };
+}
+
+export async function POST(request: { json: () => Promise<unknown> }) {
+  const body = await request.json();
+  return { created: true, user: body };
+}

--- a/packages/core/src/__tests__/fixtures/api-fixture-repo/openapi.yaml
+++ b/packages/core/src/__tests__/fixtures/api-fixture-repo/openapi.yaml
@@ -1,0 +1,19 @@
+openapi: "3.0.0"
+info:
+  title: Fixture API
+  version: "1.0.0"
+paths:
+  /api/ping:
+    get:
+      summary: Health check
+      parameters:
+        - name: verbose
+          in: query
+  /api/users:
+    get:
+      summary: List users
+    post:
+      summary: Create user
+      parameters:
+        - name: dryRun
+          in: query

--- a/packages/core/src/__tests__/fixtures/api-fixture-repo/pages/api/health.ts
+++ b/packages/core/src/__tests__/fixtures/api-fixture-repo/pages/api/health.ts
@@ -1,0 +1,13 @@
+// Fixture: Next.js Pages API route
+// This file is a static analysis fixture only — not compiled.
+
+export default function handler(
+  req: { method?: string },
+  res: { status: (code: number) => { json: (data: unknown) => void; end: () => void } }
+) {
+  if (req.method === 'GET') {
+    res.status(200).json({ status: 'ok' });
+  } else {
+    res.status(405).end();
+  }
+}

--- a/packages/core/src/__tests__/fixtures/api-fixture-repo/tests/users.test.ts
+++ b/packages/core/src/__tests__/fixtures/api-fixture-repo/tests/users.test.ts
@@ -1,0 +1,10 @@
+// Fixture test file that covers the /api/users endpoint
+import { describe, it, expect } from 'vitest';
+
+describe('users api', () => {
+  it('GET /api/users returns a list', async () => {
+    // covers /api/users
+    const res = { status: 200, body: { users: [] } };
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/core/src/adapters/__tests__/api-adapter.test.ts
+++ b/packages/core/src/adapters/__tests__/api-adapter.test.ts
@@ -1,0 +1,216 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ApiAdapter } from '../api-adapter.js';
+import type { NeutralScenario } from '../../schemas/gap-analysis.schema.js';
+import type { ApiSurface, DiscoveredEndpoint } from '../../tools/repo/api-surface.js';
+
+const adapter = new ApiAdapter();
+
+function baseSurface(endpoints: DiscoveredEndpoint[], repoPath = '/tmp/fake-repo'): ApiSurface {
+  return {
+    discoveredAt: new Date().toISOString(),
+    repoPath,
+    endpoints,
+    openApiSpecsFound: 0,
+    tier3Enabled: false,
+  };
+}
+
+function ep(
+  method: DiscoveredEndpoint['method'],
+  path: string,
+  tier: DiscoveredEndpoint['sourceTier'] = 'framework'
+): DiscoveredEndpoint {
+  return {
+    method,
+    path,
+    sourceFile: 'app/api/test/route.ts',
+    sourceTier: tier,
+    confidence: 'high',
+  };
+}
+
+const apiCallScenario: NeutralScenario = {
+  id: 'scn-api-001',
+  title: 'Health endpoint',
+  description: 'Health endpoint returns 200',
+  targetPath: '/api/health',
+  steps: [
+    { action: 'api-call', target: '/api/health', description: 'call the health endpoint' },
+  ],
+  tags: ['api'],
+  recommendations: [],
+  sourceGapIds: [],
+};
+
+// ---------------------------------------------------------------------------
+// render() — NeutralScenario → supertest spec
+// ---------------------------------------------------------------------------
+
+test('adapterType is "api"', () => {
+  assert.equal(adapter.adapterType, 'api');
+});
+
+test('render: metadata uses api adapter and template source', () => {
+  const result = adapter.render(apiCallScenario);
+  assert.equal(result.adapter, 'api');
+  assert.equal(result.source, 'template');
+  assert.equal(result.scenarioId, 'scn-api-001');
+  assert.ok(result.filename.endsWith('.api.test.ts'), `unexpected filename: ${result.filename}`);
+  assert.ok(result.outputPath.startsWith('tests/api/'), `unexpected outputPath: ${result.outputPath}`);
+});
+
+test('render: generated code imports supertest and vitest', () => {
+  const { code } = adapter.render(apiCallScenario);
+  assert.ok(code.includes("import request from 'supertest'"), 'must import supertest');
+  assert.ok(code.includes("from 'vitest'"), 'must import from vitest');
+});
+
+test('render: api-call step generates a supertest GET call', () => {
+  const { code } = adapter.render(apiCallScenario);
+  assert.ok(
+    code.includes('request(app).get("/api/health")'),
+    `expected request(app).get("/api/health") in code, got:\n${code}`
+  );
+  assert.ok(code.includes('.toBe(200)'), 'should assert status 200 for api-call step');
+});
+
+test('render: navigate step generates a GET with status < 500', () => {
+  const scenario: NeutralScenario = {
+    ...apiCallScenario,
+    id: 'scn-nav-001',
+    steps: [{ action: 'navigate', target: '/dashboard', description: 'navigate to dashboard' }],
+  };
+  const { code } = adapter.render(scenario);
+  assert.ok(code.includes('request(app).get("/dashboard")'), 'must generate GET for navigate');
+  assert.ok(code.includes('.toBeLessThan(500)'), 'navigate should assert < 500');
+});
+
+test('render: unknown step action becomes a TODO comment', () => {
+  const scenario: NeutralScenario = {
+    ...apiCallScenario,
+    id: 'scn-todo-001',
+    steps: [{ action: 'click', target: '#btn', description: 'click something' }],
+  };
+  const { code } = adapter.render(scenario);
+  assert.ok(code.includes('// TODO (click):'), 'non-api steps should become TODO comments');
+});
+
+test('render: empty steps yields placeholder comment', () => {
+  const scenario: NeutralScenario = {
+    ...apiCallScenario,
+    id: 'scn-empty-001',
+    steps: [],
+  };
+  const { code } = adapter.render(scenario);
+  assert.ok(
+    code.includes('// no api-call steps — add assertions for:'),
+    'empty steps should produce placeholder'
+  );
+});
+
+test('renderAll: each scenario becomes its own GeneratedTest', () => {
+  const s2: NeutralScenario = {
+    ...apiCallScenario,
+    id: 'scn-api-002',
+    title: 'Create user',
+    description: 'POST creates a user',
+    targetPath: '/api/users',
+    steps: [{ action: 'api-call', target: '/api/users', description: 'POST to users' }],
+  };
+  const results = adapter.renderAll([apiCallScenario, s2]);
+  assert.equal(results.length, 2);
+  assert.ok(results.every((r) => r.adapter === 'api'));
+  assert.ok(results.every((r) => r.source === 'template'));
+});
+
+// ---------------------------------------------------------------------------
+// scaffoldApiTests() — repo-first generation from ApiSurface
+// ---------------------------------------------------------------------------
+
+test('scaffoldApiTests: returns a GeneratedTest with scenarioId qulib-api-scaffold', () => {
+  const surface = baseSurface([ep('GET', '/api/users'), ep('POST', '/api/orders')]);
+  const result = adapter.scaffoldApiTests(surface);
+  assert.equal(result.scenarioId, 'qulib-api-scaffold');
+  assert.equal(result.adapter, 'api');
+  assert.equal(result.source, 'template');
+  assert.equal(result.filename, 'api-scaffold.test.ts');
+  assert.equal(result.outputPath, 'tests/api/api-scaffold.test.ts');
+});
+
+test('scaffoldApiTests: imports supertest', () => {
+  const surface = baseSurface([ep('GET', '/api/ping')]);
+  const { code } = adapter.scaffoldApiTests(surface);
+  assert.ok(code.includes("import request from 'supertest'"), 'must import supertest');
+});
+
+test('scaffoldApiTests: generates one it-block per endpoint', () => {
+  const surface = baseSurface([ep('GET', '/api/users'), ep('DELETE', '/api/orders')]);
+  const { code } = adapter.scaffoldApiTests(surface);
+  assert.ok(code.includes('GET /api/users'), 'should include GET /api/users it block');
+  assert.ok(code.includes('DELETE /api/orders'), 'should include DELETE /api/orders it block');
+});
+
+test('scaffoldApiTests: GET endpoint uses request.get()', () => {
+  const surface = baseSurface([ep('GET', '/api/users')]);
+  const { code } = adapter.scaffoldApiTests(surface);
+  assert.ok(code.includes('.get("/api/users")'), 'GET should use request.get()');
+});
+
+test('scaffoldApiTests: POST endpoint uses request.post() and includes TODO for body', () => {
+  const surface = baseSurface([ep('POST', '/api/orders')]);
+  const { code } = adapter.scaffoldApiTests(surface);
+  assert.ok(code.includes('.post("/api/orders")'), 'POST should use request.post()');
+  assert.ok(code.includes('TODO: add request body'), 'POST should include TODO for body');
+});
+
+test('scaffoldApiTests: DELETE endpoint uses request.delete()', () => {
+  const surface = baseSurface([ep('DELETE', '/api/orders')]);
+  const { code } = adapter.scaffoldApiTests(surface);
+  assert.ok(code.includes('.delete("/api/orders")'), 'DELETE should use request.delete()');
+});
+
+test('scaffoldApiTests: asserts status < 500 for each endpoint', () => {
+  const surface = baseSurface([ep('GET', '/api/users'), ep('POST', '/api/orders')]);
+  const { code } = adapter.scaffoldApiTests(surface);
+  const count = (code.match(/toBeLessThan\(500\)/g) ?? []).length;
+  assert.equal(count, 2, 'each endpoint should assert status < 500');
+});
+
+test('scaffoldApiTests: includes discovery source comment', () => {
+  const surface = baseSurface([ep('GET', '/api/users', 'openapi')]);
+  const { code } = adapter.scaffoldApiTests(surface);
+  assert.ok(
+    code.includes('// Source:') || code.includes('openapi'),
+    'should include source tier comment'
+  );
+});
+
+test('scaffoldApiTests: empty endpoints returns a no-endpoints placeholder', () => {
+  const surface = baseSurface([]);
+  const { code } = adapter.scaffoldApiTests(surface);
+  assert.ok(code.includes('No API endpoints'), 'should explain that no endpoints were found');
+});
+
+test('scaffoldApiTests: custom appImportPath is used', () => {
+  const surface = baseSurface([ep('GET', '/api/health')]);
+  const { code } = adapter.scaffoldApiTests(surface, { appImportPath: '../src/server.js' });
+  assert.ok(
+    code.includes('../src/server.js'),
+    `expected custom appImportPath in code, got:\n${code}`
+  );
+});
+
+test('scaffoldApiTests: Tier2 OpenAPI endpoint surfaces summary as comment', () => {
+  const withSummary: DiscoveredEndpoint = {
+    method: 'GET',
+    path: '/api/ping',
+    sourceFile: 'openapi.yaml',
+    sourceTier: 'openapi',
+    confidence: 'high',
+    summary: 'Health check',
+  };
+  const surface = baseSurface([withSummary]);
+  const { code } = adapter.scaffoldApiTests(surface);
+  assert.ok(code.includes('Health check'), 'summary should appear in the code as a comment');
+});

--- a/packages/core/src/adapters/api-adapter.ts
+++ b/packages/core/src/adapters/api-adapter.ts
@@ -1,14 +1,186 @@
 import type { TestAdapter } from './adapter.interface.js';
 import type { NeutralScenario, GeneratedTest } from '../schemas/gap-analysis.schema.js';
+import type { DiscoveredEndpoint, ApiSurface } from '../tools/repo/api-surface.js';
 
+function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * TestAdapter implementation for API testing via supertest.
+ *
+ * `render` / `renderAll`: convert gap-analysis NeutralScenarios that carry
+ *   `api-call` steps into supertest specs. Used by the standard adapter pipeline.
+ *
+ * `scaffoldApiTests`: separate entry point for the repo-first API toolshed flow.
+ *   Accepts discovered endpoints (ApiSurface) and generates a ready-to-run
+ *   supertest test file — NOT URL-based.
+ */
 export class ApiAdapter implements TestAdapter {
   readonly adapterType = 'api';
 
   render(scenario: NeutralScenario): GeneratedTest {
-    throw new Error('Not implemented');
+    const slug = slugify(scenario.title);
+    const filename = `${slug}.api.test.ts`;
+
+    const stepLines = scenario.steps
+      .map((step) => {
+        if (step.action === 'api-call') {
+          const path = step.target ?? step.value ?? '/';
+          return [
+            `    // ${step.description}`,
+            `    const res = await request(app).get(${JSON.stringify(path)});`,
+            `    expect(res.status).toBe(200);`,
+          ].join('\n');
+        }
+        if (step.action === 'navigate') {
+          const path = step.target ?? step.value ?? '/';
+          return [
+            `    // ${step.description}`,
+            `    const res = await request(app).get(${JSON.stringify(path)});`,
+            `    expect(res.status).toBeLessThan(500);`,
+          ].join('\n');
+        }
+        return `    // TODO (${step.action}): ${step.description}`;
+      })
+      .join('\n');
+
+    const code = [
+      `// ${scenario.description}`,
+      `// qulib-generated — scenario: ${scenario.id}`,
+      ``,
+      `import request from 'supertest';`,
+      `import { describe, it, expect } from 'vitest';`,
+      ``,
+      `// TODO: import or create your Express/Fastify/Hono app here`,
+      `// import { app } from '../src/app.js';`,
+      `declare const app: unknown;`,
+      ``,
+      `describe(${JSON.stringify(scenario.title)}, () => {`,
+      `  it(${JSON.stringify(scenario.description)}, async () => {`,
+      stepLines || `    // no api-call steps — add assertions for: ${scenario.targetPath}`,
+      `  });`,
+      `});`,
+      ``,
+    ].join('\n');
+
+    return {
+      scenarioId: scenario.id,
+      adapter: 'api',
+      filename,
+      code,
+      source: 'template',
+      outputPath: `tests/api/${filename}`,
+    };
   }
 
   renderAll(scenarios: NeutralScenario[]): GeneratedTest[] {
-    throw new Error('Not implemented');
+    return scenarios.map((s) => this.render(s));
   }
+
+  /**
+   * Generate a supertest-based test file from discovered API endpoints.
+   * This is the repo-first entry point — does NOT require a running URL.
+   *
+   * Endpoints are grouped into a single test file. Each endpoint gets one
+   * `it` block that:
+   *   - Makes the correct HTTP method call
+   *   - Asserts status < 500 (smoke-level assertion, safely runnable against a live app)
+   *   - POST/PUT/PATCH endpoints include a TODO for request body
+   *
+   * The file is NOT associated with a NeutralScenario; it uses a fixed scenarioId.
+   */
+  scaffoldApiTests(
+    apiSurface: ApiSurface,
+    options: { appImportPath?: string } = {}
+  ): GeneratedTest {
+    const appImport = options.appImportPath ?? '../src/app.js';
+    const endpoints = apiSurface.endpoints;
+
+    if (endpoints.length === 0) {
+      const code = [
+        `// qulib-generated API scaffold — no endpoints discovered`,
+        `// qulib-generated — repo: ${apiSurface.repoPath}`,
+        ``,
+        `// No API endpoints were discovered in this repository.`,
+        `// If your app has REST endpoints, ensure they are declared in a supported`,
+        `// framework (Next.js route.ts, Express, Fastify, NestJS) or an OpenAPI spec.`,
+        ``,
+      ].join('\n');
+      return {
+        scenarioId: 'qulib-api-scaffold',
+        adapter: 'api',
+        filename: 'api-scaffold.test.ts',
+        code,
+        source: 'template',
+        outputPath: 'tests/api/api-scaffold.test.ts',
+      };
+    }
+
+    const itBlocks = endpoints.map((ep) => renderEndpointTest(ep)).join('\n\n');
+
+    const code = [
+      `// qulib-generated API scaffold — ${endpoints.length} endpoint(s) discovered`,
+      `// qulib-generated — repo: ${apiSurface.repoPath}`,
+      `// Discovery tier breakdown: ${describeDiscoveryTiers(endpoints)}`,
+      ``,
+      `import request from 'supertest';`,
+      `import { describe, it, expect, beforeAll, afterAll } from 'vitest';`,
+      ``,
+      `// TODO: replace with your actual app export`,
+      `import { app } from ${JSON.stringify(appImport)};`,
+      ``,
+      `describe('API surface smoke tests (qulib-generated)', () => {`,
+      itBlocks,
+      `});`,
+      ``,
+    ].join('\n');
+
+    return {
+      scenarioId: 'qulib-api-scaffold',
+      adapter: 'api',
+      filename: 'api-scaffold.test.ts',
+      code,
+      source: 'template',
+      outputPath: 'tests/api/api-scaffold.test.ts',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function renderEndpointTest(ep: DiscoveredEndpoint): string {
+  const method = ep.method === 'unknown' ? 'GET' : ep.method;
+  const methodLower = method.toLowerCase();
+  const hasBody = method === 'POST' || method === 'PUT' || method === 'PATCH';
+  const sourceLine = `  // Source: ${ep.sourceFile} (${ep.sourceTier}, confidence: ${ep.confidence})`;
+  const itTitle = `${method} ${ep.path}`;
+
+  const requestLine = hasBody
+    ? `      const res = await request(app).${methodLower}(${JSON.stringify(ep.path)});\n      // TODO: add request body — e.g. .send({ ... })`
+    : `      const res = await request(app).${methodLower}(${JSON.stringify(ep.path)});`;
+
+  const summaryLine = ep.summary ? `  // ${ep.summary}\n` : '';
+
+  return [
+    summaryLine + sourceLine,
+    `  it(${JSON.stringify(itTitle)}, async () => {`,
+    requestLine,
+    `      expect(res.status).toBeLessThan(500);`,
+    `  });`,
+  ].join('\n');
+}
+
+function describeDiscoveryTiers(endpoints: DiscoveredEndpoint[]): string {
+  const counts = { openapi: 0, framework: 0, heuristic: 0 };
+  for (const ep of endpoints) counts[ep.sourceTier]++;
+  return Object.entries(counts)
+    .filter(([, v]) => v > 0)
+    .map(([k, v]) => `${v} ${k}`)
+    .join(', ');
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,7 +21,11 @@ export type {
 export { exploreAuth } from './tools/auth/explore.js';
 export { addUserProvider, removeUserProvider, listUserProviders } from './tools/auth/custom-providers.js';
 export { scanRepo } from './tools/repo/scan.js';
+export { discoverApiSurface, discoverApiSurfaceWithRepo } from './tools/repo/api-surface.js';
+export type { ApiSurface, DiscoveredEndpoint, DiscoverApiSurfaceOptions } from './tools/repo/api-surface.js';
 export { computeAutomationMaturity } from './tools/scoring/automation-maturity.js';
+export { computeApiCoverage } from './tools/scoring/api-coverage.js';
+export type { ApiCoverageResult, ApiEndpointCoverage } from './tools/scoring/api-coverage.js';
 export { scaffoldTests } from './scaffold-tests.js';
 export type { ScaffoldOptions, ScaffoldResult, ProjectConfig } from './scaffold-tests.js';
 export { createProvider } from './llm/provider-registry.js';

--- a/packages/core/src/schemas/automation-maturity.schema.ts
+++ b/packages/core/src/schemas/automation-maturity.schema.ts
@@ -33,6 +33,7 @@ export const AutomationMaturityDimensionSchema = z.object({
     'ci-integration',
     'auth-test-coverage',
     'component-test-ratio',
+    'api-test-coverage',
   ]),
   score: z.number().min(0).max(100),
   weight: z.number().min(0).max(1),

--- a/packages/core/src/schemas/gap-analysis.schema.ts
+++ b/packages/core/src/schemas/gap-analysis.schema.ts
@@ -6,7 +6,7 @@ export const GapSchema = z.object({
   path: z.string(),
   severity: z.enum(['critical', 'high', 'medium', 'low']),
   reason: z.string(),
-  category: z.enum(['untested-route', 'a11y', 'console-error', 'broken-link', 'auth-surface', 'coverage']),
+  category: z.enum(['untested-route', 'a11y', 'console-error', 'broken-link', 'auth-surface', 'coverage', 'untested-api-endpoint']),
   description: z.string().optional(),
   recommendation: z.string().optional(),
 });

--- a/packages/core/src/tools/repo/__tests__/api-surface.test.ts
+++ b/packages/core/src/tools/repo/__tests__/api-surface.test.ts
@@ -1,0 +1,158 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { discoverApiSurface } from '../api-surface.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const FIXTURE_REPO = join(__dirname, '../../../__tests__/fixtures/api-fixture-repo');
+
+// ---------------------------------------------------------------------------
+// OpenAPI Tier1 discovery
+// ---------------------------------------------------------------------------
+
+test('Tier1: discovers endpoints from an OpenAPI YAML spec', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+
+  const openApiEndpoints = surface.endpoints.filter((e) => e.sourceTier === 'openapi');
+  assert.ok(openApiEndpoints.length > 0, 'expected at least one Tier1 endpoint');
+  assert.ok(surface.openApiSpecsFound >= 1, `expected openApiSpecsFound >= 1, got ${surface.openApiSpecsFound}`);
+});
+
+test('Tier1: all OpenAPI endpoints carry sourceFile pointing to the spec', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+
+  const openApiEndpoints = surface.endpoints.filter((e) => e.sourceTier === 'openapi');
+  for (const ep of openApiEndpoints) {
+    assert.ok(ep.sourceFile.endsWith('.yaml') || ep.sourceFile.endsWith('.json'),
+      `expected sourceFile to be a spec file, got: ${ep.sourceFile}`);
+  }
+});
+
+test('Tier1: OpenAPI endpoints have confidence "high"', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+
+  const openApiEndpoints = surface.endpoints.filter((e) => e.sourceTier === 'openapi');
+  for (const ep of openApiEndpoints) {
+    assert.equal(ep.confidence, 'high', `expected high confidence for Tier1 ep ${ep.path}`);
+  }
+});
+
+test('Tier1: summary is populated from OpenAPI spec operation', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+
+  const pingEndpoint = surface.endpoints.find((e) => e.path === '/api/ping' && e.sourceTier === 'openapi');
+  assert.ok(pingEndpoint, 'expected /api/ping from Tier1');
+  assert.ok(
+    typeof pingEndpoint!.summary === 'string' && pingEndpoint!.summary.length > 0,
+    `expected summary populated, got: ${JSON.stringify(pingEndpoint!.summary)}`
+  );
+  assert.equal(pingEndpoint!.summary, 'Health check');
+});
+
+test('Tier1: parameter names are extracted from OpenAPI spec (never fabricated)', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+
+  const pingEndpoint = surface.endpoints.find((e) => e.path === '/api/ping' && e.sourceTier === 'openapi');
+  assert.ok(pingEndpoint, 'expected /api/ping');
+  assert.deepEqual(pingEndpoint!.parameterNames, ['verbose']);
+});
+
+// ---------------------------------------------------------------------------
+// Next.js App Router Tier2 discovery
+// ---------------------------------------------------------------------------
+
+test('Tier2: discovers GET and POST from Next.js App Router route.ts exports', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+
+  const frameworkEndpoints = surface.endpoints.filter(
+    (e) => e.sourceTier === 'framework' && e.path === '/api/users'
+  );
+  const methods = frameworkEndpoints.map((e) => e.method);
+  // The fixture has GET and POST — but Tier1 (OpenAPI) deduplicates them to Tier1
+  // So check that at minimum GET or POST appears for /api/users (from either tier)
+  const usersEndpoints = surface.endpoints.filter((e) => e.path === '/api/users');
+  assert.ok(usersEndpoints.length >= 1, 'expected at least one endpoint for /api/users');
+  const usersGet = usersEndpoints.find((e) => e.method === 'GET');
+  assert.ok(usersGet, 'expected a GET /api/users endpoint');
+});
+
+test('Tier2: discovers DELETE from Next.js App Router route.ts (orders)', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+
+  const ordersDelete = surface.endpoints.find((e) => e.path === '/api/orders' && e.method === 'DELETE');
+  assert.ok(ordersDelete, 'expected DELETE /api/orders from Tier2');
+  assert.equal(ordersDelete!.sourceTier, 'framework');
+});
+
+test('Tier2: App Router endpoints carry high confidence', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+
+  const appRouterEndpoints = surface.endpoints.filter(
+    (e) => e.sourceTier === 'framework' && e.sourceFile.includes('app/')
+  );
+  for (const ep of appRouterEndpoints) {
+    assert.ok(
+      ep.confidence === 'high' || ep.confidence === 'medium',
+      `expected high or medium confidence, got ${ep.confidence} for ${ep.path}`
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Next.js Pages API Tier2 discovery
+// ---------------------------------------------------------------------------
+
+test('Tier2: discovers Pages API route with method from req.method check', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+
+  const healthEndpoint = surface.endpoints.find(
+    (e) => e.path === '/api/health' && e.method === 'GET'
+  );
+  assert.ok(healthEndpoint, 'expected GET /api/health from Pages API discovery');
+  assert.equal(healthEndpoint!.sourceTier, 'framework');
+  assert.ok(healthEndpoint!.sourceFile.includes('pages/api/'), `sourceFile should be in pages/api/, got: ${healthEndpoint!.sourceFile}`);
+});
+
+// ---------------------------------------------------------------------------
+// General surface properties
+// ---------------------------------------------------------------------------
+
+test('discoveredAt is a valid ISO date string', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+  const d = new Date(surface.discoveredAt);
+  assert.ok(!isNaN(d.getTime()), `discoveredAt should be a valid date, got: ${surface.discoveredAt}`);
+});
+
+test('all endpoints carry sourceFile and sourceTier', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+  for (const ep of surface.endpoints) {
+    assert.ok(typeof ep.sourceFile === 'string' && ep.sourceFile.length > 0,
+      `endpoint ${ep.method} ${ep.path} missing sourceFile`);
+    assert.ok(['openapi', 'framework', 'heuristic'].includes(ep.sourceTier),
+      `unexpected sourceTier: ${ep.sourceTier}`);
+  }
+});
+
+test('de-duplication: Tier1 beats Tier2 for the same method+path key', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+
+  // /api/users GET and POST exist in both openapi.yaml (Tier1) AND app/api/users/route.ts (Tier2)
+  // After dedup, sourceTier must be 'openapi' for those paths
+  const usersGet = surface.endpoints.find((e) => e.path === '/api/users' && e.method === 'GET');
+  assert.ok(usersGet, 'expected GET /api/users');
+  assert.equal(usersGet!.sourceTier, 'openapi', 'Tier1 should win deduplication for GET /api/users');
+});
+
+test('tier3 is disabled by default', async () => {
+  const surface = await discoverApiSurface(FIXTURE_REPO);
+  assert.equal(surface.tier3Enabled, false, 'tier3 should be false by default');
+  const heuristicEndpoints = surface.endpoints.filter((e) => e.sourceTier === 'heuristic');
+  assert.equal(heuristicEndpoints.length, 0, 'no heuristic endpoints when tier3 disabled');
+});
+
+test('empty repo path discovers no endpoints without erroring', async () => {
+  // Use a temp directory that is guaranteed to have no API files
+  const surface = await discoverApiSurface('/tmp');
+  assert.ok(Array.isArray(surface.endpoints), 'endpoints should be an array');
+});

--- a/packages/core/src/tools/repo/api-surface.ts
+++ b/packages/core/src/tools/repo/api-surface.ts
@@ -1,0 +1,519 @@
+/**
+ * @module tools/repo/api-surface
+ * @packageBoundary @qulib/core
+ *
+ * Evidence-only API surface discovery. Three tiers of confidence:
+ *   Tier1 — OpenAPI / Swagger spec files (YAML or JSON). Only reads `summary` and
+ *            `parameters` from a real spec; never fabricates endpoints.
+ *   Tier2 — Framework route files: Next.js App-Router `route.ts` exports,
+ *            Next.js Pages `pages/api/`, Express router calls from RepoAnalysis.routes,
+ *            Fastify `fastify.{method}`, Hono `app.{method}`, NestJS decorators.
+ *   Tier3 — Opt-in heuristics. Currently: tRPC router definition files.
+ *            Only activated when `options.enableTier3 === true`.
+ *
+ * Every endpoint carries:
+ *   sourceFile  — repo-relative file path that evidence was read from
+ *   sourceTier  — 'openapi' | 'framework' | 'heuristic'
+ *   confidence  — 'high' | 'medium' | 'low'
+ *
+ * NEVER invents endpoints or parameters. When a spec file cannot be parsed,
+ * or a file pattern does not clearly indicate a route, the file is skipped.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { relative, join, basename } from 'node:path';
+import glob from 'fast-glob';
+import type { RepoAnalysis } from '../../schemas/repo-analysis.schema.js';
+
+const IGNORE_PATTERNS = ['**/node_modules/**', '**/.next/**', '**/dist/**', '**/build/**'];
+
+function toPosix(p: string): string {
+  return p.split('\\').join('/');
+}
+
+function normalizeMethod(raw: string): DiscoveredEndpoint['method'] {
+  const upper = raw.toUpperCase();
+  if (upper === 'GET') return 'GET';
+  if (upper === 'POST') return 'POST';
+  if (upper === 'PUT') return 'PUT';
+  if (upper === 'DELETE') return 'DELETE';
+  if (upper === 'PATCH') return 'PATCH';
+  return 'unknown';
+}
+
+export interface DiscoveredEndpoint {
+  /** HTTP method inferred from the source — 'unknown' when ambiguous */
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'unknown';
+  /** Path as extracted from source — may contain framework-specific params like [id] or :id */
+  path: string;
+  /** Repo-relative file path the evidence was read from */
+  sourceFile: string;
+  /** Discovery tier */
+  sourceTier: 'openapi' | 'framework' | 'heuristic';
+  /** Evidence confidence */
+  confidence: 'high' | 'medium' | 'low';
+  /** Human-readable summary from spec, if available (Tier1 only) */
+  summary?: string;
+  /** Parameter names extracted from spec (Tier1 only; never fabricated) */
+  parameterNames?: string[];
+}
+
+export interface ApiSurface {
+  discoveredAt: string;
+  repoPath: string;
+  endpoints: DiscoveredEndpoint[];
+  /** Number of OpenAPI/Swagger spec files found and successfully parsed */
+  openApiSpecsFound: number;
+  /** Tier3 heuristics were enabled */
+  tier3Enabled: boolean;
+}
+
+export interface DiscoverApiSurfaceOptions {
+  /** Enable Tier3 heuristic discovery (default false — opt-in) */
+  enableTier3?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1 — OpenAPI / Swagger spec files
+// ---------------------------------------------------------------------------
+
+type OpenApiDocument = {
+  openapi?: string;
+  swagger?: string;
+  paths?: Record<string, Record<string, unknown>>;
+};
+
+type OpenApiOperation = {
+  summary?: string;
+  parameters?: Array<{ name?: string; in?: string }>;
+};
+
+function isOpenApiDocument(raw: unknown): raw is OpenApiDocument {
+  if (typeof raw !== 'object' || raw === null) return false;
+  const obj = raw as Record<string, unknown>;
+  return (
+    (typeof obj['openapi'] === 'string' || typeof obj['swagger'] === 'string') &&
+    typeof obj['paths'] === 'object'
+  );
+}
+
+async function discoverFromOpenApi(repoPath: string): Promise<{ endpoints: DiscoveredEndpoint[]; specsFound: number }> {
+  const endpoints: DiscoveredEndpoint[] = [];
+
+  const specFiles = await glob(
+    [
+      '**/openapi.yaml',
+      '**/openapi.yml',
+      '**/openapi.json',
+      '**/swagger.yaml',
+      '**/swagger.yml',
+      '**/swagger.json',
+      '**/api-docs.yaml',
+      '**/api-docs.json',
+    ],
+    { cwd: repoPath, onlyFiles: true, absolute: true, ignore: IGNORE_PATTERNS }
+  );
+
+  let specsFound = 0;
+
+  for (const file of specFiles) {
+    const rel = toPosix(relative(repoPath, file));
+
+    let raw: unknown;
+    try {
+      const content = await readFile(file, 'utf8');
+      if (file.endsWith('.json')) {
+        raw = JSON.parse(content) as unknown;
+      } else {
+        // Dynamic import of js-yaml to avoid bundling issues
+        const yaml = (await import('js-yaml')) as typeof import('js-yaml');
+        raw = yaml.load(content);
+      }
+    } catch {
+      // Skip unparseable files — never fabricate
+      continue;
+    }
+
+    if (!isOpenApiDocument(raw)) continue;
+
+    specsFound++;
+
+    const paths = raw.paths ?? {};
+    for (const [path, pathItem] of Object.entries(paths)) {
+      if (typeof pathItem !== 'object' || pathItem === null) continue;
+      const methods = ['get', 'post', 'put', 'delete', 'patch'] as const;
+      for (const method of methods) {
+        const operation = (pathItem as Record<string, unknown>)[method];
+        if (typeof operation !== 'object' || operation === null) continue;
+
+        const op = operation as OpenApiOperation;
+        const parameterNames = (op.parameters ?? [])
+          .filter((p): p is { name: string; in: string } => typeof p?.name === 'string')
+          .map((p) => p.name);
+
+        endpoints.push({
+          method: normalizeMethod(method),
+          path,
+          sourceFile: rel,
+          sourceTier: 'openapi',
+          confidence: 'high',
+          ...(typeof op.summary === 'string' && op.summary ? { summary: op.summary } : {}),
+          ...(parameterNames.length > 0 ? { parameterNames } : {}),
+        });
+      }
+    }
+  }
+
+  return { endpoints, specsFound };
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2 — Framework route files
+// ---------------------------------------------------------------------------
+
+async function discoverNextAppRouterEndpoints(repoPath: string): Promise<DiscoveredEndpoint[]> {
+  const endpoints: DiscoveredEndpoint[] = [];
+
+  const routeFiles = await glob(['app/**/route.ts', 'app/**/route.tsx', 'src/app/**/route.ts', 'src/app/**/route.tsx'], {
+    cwd: repoPath,
+    onlyFiles: true,
+    absolute: true,
+    ignore: IGNORE_PATTERNS,
+  });
+
+  for (const file of routeFiles) {
+    const rel = toPosix(relative(repoPath, file));
+    let content: string;
+    try {
+      content = await readFile(file, 'utf8');
+    } catch {
+      continue;
+    }
+
+    // Extract the route path from the file location
+    const routeSegment = rel
+      .replace(/^(src\/)?app\//, '')
+      .replace(/\/route\.tsx?$/, '');
+    // Normalize Next.js dynamic segments: [id] -> [id] (keep as-is, it's the real path)
+    const routePath = `/${routeSegment}`.replace(/\/+/g, '/').replace(/\/$/, '') || '/';
+
+    // Find exported HTTP method functions: export async function GET/POST/PUT/DELETE/PATCH
+    const methodExportRe = /export\s+(?:async\s+)?function\s+(GET|POST|PUT|DELETE|PATCH)\b/g;
+    let match: RegExpExecArray | null;
+    let foundAny = false;
+    while ((match = methodExportRe.exec(content)) !== null) {
+      foundAny = true;
+      endpoints.push({
+        method: normalizeMethod(match[1] ?? 'unknown'),
+        path: routePath,
+        sourceFile: rel,
+        sourceTier: 'framework',
+        confidence: 'high',
+      });
+    }
+
+    // If the file exists but has no recognized export, it's still a route — emit as unknown method
+    if (!foundAny) {
+      endpoints.push({
+        method: 'unknown',
+        path: routePath,
+        sourceFile: rel,
+        sourceTier: 'framework',
+        confidence: 'medium',
+      });
+    }
+  }
+
+  return endpoints;
+}
+
+async function discoverNextPagesApiEndpoints(repoPath: string): Promise<DiscoveredEndpoint[]> {
+  const endpoints: DiscoveredEndpoint[] = [];
+
+  const apiFiles = await glob(['pages/api/**/*.ts', 'pages/api/**/*.tsx', 'src/pages/api/**/*.ts'], {
+    cwd: repoPath,
+    onlyFiles: true,
+    absolute: true,
+    ignore: IGNORE_PATTERNS,
+  });
+
+  for (const file of apiFiles) {
+    const rel = toPosix(relative(repoPath, file));
+    const name = basename(rel);
+    if (name.startsWith('_')) continue;
+
+    const routeSegment = rel
+      .replace(/^(src\/)?pages\/api\//, '')
+      .replace(/\.tsx?$/, '');
+    const routePath = routeSegment === 'index'
+      ? '/api'
+      : `/api/${routeSegment.replace(/\/index$/, '')}`.replace(/\/+/g, '/');
+
+    let content: string;
+    try {
+      content = await readFile(file, 'utf8');
+    } catch {
+      continue;
+    }
+
+    // Pages API routes export a default handler that typically checks req.method internally.
+    // We can't know the HTTP methods without executing the code, so we emit 'unknown'.
+    // Look for explicit method checks like: req.method === 'POST'
+    const methodCheckRe = /req\.method\s*(?:===|==|!==|!=)\s*['"`](GET|POST|PUT|DELETE|PATCH)['"`]/g;
+    const methods = new Set<string>();
+    let match: RegExpExecArray | null;
+    while ((match = methodCheckRe.exec(content)) !== null) {
+      if (match[1]) methods.add(match[1]);
+    }
+
+    if (methods.size > 0) {
+      for (const method of methods) {
+        endpoints.push({
+          method: normalizeMethod(method),
+          path: routePath,
+          sourceFile: rel,
+          sourceTier: 'framework',
+          confidence: 'medium',
+        });
+      }
+    } else {
+      endpoints.push({
+        method: 'unknown',
+        path: routePath,
+        sourceFile: rel,
+        sourceTier: 'framework',
+        confidence: 'medium',
+      });
+    }
+  }
+
+  return endpoints;
+}
+
+function discoverExpressEndpoints(repo: RepoAnalysis): DiscoveredEndpoint[] {
+  // Re-use existing RepoAnalysis.routes which already extracted Express router calls.
+  // Filter to only include routes that came from src/ files (Express pattern).
+  return repo.routes
+    .filter((r) => r.method !== 'GET' || r.file.startsWith('src/'))
+    .map((r) => ({
+      method: normalizeMethod(r.method),
+      path: r.path,
+      sourceFile: r.file,
+      sourceTier: 'framework' as const,
+      confidence: 'medium' as const,
+    }));
+}
+
+async function discoverFastifyEndpoints(repoPath: string): Promise<DiscoveredEndpoint[]> {
+  const endpoints: DiscoveredEndpoint[] = [];
+
+  const files = await glob(['src/**/*.ts', 'src/**/*.js', 'routes/**/*.ts', 'routes/**/*.js'], {
+    cwd: repoPath,
+    onlyFiles: true,
+    absolute: true,
+    ignore: IGNORE_PATTERNS,
+  });
+
+  for (const file of files) {
+    const rel = toPosix(relative(repoPath, file));
+    let content: string;
+    try {
+      content = await readFile(file, 'utf8');
+    } catch {
+      continue;
+    }
+
+    // Fastify: fastify.get('/path', ...) or fastify.route({ method: 'GET', url: '/path' })
+    const fastifyCallRe = /(?:fastify|app|server)\.(get|post|put|delete|patch)\s*\(\s*['"`]([^'"`]+)['"`]/gi;
+    let match: RegExpExecArray | null;
+    while ((match = fastifyCallRe.exec(content)) !== null) {
+      const method = match[1];
+      const path = match[2];
+      if (method && path) {
+        endpoints.push({
+          method: normalizeMethod(method),
+          path: path.startsWith('/') ? path : `/${path}`,
+          sourceFile: rel,
+          sourceTier: 'framework',
+          confidence: 'medium',
+        });
+      }
+    }
+
+    // Hono: app.get('/path', ...) — same pattern, already covered above if variable is named app/server
+    // NestJS decorators: @Get('/path'), @Post('/path'), etc.
+    const nestDecoratorRe = /@(Get|Post|Put|Delete|Patch)\s*\(\s*['"`]([^'"`]*)['"`]\s*\)/g;
+    while ((match = nestDecoratorRe.exec(content)) !== null) {
+      const method = match[1];
+      const path = match[2];
+      if (method !== undefined && path !== undefined) {
+        endpoints.push({
+          method: normalizeMethod(method),
+          path: path === '' ? '/' : (path.startsWith('/') ? path : `/${path}`),
+          sourceFile: rel,
+          sourceTier: 'framework',
+          confidence: 'medium',
+        });
+      }
+    }
+  }
+
+  return endpoints;
+}
+
+// ---------------------------------------------------------------------------
+// Tier 3 — Heuristic (opt-in): tRPC
+// ---------------------------------------------------------------------------
+
+async function discoverTrpcEndpoints(repoPath: string): Promise<DiscoveredEndpoint[]> {
+  const endpoints: DiscoveredEndpoint[] = [];
+
+  const trpcFiles = await glob(
+    ['src/**/*.ts', 'server/**/*.ts', 'lib/**/*.ts', 'app/**/*.ts'],
+    {
+      cwd: repoPath,
+      onlyFiles: true,
+      absolute: true,
+      ignore: IGNORE_PATTERNS,
+    }
+  );
+
+  for (const file of trpcFiles) {
+    const rel = toPosix(relative(repoPath, file));
+    let content: string;
+    try {
+      content = await readFile(file, 'utf8');
+    } catch {
+      continue;
+    }
+
+    // Only look at files that import from @trpc
+    if (!content.includes('@trpc/server') && !content.includes('@trpc/next')) continue;
+
+    // tRPC procedure definitions: .query({ ... }) or .mutation({ ... })
+    // These aren't HTTP routes in the traditional sense, but procedure names are the "paths"
+    const queryRe = /(\w+)\s*:\s*(?:publicProcedure|protectedProcedure|procedure)\s*\.(?:input\([^)]*\)\s*\.)?query\s*\(/g;
+    const mutationRe = /(\w+)\s*:\s*(?:publicProcedure|protectedProcedure|procedure)\s*\.(?:input\([^)]*\)\s*\.)?mutation\s*\(/g;
+
+    let match: RegExpExecArray | null;
+    while ((match = queryRe.exec(content)) !== null) {
+      const name = match[1];
+      if (name) {
+        endpoints.push({
+          method: 'GET',
+          path: `/trpc/${name}`,
+          sourceFile: rel,
+          sourceTier: 'heuristic',
+          confidence: 'low',
+          summary: `tRPC query: ${name}`,
+        });
+      }
+    }
+    while ((match = mutationRe.exec(content)) !== null) {
+      const name = match[1];
+      if (name) {
+        endpoints.push({
+          method: 'POST',
+          path: `/trpc/${name}`,
+          sourceFile: rel,
+          sourceTier: 'heuristic',
+          confidence: 'low',
+          summary: `tRPC mutation: ${name}`,
+        });
+      }
+    }
+  }
+
+  return endpoints;
+}
+
+// ---------------------------------------------------------------------------
+// De-duplication
+// ---------------------------------------------------------------------------
+
+function deduplicateEndpoints(endpoints: DiscoveredEndpoint[]): DiscoveredEndpoint[] {
+  // Higher tier = higher priority; within a tier, first seen wins
+  const tierRank = { openapi: 0, framework: 1, heuristic: 2 };
+  const seen = new Map<string, DiscoveredEndpoint>();
+
+  for (const ep of endpoints) {
+    const key = `${ep.method}:${ep.path}`;
+    const existing = seen.get(key);
+    if (!existing) {
+      seen.set(key, ep);
+    } else {
+      // Keep the one with higher tier rank (lower number = better)
+      const existingRank = tierRank[existing.sourceTier];
+      const newRank = tierRank[ep.sourceTier];
+      if (newRank < existingRank) {
+        seen.set(key, ep);
+      }
+    }
+  }
+
+  return [...seen.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+export async function discoverApiSurface(
+  repoPath: string,
+  options: DiscoverApiSurfaceOptions = {}
+): Promise<ApiSurface> {
+  const tier3Enabled = options.enableTier3 === true;
+
+  // Run tiers in parallel for speed
+  const [
+    tier1Result,
+    nextAppEndpoints,
+    nextPagesEndpoints,
+    fastifyEndpoints,
+  ] = await Promise.all([
+    discoverFromOpenApi(repoPath),
+    discoverNextAppRouterEndpoints(repoPath),
+    discoverNextPagesApiEndpoints(repoPath),
+    discoverFastifyEndpoints(repoPath),
+  ]);
+
+  // Express uses existing RepoAnalysis — callers may pass a pre-scanned repo via a
+  // separate helper. Here we expose the raw discovery functions; the integration
+  // layer in computeApiCoverage passes the repo. For standalone usage we return
+  // only file-based discoveries.
+  const tier1 = tier1Result.endpoints;
+  const tier2 = [...nextAppEndpoints, ...nextPagesEndpoints, ...fastifyEndpoints];
+
+  const tier3: DiscoveredEndpoint[] = tier3Enabled
+    ? await discoverTrpcEndpoints(repoPath)
+    : [];
+
+  const allEndpoints = deduplicateEndpoints([...tier1, ...tier2, ...tier3]);
+
+  return {
+    discoveredAt: new Date().toISOString(),
+    repoPath,
+    endpoints: allEndpoints,
+    openApiSpecsFound: tier1Result.specsFound,
+    tier3Enabled,
+  };
+}
+
+/**
+ * Variant that also incorporates RepoAnalysis.routes (Express routes already
+ * extracted by scanRepo). Use this when you already have a RepoAnalysis to avoid
+ * double-reading files.
+ */
+export async function discoverApiSurfaceWithRepo(
+  repoPath: string,
+  repo: RepoAnalysis,
+  options: DiscoverApiSurfaceOptions = {}
+): Promise<ApiSurface> {
+  const base = await discoverApiSurface(repoPath, options);
+  const expressEndpoints = discoverExpressEndpoints(repo);
+
+  return {
+    ...base,
+    endpoints: deduplicateEndpoints([...base.endpoints, ...expressEndpoints]),
+  };
+}

--- a/packages/core/src/tools/scoring/__tests__/api-coverage.test.ts
+++ b/packages/core/src/tools/scoring/__tests__/api-coverage.test.ts
@@ -1,0 +1,226 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeApiCoverage, REBALANCED_WEIGHTS, W_API_COVERAGE } from '../api-coverage.js';
+import type { RepoAnalysis } from '../../../schemas/repo-analysis.schema.js';
+import type { ApiSurface, DiscoveredEndpoint } from '../../repo/api-surface.js';
+
+function baseRepo(overrides: Partial<RepoAnalysis> = {}): RepoAnalysis {
+  return {
+    scannedAt: new Date().toISOString(),
+    repoPath: '/tmp/fake-repo',
+    routes: [],
+    testFiles: [],
+    missingTestIds: [],
+    interactiveTsxFilesScanned: 0,
+    cypressStructure: {
+      detected: false,
+      hasCommandsFile: false,
+      existingE2eFiles: [],
+      existingComponentFiles: [],
+    },
+    ...overrides,
+  };
+}
+
+function baseSurface(endpoints: DiscoveredEndpoint[], overrides: Partial<ApiSurface> = {}): ApiSurface {
+  return {
+    discoveredAt: new Date().toISOString(),
+    repoPath: '/tmp/fake-repo',
+    endpoints,
+    openApiSpecsFound: 0,
+    tier3Enabled: false,
+    ...overrides,
+  };
+}
+
+function ep(
+  method: DiscoveredEndpoint['method'],
+  path: string,
+  sourceFile = 'app/api/test/route.ts',
+  tier: DiscoveredEndpoint['sourceTier'] = 'framework'
+): DiscoveredEndpoint {
+  return { method, path, sourceFile, sourceTier: tier, confidence: 'high' };
+}
+
+// ---------------------------------------------------------------------------
+// Not-applicable: no endpoints
+// ---------------------------------------------------------------------------
+
+test('api-test-coverage is not_applicable when no endpoints discovered', () => {
+  const result = computeApiCoverage(baseRepo(), baseSurface([]));
+  const dim = result.dimension;
+  assert.equal(dim.dimension, 'api-test-coverage');
+  assert.equal(dim.applicability, 'not_applicable');
+  assert.equal(dim.score, 0);
+  assert.ok(typeof dim.reason === 'string' && dim.reason.length > 0, 'reason must be set');
+  assert.ok(typeof dim.guidance === 'string' && dim.guidance.length > 0, 'guidance must be set');
+  assert.equal(result.endpointCoverage.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Score computation
+// ---------------------------------------------------------------------------
+
+test('score is 100 when all endpoints are covered', () => {
+  const repo = baseRepo({
+    testFiles: [
+      { file: 'tests/users.test.ts', type: 'vitest', coveredPaths: ['/api/users'] },
+    ],
+  });
+  const surface = baseSurface([ep('GET', '/api/users')]);
+  const result = computeApiCoverage(repo, surface);
+  assert.equal(result.dimension.score, 100);
+  assert.equal(result.untestedHighSeverityCount, 0);
+  assert.equal(result.untestedMediumSeverityCount, 0);
+});
+
+test('score is 0 when no endpoints are covered', () => {
+  const repo = baseRepo({ testFiles: [] });
+  const surface = baseSurface([ep('POST', '/api/orders'), ep('DELETE', '/api/orders')]);
+  const result = computeApiCoverage(repo, surface);
+  assert.equal(result.dimension.score, 0);
+  assert.equal(result.untestedHighSeverityCount, 2, 'POST and DELETE are high severity');
+  assert.equal(result.untestedMediumSeverityCount, 0);
+});
+
+test('score is proportional: 1 of 2 covered = 50', () => {
+  const repo = baseRepo({
+    testFiles: [
+      // users.test.ts covers /api/users (GET), but billing has no test
+      { file: 'tests/users.test.ts', type: 'vitest', coveredPaths: ['/api/users'] },
+    ],
+  });
+  const surface = baseSurface([ep('GET', '/api/users'), ep('DELETE', '/api/billing')]);
+  const result = computeApiCoverage(repo, surface);
+  assert.equal(result.dimension.score, 50);
+  assert.equal(result.untestedHighSeverityCount, 1, 'DELETE /api/billing is high severity');
+});
+
+// ---------------------------------------------------------------------------
+// Coverage matching
+// ---------------------------------------------------------------------------
+
+test('direct coveredPath match covers an endpoint', () => {
+  const repo = baseRepo({
+    testFiles: [{ file: 'tests/ping.test.ts', type: 'vitest', coveredPaths: ['/api/ping'] }],
+  });
+  const surface = baseSurface([ep('GET', '/api/ping')]);
+  const result = computeApiCoverage(repo, surface);
+  assert.equal(result.endpointCoverage[0]?.covered, true);
+  assert.equal(result.endpointCoverage[0]?.coveringTestFile, 'tests/ping.test.ts');
+});
+
+test('heuristic: test filename token match covers endpoint', () => {
+  const repo = baseRepo({
+    testFiles: [{ file: 'tests/orders.test.ts', type: 'vitest', coveredPaths: [] }],
+  });
+  const surface = baseSurface([ep('POST', '/api/orders')]);
+  const result = computeApiCoverage(repo, surface);
+  assert.equal(result.endpointCoverage[0]?.covered, true,
+    'filename token "orders" should match /api/orders');
+});
+
+test('endpoint is NOT covered when no coveredPaths or filename match', () => {
+  const repo = baseRepo({
+    testFiles: [{ file: 'tests/auth.test.ts', type: 'vitest', coveredPaths: ['/login'] }],
+  });
+  const surface = baseSurface([ep('DELETE', '/api/billing')]);
+  const result = computeApiCoverage(repo, surface);
+  assert.equal(result.endpointCoverage[0]?.covered, false);
+  assert.equal(result.untestedHighSeverityCount, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Severity classification
+// ---------------------------------------------------------------------------
+
+test('POST/PUT/DELETE/PATCH endpoints are high severity', () => {
+  const surface = baseSurface([
+    ep('POST', '/api/x'),
+    ep('PUT', '/api/x'),
+    ep('DELETE', '/api/x'),
+    ep('PATCH', '/api/x'),
+  ]);
+  const result = computeApiCoverage(baseRepo(), surface);
+  for (const cov of result.endpointCoverage) {
+    assert.equal(cov.severity, 'high', `expected high for ${cov.method}`);
+  }
+});
+
+test('GET endpoints are medium severity', () => {
+  const surface = baseSurface([ep('GET', '/api/users')]);
+  const result = computeApiCoverage(baseRepo(), surface);
+  assert.equal(result.endpointCoverage[0]?.severity, 'medium');
+});
+
+// ---------------------------------------------------------------------------
+// Evidence and recommendations
+// ---------------------------------------------------------------------------
+
+test('evidence lists per-endpoint coverage status', () => {
+  const repo = baseRepo({
+    testFiles: [{ file: 'tests/users.test.ts', type: 'vitest', coveredPaths: ['/api/users'] }],
+  });
+  const surface = baseSurface([ep('GET', '/api/users'), ep('POST', '/api/orders')]);
+  const result = computeApiCoverage(repo, surface);
+  const evText = result.dimension.evidence.join(' ');
+  assert.ok(evText.includes('/api/users'), 'evidence should mention /api/users');
+  assert.ok(evText.includes('/api/orders'), 'evidence should mention /api/orders');
+});
+
+test('OpenAPI spec note appears in evidence when specs are found', () => {
+  const surface = baseSurface([ep('GET', '/api/ping', 'openapi.yaml', 'openapi')], {
+    openApiSpecsFound: 1,
+  });
+  const result = computeApiCoverage(baseRepo(), surface);
+  const evText = result.dimension.evidence[0] ?? '';
+  assert.ok(evText.includes('OpenAPI'), `expected "OpenAPI" in evidence[0], got: ${evText}`);
+});
+
+test('recommendations list untested high-severity endpoints', () => {
+  const surface = baseSurface([ep('DELETE', '/api/users')]);
+  const result = computeApiCoverage(baseRepo(), surface);
+  assert.ok(result.dimension.recommendations.length > 0, 'should have recommendations');
+  assert.ok(
+    result.dimension.recommendations[0]?.includes('supertest') ||
+    result.dimension.recommendations[0]?.includes('POST/PUT/DELETE'),
+    `expected recommendation to mention mutation methods, got: ${result.dimension.recommendations[0]}`
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Weight constants
+// ---------------------------------------------------------------------------
+
+test('W_API_COVERAGE is 0.15', () => {
+  assert.equal(W_API_COVERAGE, 0.15);
+});
+
+test('REBALANCED_WEIGHTS sum to 0.85 (leaving room for api-test-coverage 0.15)', () => {
+  const sum = Object.values(REBALANCED_WEIGHTS).reduce((a, b) => a + b, 0);
+  assert.ok(
+    Math.abs(sum - 0.85) < 0.001,
+    `REBALANCED_WEIGHTS should sum to 0.85, got ${sum}`
+  );
+});
+
+test('all 7 weights sum to 1.0 when combined', () => {
+  const combinedSum = Object.values(REBALANCED_WEIGHTS).reduce((a, b) => a + b, 0) + W_API_COVERAGE;
+  assert.ok(
+    Math.abs(combinedSum - 1.0) < 0.001,
+    `All 7 dimension weights should sum to 1.0, got ${combinedSum}`
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Dimension shape
+// ---------------------------------------------------------------------------
+
+test('dimension result carries the required schema fields', () => {
+  const surface = baseSurface([ep('GET', '/api/test')]);
+  const result = computeApiCoverage(baseRepo(), surface);
+  assert.equal(result.dimension.dimension, 'api-test-coverage');
+  assert.equal(result.dimension.weight, 0.15);
+  assert.ok(Array.isArray(result.dimension.evidence));
+  assert.ok(Array.isArray(result.dimension.recommendations));
+});

--- a/packages/core/src/tools/scoring/__tests__/automation-maturity-with-api.test.ts
+++ b/packages/core/src/tools/scoring/__tests__/automation-maturity-with-api.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for computeAutomationMaturity when apiCoverageResult is provided (D4 backward-compat
+ * and the new 7-dimension path).
+ *
+ * The existing automation-maturity.test.ts covers the 6-dimension (no API surface) path
+ * and must remain GREEN — these tests cover the additive case.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { RepoAnalysis } from '../../../schemas/repo-analysis.schema.js';
+import { computeAutomationMaturity } from '../automation-maturity.js';
+import { computeApiCoverage, REBALANCED_WEIGHTS, W_API_COVERAGE } from '../api-coverage.js';
+import type { ApiSurface, DiscoveredEndpoint } from '../../repo/api-surface.js';
+
+function baseRepo(overrides: Partial<RepoAnalysis> = {}): RepoAnalysis {
+  return {
+    scannedAt: new Date().toISOString(),
+    repoPath: '/tmp/fake-repo',
+    routes: [],
+    testFiles: [],
+    missingTestIds: [],
+    interactiveTsxFilesScanned: 0,
+    cypressStructure: {
+      detected: false,
+      hasCommandsFile: false,
+      existingE2eFiles: [],
+      existingComponentFiles: [],
+    },
+    ...overrides,
+  };
+}
+
+function baseSurface(endpoints: DiscoveredEndpoint[]): ApiSurface {
+  return {
+    discoveredAt: new Date().toISOString(),
+    repoPath: '/tmp/fake-repo',
+    endpoints,
+    openApiSpecsFound: 0,
+    tier3Enabled: false,
+  };
+}
+
+function ep(method: DiscoveredEndpoint['method'], path: string): DiscoveredEndpoint {
+  return { method, path, sourceFile: 'app/api/test/route.ts', sourceTier: 'framework', confidence: 'high' };
+}
+
+// ---------------------------------------------------------------------------
+// Backward-compat: no apiCoverageResult → original 6 dimensions, original weights
+// ---------------------------------------------------------------------------
+
+test('backward-compat: 6 dimensions when apiCoverageResult is absent', () => {
+  const maturity = computeAutomationMaturity(baseRepo());
+  assert.equal(maturity.dimensions.length, 6, 'should have exactly 6 dimensions');
+});
+
+test('backward-compat: original weights used (test-coverage-breadth = 0.28)', () => {
+  const maturity = computeAutomationMaturity(baseRepo());
+  const dim = maturity.dimensions.find((d) => d.dimension === 'test-coverage-breadth');
+  assert.ok(dim, 'test-coverage-breadth must be present');
+  assert.equal(dim!.weight, 0.28, 'original weight should be 0.28');
+});
+
+test('backward-compat: existing tests pass without apiCoverageResult (regression guard)', () => {
+  const maturity = computeAutomationMaturity(
+    baseRepo({
+      testFiles: [{ file: 'tests/home.spec.ts', type: 'playwright', coveredPaths: ['/login'] }],
+      routes: [{ path: '/login', file: 'app/login/page.tsx', method: 'GET' }],
+    })
+  );
+  // Should produce valid maturity without throwing
+  assert.ok(maturity.overallScore >= 0 && maturity.overallScore <= 100);
+  assert.ok(maturity.level >= 1 && maturity.level <= 5);
+});
+
+// ---------------------------------------------------------------------------
+// New 7-dimension path
+// ---------------------------------------------------------------------------
+
+test('7 dimensions when apiCoverageResult is provided', () => {
+  const surface = baseSurface([ep('GET', '/api/users')]);
+  const apiResult = computeApiCoverage(baseRepo(), surface);
+  const maturity = computeAutomationMaturity(baseRepo(), apiResult);
+  assert.equal(maturity.dimensions.length, 7, 'should have 7 dimensions with api surface');
+});
+
+test('api-test-coverage dimension is present in the 7-dimension result', () => {
+  const surface = baseSurface([ep('POST', '/api/orders')]);
+  const apiResult = computeApiCoverage(baseRepo(), surface);
+  const maturity = computeAutomationMaturity(baseRepo(), apiResult);
+  const dim = maturity.dimensions.find((d) => d.dimension === 'api-test-coverage');
+  assert.ok(dim, 'api-test-coverage dimension must be present');
+  assert.equal(dim!.weight, W_API_COVERAGE);
+});
+
+test('rebalanced weights are used for existing 6 dimensions when API surface provided', () => {
+  const surface = baseSurface([ep('GET', '/api/ping')]);
+  const apiResult = computeApiCoverage(baseRepo(), surface);
+  const maturity = computeAutomationMaturity(baseRepo(), apiResult);
+
+  const breadth = maturity.dimensions.find((d) => d.dimension === 'test-coverage-breadth');
+  assert.ok(breadth, 'test-coverage-breadth must be present');
+  assert.equal(breadth!.weight, REBALANCED_WEIGHTS.TEST_BREADTH, `expected ${REBALANCED_WEIGHTS.TEST_BREADTH}, got ${breadth!.weight}`);
+
+  const framework = maturity.dimensions.find((d) => d.dimension === 'framework-adoption');
+  assert.equal(framework!.weight, REBALANCED_WEIGHTS.FRAMEWORK);
+});
+
+test('overall score is still normalized over applicable dimensions only (7-dim path)', () => {
+  // All 6 original N/A dims + api-test-coverage = not_applicable (no endpoints)
+  const surface = baseSurface([]);
+  const apiResult = computeApiCoverage(baseRepo(), surface);
+  const maturity = computeAutomationMaturity(baseRepo(), apiResult);
+
+  const apiDim = maturity.dimensions.find((d) => d.dimension === 'api-test-coverage');
+  assert.equal(apiDim!.applicability, 'not_applicable',
+    'api-test-coverage should be not_applicable when no endpoints');
+
+  // overallScore should still be computed correctly
+  assert.ok(maturity.overallScore >= 0 && maturity.overallScore <= 100);
+});
+
+test('7-dimension overall score reflects api coverage when endpoints exist and are covered', () => {
+  const repo = baseRepo({
+    testFiles: [{ file: 'tests/api.test.ts', type: 'vitest', coveredPaths: ['/api/users'] }],
+  });
+  const surface = baseSurface([ep('GET', '/api/users')]);
+  const apiResult = computeApiCoverage(repo, surface);
+  const maturity = computeAutomationMaturity(repo, apiResult);
+
+  const apiDim = maturity.dimensions.find((d) => d.dimension === 'api-test-coverage');
+  assert.ok(apiDim, 'api-test-coverage dim must be present');
+  assert.equal(apiDim!.applicability ?? 'applicable', 'applicable');
+  assert.equal(apiDim!.score, 100, 'fully covered API endpoint should score 100');
+
+  // overallScore should not be 0
+  assert.ok(maturity.overallScore > 0, 'overall should be > 0 with covered API endpoint');
+});
+
+test('topRecommendations includes api-coverage recommendation when endpoints untested', () => {
+  const surface = baseSurface([ep('DELETE', '/api/orders')]);
+  const apiResult = computeApiCoverage(baseRepo(), surface);
+  const maturity = computeAutomationMaturity(baseRepo(), apiResult);
+
+  const hasApiRec = maturity.topRecommendations.some(
+    (r) => r.includes('supertest') || r.includes('POST/PUT/DELETE') || r.includes('API')
+  );
+  // Only assert if the api dim is applicable (it will be, we have an endpoint)
+  const apiDim = maturity.dimensions.find((d) => d.dimension === 'api-test-coverage');
+  if (apiDim?.applicability === 'applicable') {
+    assert.ok(hasApiRec, `expected API coverage recommendation, got: ${JSON.stringify(maturity.topRecommendations)}`);
+  }
+});

--- a/packages/core/src/tools/scoring/api-coverage.ts
+++ b/packages/core/src/tools/scoring/api-coverage.ts
@@ -1,0 +1,208 @@
+/**
+ * @module tools/scoring/api-coverage
+ *
+ * Computes the `api-test-coverage` dimension for the automation maturity score.
+ *
+ * Weight: 0.15. The six existing dimensions have been rebalanced to sum to 1.0:
+ *
+ *   Before (sum = 1.0):
+ *     test-coverage-breadth   0.28
+ *     framework-adoption      0.22
+ *     test-id-hygiene         0.18
+ *     ci-integration          0.14
+ *     auth-test-coverage      0.10
+ *     component-test-ratio    0.08
+ *                             ────
+ *                             1.00
+ *
+ *   After (sum = 1.0, api-test-coverage added at 0.15):
+ *     test-coverage-breadth   0.24   (-0.04)
+ *     framework-adoption      0.19   (-0.03)
+ *     test-id-hygiene         0.15   (-0.03)
+ *     ci-integration          0.12   (-0.02)
+ *     auth-test-coverage      0.09   (-0.01)
+ *     component-test-ratio    0.06   (-0.02)
+ *     api-test-coverage       0.15   (new)
+ *                             ────
+ *                             1.00
+ *
+ * Scoring rules:
+ *   - If 0 API endpoints discovered → applicability = 'not_applicable' (excluded from denominator)
+ *   - A test file "covers" an endpoint if:
+ *       (a) the endpoint path appears verbatim in the file's coveredPaths, OR
+ *       (b) the file name contains a token from the endpoint path (heuristic fallback)
+ *   - Each endpoint that is covered raises the score proportionally.
+ *   - POST/PUT/DELETE endpoints are HIGH severity gaps when untested;
+ *     GET endpoints are MEDIUM severity gaps when untested.
+ *
+ * Evidence is per-endpoint and contextual:
+ *   "GET /api/users — found in app/api/users/route.ts, covered by tests/api/users.test.ts"
+ *   "POST /api/orders — found in app/api/orders/route.ts, NOT covered"
+ */
+
+import type { RepoAnalysis } from '../../schemas/repo-analysis.schema.js';
+import type {
+  AutomationMaturityDimension,
+  AutomationMaturityApplicability,
+} from '../../schemas/automation-maturity.schema.js';
+import type { ApiSurface, DiscoveredEndpoint } from '../repo/api-surface.js';
+
+export const W_API_COVERAGE = 0.15;
+
+/**
+ * Rebalanced weights for the original 6 dimensions (sum = 0.85).
+ * Export these so automation-maturity.ts can import and use them.
+ */
+export const REBALANCED_WEIGHTS = {
+  TEST_BREADTH: 0.24,
+  FRAMEWORK: 0.19,
+  TEST_ID: 0.15,
+  CI: 0.12,
+  AUTH_TESTS: 0.09,
+  COMPONENT_RATIO: 0.06,
+} as const;
+
+export interface ApiEndpointCoverage {
+  method: DiscoveredEndpoint['method'];
+  path: string;
+  sourceFile: string;
+  sourceTier: DiscoveredEndpoint['sourceTier'];
+  covered: boolean;
+  coveringTestFile?: string;
+  severity: 'high' | 'medium' | 'low';
+}
+
+export interface ApiCoverageResult {
+  dimension: AutomationMaturityDimension;
+  endpointCoverage: ApiEndpointCoverage[];
+  untestedHighSeverityCount: number;
+  untestedMediumSeverityCount: number;
+}
+
+/**
+ * Returns true if testCoveredPaths or test filename hints that it covers endpointPath.
+ */
+function endpointIsCovered(
+  endpoint: DiscoveredEndpoint,
+  testFile: RepoAnalysis['testFiles'][number]
+): boolean {
+  const ep = endpoint.path.toLowerCase();
+
+  // (a) Exact or prefix match in coveredPaths
+  const directCover = testFile.coveredPaths.some((cp) => {
+    const norm = cp.toLowerCase();
+    return norm === ep || (ep !== '/' && ep.startsWith(norm) && (norm === ep || ep[norm.length] === '/'));
+  });
+  if (directCover) return true;
+
+  // (b) Heuristic: test filename tokens match endpoint path segments
+  const testFileName = testFile.file.toLowerCase();
+  const segments = ep.split('/').filter((s) => s.length > 2 && !/^\[/.test(s));
+  if (segments.length === 0) return false;
+  return segments.some((seg) => testFileName.includes(seg));
+}
+
+function classifySeverity(method: DiscoveredEndpoint['method']): ApiEndpointCoverage['severity'] {
+  if (method === 'POST' || method === 'PUT' || method === 'DELETE') return 'high';
+  if (method === 'PATCH') return 'high';
+  return 'medium';
+}
+
+export function computeApiCoverage(
+  repo: RepoAnalysis,
+  apiSurface: ApiSurface
+): ApiCoverageResult {
+  const endpoints = apiSurface.endpoints;
+
+  // Not applicable when there are no API endpoints
+  if (endpoints.length === 0) {
+    const dim: AutomationMaturityDimension = {
+      dimension: 'api-test-coverage',
+      score: 0,
+      weight: W_API_COVERAGE,
+      evidence: ['No API endpoints discovered — api-test-coverage dimension does not apply.'],
+      recommendations: [],
+      applicability: 'not_applicable' as AutomationMaturityApplicability,
+      reason: 'No API endpoints discovered — api-test-coverage dimension does not apply.',
+      guidance:
+        'No API endpoints were found. If this repo has REST endpoints, ensure they are declared in a supported framework (Next.js route.ts, Express, Fastify, NestJS) or an OpenAPI spec file.',
+    };
+    return { dimension: dim, endpointCoverage: [], untestedHighSeverityCount: 0, untestedMediumSeverityCount: 0 };
+  }
+
+  const endpointCoverage: ApiEndpointCoverage[] = [];
+  let coveredCount = 0;
+  let untestedHighSeverityCount = 0;
+  let untestedMediumSeverityCount = 0;
+  const evidence: string[] = [];
+
+  for (const ep of endpoints) {
+    const severity = classifySeverity(ep.method);
+
+    // Find the first test file that covers this endpoint
+    let coveringTestFile: string | undefined;
+    for (const tf of repo.testFiles) {
+      if (endpointIsCovered(ep, tf)) {
+        coveringTestFile = tf.file;
+        break;
+      }
+    }
+
+    const covered = coveringTestFile !== undefined;
+    if (covered) {
+      coveredCount++;
+      evidence.push(
+        `${ep.method} ${ep.path} — found in ${ep.sourceFile}, covered by ${coveringTestFile}`
+      );
+    } else {
+      if (severity === 'high') untestedHighSeverityCount++;
+      else untestedMediumSeverityCount++;
+      evidence.push(
+        `${ep.method} ${ep.path} — found in ${ep.sourceFile}, NOT covered`
+      );
+    }
+
+    endpointCoverage.push({
+      method: ep.method,
+      path: ep.path,
+      sourceFile: ep.sourceFile,
+      sourceTier: ep.sourceTier,
+      covered,
+      ...(coveringTestFile !== undefined ? { coveringTestFile } : {}),
+      severity,
+    });
+  }
+
+  const score = Math.round((100 * coveredCount) / endpoints.length);
+
+  const recommendations: string[] = [];
+  if (untestedHighSeverityCount > 0) {
+    recommendations.push(
+      `${untestedHighSeverityCount} high-severity API endpoint(s) (POST/PUT/DELETE/PATCH) have no test coverage — add supertest or API-level tests.`
+    );
+  }
+  if (untestedMediumSeverityCount > 0) {
+    recommendations.push(
+      `${untestedMediumSeverityCount} GET endpoint(s) have no test coverage — add route smoke tests.`
+    );
+  }
+
+  const specNote = apiSurface.openApiSpecsFound > 0
+    ? ` (${apiSurface.openApiSpecsFound} OpenAPI spec(s) parsed — Tier1 high-confidence)`
+    : '';
+
+  const dim: AutomationMaturityDimension = {
+    dimension: 'api-test-coverage',
+    score,
+    weight: W_API_COVERAGE,
+    evidence: [
+      `${coveredCount}/${endpoints.length} API endpoints appear covered by test files${specNote}.`,
+      ...evidence.slice(0, 10),
+      ...(evidence.length > 10 ? [`… and ${evidence.length - 10} more endpoint(s)`] : []),
+    ],
+    recommendations,
+    applicability: 'applicable',
+  };
+
+  return { dimension: dim, endpointCoverage, untestedHighSeverityCount, untestedMediumSeverityCount };
+}

--- a/packages/core/src/tools/scoring/automation-maturity.ts
+++ b/packages/core/src/tools/scoring/automation-maturity.ts
@@ -7,17 +7,30 @@ import type {
   AutomationMaturityDimension,
 } from '../../schemas/automation-maturity.schema.js';
 import { AutomationMaturitySchema } from '../../schemas/automation-maturity.schema.js';
+import { REBALANCED_WEIGHTS, type ApiCoverageResult } from './api-coverage.js';
 
 /**
- * Dimension weights (sum = 1). Breadth + harness adoption dominate: shipping risk is mostly
- * untested routes and missing Playwright/Cypress-level coverage.
+ * Dimension weights (sum = 1).
+ *
+ * When apiSurface is NOT provided (backward-compat path), the original 6 dimensions
+ * continue to use the original weights (sum = 1.0). When apiSurface IS provided, the
+ * rebalanced weights from api-coverage.ts are used and the 7th dimension is added.
+ *
+ * Original weights (no API surface):
+ *   test-coverage-breadth  0.28, framework-adoption 0.22, test-id-hygiene 0.18,
+ *   ci-integration 0.14, auth-test-coverage 0.10, component-test-ratio 0.08
+ *
+ * Rebalanced weights (with API surface, sum still = 1.0 across all 7):
+ *   test-coverage-breadth  0.24, framework-adoption 0.19, test-id-hygiene 0.15,
+ *   ci-integration 0.12, auth-test-coverage 0.09, component-test-ratio 0.06,
+ *   api-test-coverage 0.15
  */
-const W_TEST_BREADTH = 0.28;
-const W_FRAMEWORK = 0.22;
-const W_TEST_ID = 0.18;
-const W_CI = 0.14;
-const W_AUTH_TESTS = 0.1;
-const W_COMPONENT_RATIO = 0.08;
+const W_TEST_BREADTH_ORIGINAL = 0.28;
+const W_FRAMEWORK_ORIGINAL = 0.22;
+const W_TEST_ID_ORIGINAL = 0.18;
+const W_CI_ORIGINAL = 0.14;
+const W_AUTH_TESTS_ORIGINAL = 0.1;
+const W_COMPONENT_RATIO_ORIGINAL = 0.08;
 
 function hasCiAtRoot(repoPath: string): { ok: boolean; evidence: string[] } {
   const ev: string[] = [];
@@ -54,7 +67,28 @@ function scoreLevel(overall: number): { level: number; label: string } {
   return { level: 5, label: 'L5 — advanced QA automation' };
 }
 
-export function computeAutomationMaturity(repo: RepoAnalysis): AutomationMaturity {
+/**
+ * Compute automation maturity for a repo.
+ *
+ * @param repo - The scanned repo analysis.
+ * @param apiCoverageResult - Optional pre-computed API coverage result. When absent the
+ *   6 original dimensions are scored with the original weights (backward-compatible).
+ *   When provided, a 7th dimension (`api-test-coverage`) is added and weights are
+ *   rebalanced so the total still sums to 1.0 across applicable dimensions.
+ */
+export function computeAutomationMaturity(
+  repo: RepoAnalysis,
+  apiCoverageResult?: ApiCoverageResult
+): AutomationMaturity {
+  // Choose weights based on whether we have an API surface result
+  const hasApiDim = apiCoverageResult !== undefined;
+  const W_TEST_BREADTH = hasApiDim ? REBALANCED_WEIGHTS.TEST_BREADTH : W_TEST_BREADTH_ORIGINAL;
+  const W_FRAMEWORK = hasApiDim ? REBALANCED_WEIGHTS.FRAMEWORK : W_FRAMEWORK_ORIGINAL;
+  const W_TEST_ID = hasApiDim ? REBALANCED_WEIGHTS.TEST_ID : W_TEST_ID_ORIGINAL;
+  const W_CI = hasApiDim ? REBALANCED_WEIGHTS.CI : W_CI_ORIGINAL;
+  const W_AUTH_TESTS = hasApiDim ? REBALANCED_WEIGHTS.AUTH_TESTS : W_AUTH_TESTS_ORIGINAL;
+  const W_COMPONENT_RATIO = hasApiDim ? REBALANCED_WEIGHTS.COMPONENT_RATIO : W_COMPONENT_RATIO_ORIGINAL;
+
   const routePaths = [...new Set(repo.routes.map((r) => r.path))];
   let coveredRoutes = 0;
   for (const p of routePaths) {
@@ -219,7 +253,12 @@ export function computeAutomationMaturity(repo: RepoAnalysis): AutomationMaturit
     ...(compGuidance && { guidance: compGuidance }),
   };
 
-  const dimensions = [breadthDim, frameworkDim, hygieneDim, ciDim, authDim, compDim];
+  const dimensions: AutomationMaturityDimension[] = [breadthDim, frameworkDim, hygieneDim, ciDim, authDim, compDim];
+
+  // Append api-test-coverage dimension when an API surface result was provided
+  if (apiCoverageResult) {
+    dimensions.push(apiCoverageResult.dimension);
+  }
 
   // Overall score normalizes over applicable dimensions only.
   // overallScore = round( Σ score_i * weight_i / Σ weight_i ) for i ∈ applicable.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qulib/mcp",
-  "version": "0.7.0",
+  "version": "0.8.2",
   "description": "MCP server for Qulib — AI-callable QA gap analysis",
   "license": "MIT",
   "author": "Tapesh Nagarwal",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@qulib/core": "0.7.0",
+    "@qulib/core": "0.8.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -23,6 +23,8 @@ import {
   scanRepo,
   computeAutomationMaturity,
   scaffoldTests,
+  discoverApiSurfaceWithRepo,
+  computeApiCoverage,
 } from '@qulib/core';
 import type { HarnessConfig, AnalyzeProgressSink, TelemetrySink } from '@qulib/core';
 import { z } from 'zod';
@@ -381,6 +383,72 @@ mcpServer.registerTool(
       const msg = err instanceof Error ? err.message : String(err);
       log.error(`qulib_scaffold_tests failed: ${msg}`);
       return toolError('QULIB_SCAFFOLD_FAILED', msg, err instanceof Error ? err.stack : undefined);
+    }
+  }
+);
+
+const ScoreApiInputSchema = z.object({
+  repoPath: z.string().describe('Absolute path to the repository on the MCP host filesystem'),
+  enableTier3: z
+    .boolean()
+    .optional()
+    .describe(
+      'Enable Tier3 heuristic discovery (currently: tRPC router definitions). Default false. Tier1=OpenAPI specs, Tier2=framework routes (Next.js, Express, Fastify, NestJS), Tier3=heuristic.'
+    ),
+  includeEndpointDetail: z
+    .boolean()
+    .optional()
+    .describe('When true, includes per-endpoint coverage detail in the response. Default false.'),
+});
+
+mcpServer.registerTool(
+  'qulib_score_api',
+  {
+    description:
+      'Discover API endpoints in a repository and score their test coverage. Returns an api-test-coverage dimension score (0–100) with per-endpoint contextual evidence — which endpoints are covered by tests and which are not. Discovery is evidence-only: Tier1=OpenAPI/Swagger specs, Tier2=framework routes (Next.js App-Router route.ts exports, Pages API routes, Express, Fastify, Hono, NestJS decorators), Tier3=heuristic opt-in (tRPC). Never fabricates endpoints. Returns "not_applicable" when no API endpoints are found.',
+    inputSchema: ScoreApiInputSchema,
+  },
+  async ({ repoPath, enableTier3, includeEndpointDetail }) => {
+    try {
+      const abs = validateAbsoluteRepoPath(repoPath);
+      log.info(`qulib_score_api repoPath=${abs} enableTier3=${enableTier3 ?? false}`);
+
+      const repo = await scanRepo(abs);
+      const apiSurfaceResult = await discoverApiSurfaceWithRepo(abs, repo, {
+        enableTier3: enableTier3 ?? false,
+      });
+
+      const coverageResult = computeApiCoverage(repo, apiSurfaceResult);
+
+      const payload: Record<string, unknown> = {
+        repoPath: abs,
+        computedAt: new Date().toISOString(),
+        endpointsDiscovered: apiSurfaceResult.endpoints.length,
+        openApiSpecsFound: apiSurfaceResult.openApiSpecsFound,
+        tier3Enabled: apiSurfaceResult.tier3Enabled,
+        dimension: coverageResult.dimension,
+        untestedHighSeverityCount: coverageResult.untestedHighSeverityCount,
+        untestedMediumSeverityCount: coverageResult.untestedMediumSeverityCount,
+      };
+
+      if (includeEndpointDetail === true) {
+        payload['endpointCoverage'] = coverageResult.endpointCoverage;
+      }
+
+      log.info(
+        `qulib_score_api done endpoints=${apiSurfaceResult.endpoints.length} score=${coverageResult.dimension.score} applicability=${coverageResult.dimension.applicability ?? 'applicable'}`
+      );
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('repoPath must')) {
+        return toolError('QULIB_INPUT_INVALID', msg, undefined);
+      }
+      log.error(`qulib_score_api failed: ${msg}`);
+      return toolError('QULIB_API_SCORE_FAILED', msg, err instanceof Error ? err.stack : undefined);
     }
   }
 );


### PR DESCRIPTION
Repo-first API toolshed (v0.8.2): discoverApiSurface (tiered, evidence-only) + ApiAdapter/supertest + computeApiCoverage (new api-test-coverage dimension, weights rebalanced to 1.0) + the qulib_score_api MCP tool. 185/185 tests (+58; 127 existing untouched). Backward-compatible. Publishes via the CI provenance pipeline (#80) on the v0.8.2 release.