### PR TITLE
fix: resilient API surface discovery for unreadable directories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,7 +2064,7 @@
     },
     "packages/core": {
       "name": "@qulib/core",
-      "version": "0.7.0",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "^4.9.0",
@@ -2086,11 +2086,11 @@
     },
     "packages/mcp": {
       "name": "@qulib/mcp",
-      "version": "0.7.0",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@qulib/core": "0.7.0",
+        "@qulib/core": "0.8.2",
         "zod": "^3.23.0"
       },
       "bin": {

--- a/packages/core/src/tools/repo/__tests__/api-surface.test.ts
+++ b/packages/core/src/tools/repo/__tests__/api-surface.test.ts
@@ -1,11 +1,18 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, chmod, rm } from 'node:fs/promises';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { discoverApiSurface } from '../api-surface.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const FIXTURE_REPO = join(__dirname, '../../../__tests__/fixtures/api-fixture-repo');
+
+// The EACCES regression test relies on POSIX permission bits: skip on Windows (different
+// chmod semantics) and when running as root (which bypasses permission checks entirely).
+const SKIP_PERM_TEST =
+  process.platform === 'win32' || (typeof process.getuid === 'function' && process.getuid() === 0);
 
 // ---------------------------------------------------------------------------
 // OpenAPI Tier1 discovery
@@ -152,7 +159,36 @@ test('tier3 is disabled by default', async () => {
 });
 
 test('empty repo path discovers no endpoints without erroring', async () => {
-  // Use a temp directory that is guaranteed to have no API files
-  const surface = await discoverApiSurface('/tmp');
-  assert.ok(Array.isArray(surface.endpoints), 'endpoints should be an array');
+  // A freshly created temp dir is guaranteed empty AND isolated from the shared system
+  // /tmp — which on CI runners contains unreadable subtrees (e.g. /tmp/snap-private-tmp on
+  // Ubuntu) that previously surfaced as EACCES during the recursive glob.
+  const emptyDir = await mkdtemp(join(tmpdir(), 'qulib-api-surface-'));
+  try {
+    const surface = await discoverApiSurface(emptyDir);
+    assert.ok(Array.isArray(surface.endpoints), 'endpoints should be an array');
+    assert.equal(surface.endpoints.length, 0, 'an empty dir should yield zero endpoints');
+    assert.equal(surface.openApiSpecsFound, 0, 'an empty dir should yield zero OpenAPI specs');
+  } finally {
+    await rm(emptyDir, { recursive: true, force: true });
+  }
 });
+
+test(
+  'unreadable subdirectory is skipped, not fatal (EACCES regression)',
+  { skip: SKIP_PERM_TEST },
+  async () => {
+    // Reproduces the CI failure: a recursive scan must skip a directory it has no
+    // permission to enter, never throw. Without suppressErrors this throws EACCES.
+    const root = await mkdtemp(join(tmpdir(), 'qulib-api-surface-eacces-'));
+    const locked = join(root, 'locked');
+    await mkdir(locked);
+    await chmod(locked, 0o000);
+    try {
+      const surface = await discoverApiSurface(root);
+      assert.ok(Array.isArray(surface.endpoints), 'should return an array, not throw');
+    } finally {
+      await chmod(locked, 0o755);
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+);

--- a/packages/core/src/tools/repo/api-surface.ts
+++ b/packages/core/src/tools/repo/api-surface.ts
@@ -27,6 +27,21 @@ import type { RepoAnalysis } from '../../schemas/repo-analysis.schema.js';
 
 const IGNORE_PATTERNS = ['**/node_modules/**', '**/.next/**', '**/dist/**', '**/build/**'];
 
+/**
+ * Shared fast-glob options for every discovery tier. `suppressErrors: true` makes the
+ * recursive walk skip subtrees it cannot read (EACCES/EPERM) or that disappear mid-scan
+ * (ENOENT) instead of throwing. Real repos — and shared dirs like /tmp on CI runners
+ * (e.g. the root-owned, unreadable /tmp/snap-private-tmp on Ubuntu) — routinely contain
+ * directories the scanner cannot enter; discovery must degrade gracefully, never crash.
+ * `cwd` is supplied per-call.
+ */
+const GLOB_OPTIONS = {
+  onlyFiles: true,
+  absolute: true,
+  ignore: IGNORE_PATTERNS,
+  suppressErrors: true,
+};
+
 function toPosix(p: string): string {
   return p.split('\\').join('/');
 }
@@ -111,7 +126,7 @@ async function discoverFromOpenApi(repoPath: string): Promise<{ endpoints: Disco
       '**/api-docs.yaml',
       '**/api-docs.json',
     ],
-    { cwd: repoPath, onlyFiles: true, absolute: true, ignore: IGNORE_PATTERNS }
+    { cwd: repoPath, ...GLOB_OPTIONS }
   );
 
   let specsFound = 0;
@@ -176,9 +191,7 @@ async function discoverNextAppRouterEndpoints(repoPath: string): Promise<Discove
 
   const routeFiles = await glob(['app/**/route.ts', 'app/**/route.tsx', 'src/app/**/route.ts', 'src/app/**/route.tsx'], {
     cwd: repoPath,
-    onlyFiles: true,
-    absolute: true,
-    ignore: IGNORE_PATTERNS,
+    ...GLOB_OPTIONS,
   });
 
   for (const file of routeFiles) {
@@ -232,9 +245,7 @@ async function discoverNextPagesApiEndpoints(repoPath: string): Promise<Discover
 
   const apiFiles = await glob(['pages/api/**/*.ts', 'pages/api/**/*.tsx', 'src/pages/api/**/*.ts'], {
     cwd: repoPath,
-    onlyFiles: true,
-    absolute: true,
-    ignore: IGNORE_PATTERNS,
+    ...GLOB_OPTIONS,
   });
 
   for (const file of apiFiles) {
@@ -309,9 +320,7 @@ async function discoverFastifyEndpoints(repoPath: string): Promise<DiscoveredEnd
 
   const files = await glob(['src/**/*.ts', 'src/**/*.js', 'routes/**/*.ts', 'routes/**/*.js'], {
     cwd: repoPath,
-    onlyFiles: true,
-    absolute: true,
-    ignore: IGNORE_PATTERNS,
+    ...GLOB_OPTIONS,
   });
 
   for (const file of files) {
@@ -370,12 +379,7 @@ async function discoverTrpcEndpoints(repoPath: string): Promise<DiscoveredEndpoi
 
   const trpcFiles = await glob(
     ['src/**/*.ts', 'server/**/*.ts', 'lib/**/*.ts', 'app/**/*.ts'],
-    {
-      cwd: repoPath,
-      onlyFiles: true,
-      absolute: true,
-      ignore: IGNORE_PATTERNS,
-    }
+    { cwd: repoPath, ...GLOB_OPTIONS }
   );
 
   for (const file of trpcFiles) {


### PR DESCRIPTION
## What

Makes `discoverApiSurface` resilient to directories it cannot read, fixing the red CI on `main` left by the v0.8.2 merge.

## Why

`discoverApiSurface` globs recursively; `fast-glob` only suppresses `ENOENT` by default. On the Ubuntu CI runner the empty-path test scanned `/tmp` and hit `/tmp/snap-private-tmp` (root-owned, unreadable) → `EACCES` was thrown → `not ok 129 - empty repo path discovers no endpoints without erroring`. It passed locally on macOS, where that directory does not exist.

## Changes

- `suppressErrors: true` on every glob via a shared `GLOB_OPTIONS` — the recursive walk now skips unreadable/vanishing subtrees instead of throwing. A real-repo robustness fix, not just a test workaround.
- Replaced the fragile `/tmp` scan with an isolated `mkdtemp` empty dir (asserts zero endpoints), and added an EACCES regression test (chmod-000 subdir) that fails without the fix. Skipped on Windows / when running as root.
- Re-synced `package-lock.json` to 0.8.2.

## Verification

- `@qulib/core` full suite: **176/176 pass, 0 fail**
- `tsc --noEmit`: clean
- New regression test runs (not skipped) and passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
