### PR TITLE
Thread tenantId through the eval ledger append

### DIFF
--- a/packages/core/evals/runner/__tests__/runner.test.ts
+++ b/packages/core/evals/runner/__tests__/runner.test.ts
@@ -27,13 +27,14 @@ import {
   meanJudgeScore,
   summarize,
   toLedgerEntry,
+  resolveTenantId,
 } from '../rollup.js';
 import { loadCases, goldenRoot, EVAL_SUITES } from '../load-cases.js';
 import { runScaffoldCase } from '../run-scaffold.js';
 import { runScoreAutomationCase } from '../run-score-automation.js';
 import { judgeConfigured, skipVerdict, judgeOrSkip, reduceScaffoldVerdicts } from '../judge-bridge.js';
 import type { JudgeImpl } from '../judge-bridge.js';
-import { runSuite, runEval, ledgerLineCount } from '../index.js';
+import { runSuite, runEval, ledgerLineCount, readLedger, filterLedgerByTenant } from '../index.js';
 import type { EvalCaseResult, JudgeVerdict } from '../../types.js';
 import type { NeutralScenario } from '../../../src/schemas/gap-analysis.schema.js';
 
@@ -437,5 +438,110 @@ test('ledger: exactly one line is appended per suite run', async () => {
     assert.ok(typeof entry.qulibVersion === 'string');
     assert.ok(entry.counts && typeof entry.counts === 'object');
   }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// tenantId — TENANT-A4
+// ---------------------------------------------------------------------------
+
+test('resolveTenantId: explicit value wins', () => {
+  assert.equal(resolveTenantId('team-1', {}), 'team-1');
+});
+
+test('resolveTenantId: falls back to TAP_TENANT_ID env when no explicit value', () => {
+  assert.equal(resolveTenantId(undefined, { TAP_TENANT_ID: 'env-tenant' }), 'env-tenant');
+});
+
+test('resolveTenantId: falls back to "default" when neither explicit nor env is set', () => {
+  assert.equal(resolveTenantId(undefined, {}), 'default');
+  assert.equal(resolveTenantId('', { TAP_TENANT_ID: '' }), 'default');
+  assert.equal(resolveTenantId('  ', { TAP_TENANT_ID: '  ' }), 'default');
+});
+
+test('toLedgerEntry: tenantId is stamped on the entry', () => {
+  const results: EvalCaseResult[] = [
+    { caseId: 'a', suite: 'scaffold', outcome: 'PASS', deterministic: { outcome: 'PASS', notes: [] }, latencyMs: 1 },
+  ];
+  const summary = summarize('scaffold', results, 't0', 't1');
+  const entry = toLedgerEntry(summary, '0.0.0', 'team-1');
+  assert.equal(entry.tenantId, 'team-1');
+});
+
+test('toLedgerEntry: defaults to "default" when tenantId omitted', () => {
+  const results: EvalCaseResult[] = [
+    { caseId: 'a', suite: 'scaffold', outcome: 'PASS', deterministic: { outcome: 'PASS', notes: [] }, latencyMs: 1 },
+  ];
+  const summary = summarize('scaffold', results, 't0', 't1');
+  const entry = toLedgerEntry(summary, '0.0.0');
+  assert.equal(entry.tenantId, 'default');
+  assert.ok(entry.tenantId.length > 0, 'tenantId must never be empty');
+});
+
+test('runEval: explicit tenantId is written to ledger', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'qulib-tenant-write-'));
+  const ledger = join(dir, 'ledger.jsonl');
+  writeFileSync(ledger, '');
+
+  const { summaries } = await runEval({ appendLedger: false, tenantId: 'team-1' });
+  for (const s of summaries) {
+    appendFileSync(ledger, `${JSON.stringify(toLedgerEntry(s, '0.0.0', 'team-1'))}\n`);
+  }
+  const lines = readFileSync(ledger, 'utf8').trim().split('\n');
+  for (const line of lines) {
+    const entry = JSON.parse(line) as Record<string, unknown>;
+    assert.equal(entry.tenantId, 'team-1', 'each ledger line must carry tenantId=team-1');
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('runEval: default tenantId applied when none supplied (not null, not empty)', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'qulib-tenant-default-'));
+  const ledger = join(dir, 'ledger.jsonl');
+  writeFileSync(ledger, '');
+
+  const { summaries } = await runEval({ appendLedger: false });
+  for (const s of summaries) {
+    appendFileSync(ledger, `${JSON.stringify(toLedgerEntry(s, '0.0.0'))}\n`);
+  }
+  const entries = readLedger(ledger);
+  for (const e of entries) {
+    assert.ok(e.tenantId && e.tenantId.length > 0, 'tenantId must be non-empty on every new entry');
+    assert.equal(e.tenantId, 'default');
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('filterLedgerByTenant: returns only entries matching the requested tenantId', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'qulib-tenant-filter-'));
+  const ledger = join(dir, 'ledger.jsonl');
+
+  const { summaries } = await runEval({ appendLedger: false });
+  for (const s of summaries) {
+    appendFileSync(ledger, `${JSON.stringify(toLedgerEntry(s, '0.0.0', 'team-alpha'))}\n`);
+    appendFileSync(ledger, `${JSON.stringify(toLedgerEntry(s, '0.0.0', 'team-beta'))}\n`);
+  }
+  const alpha = filterLedgerByTenant('team-alpha', ledger);
+  const beta = filterLedgerByTenant('team-beta', ledger);
+  const none = filterLedgerByTenant('team-gamma', ledger);
+
+  assert.equal(alpha.length, summaries.length, 'team-alpha should have one entry per suite');
+  assert.equal(beta.length, summaries.length, 'team-beta should have one entry per suite');
+  assert.equal(none.length, 0, 'unknown tenant returns empty array');
+  assert.ok(alpha.every((e) => e.tenantId === 'team-alpha'));
+  assert.ok(beta.every((e) => e.tenantId === 'team-beta'));
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('readLedger: old records without tenantId parse back as "legacy" (backward-compat)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'qulib-tenant-legacy-'));
+  const ledger = join(dir, 'ledger.jsonl');
+  // Simulate an old-format ledger line with no tenantId field
+  const oldEntry = { ts: '2025-01-01T00:00:00.000Z', suite: 'scaffold', outcome: 'PASS', score: 0.9, counts: { pass: 1, warn: 0, fail: 0, skip: 0, total: 1 }, qulibVersion: '0.8.0' };
+  writeFileSync(ledger, `${JSON.stringify(oldEntry)}\n`);
+
+  const entries = readLedger(ledger);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].tenantId, 'legacy', 'old record without tenantId must read back as "legacy"');
   rmSync(dir, { recursive: true, force: true });
 });

--- a/packages/core/evals/runner/index.ts
+++ b/packages/core/evals/runner/index.ts
@@ -20,13 +20,13 @@
  */
 import { appendFileSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import type { EvalRunSummary, EvalSuite } from '../types.js';
+import type { EvalLedgerEntry, EvalRunSummary, EvalSuite } from '../types.js';
 import { EVAL_SUITES, loadCases, ledgerPath } from './load-cases.js';
 import { runScaffoldCase } from './run-scaffold.js';
 import { runScoreAutomationCase } from './run-score-automation.js';
 import { runConfidenceCase } from './run-confidence.js';
 import { judgeConfigured, type JudgeImpl } from './judge-bridge.js';
-import { summarize, toLedgerEntry } from './rollup.js';
+import { summarize, toLedgerEntry, resolveTenantId } from './rollup.js';
 
 const require = createRequire(import.meta.url);
 
@@ -38,6 +38,12 @@ export interface RunOptions {
   env?: NodeJS.ProcessEnv;
   /** Inject a judge implementation (tests). Defaults to Q2c's real judge (SKIPs without a key). */
   judge?: JudgeImpl;
+  /**
+   * Tenant that owns this eval run. Stamped on every ledger entry.
+   * Source precedence: explicit value here → env TAP_TENANT_ID → "default".
+   * Never null/empty — guaranteed by resolveTenantId().
+   */
+  tenantId?: string;
 }
 
 function qulibVersion(): string {
@@ -70,13 +76,14 @@ export async function runEval(
   const suites = opts.suites && opts.suites.length > 0 ? opts.suites : [...EVAL_SUITES];
   const appendLedger = opts.appendLedger ?? true;
   const version = qulibVersion();
+  const tenantId = resolveTenantId(opts.tenantId, opts.env ?? process.env);
   const summaries: EvalRunSummary[] = [];
 
   for (const suite of suites) {
     const summary = await runSuite(suite, opts);
     summaries.push(summary);
     if (appendLedger) {
-      const entry = toLedgerEntry(summary, version);
+      const entry = toLedgerEntry(summary, version, tenantId);
       appendFileSync(ledgerPath(), `${JSON.stringify(entry)}\n`, 'utf8');
     }
   }
@@ -143,6 +150,32 @@ export function ledgerLineCount(path: string = ledgerPath()): number {
   } catch {
     return 0;
   }
+}
+
+/**
+ * Read all entries from a ledger file. Old records without a tenantId field
+ * are returned with tenantId set to "legacy" — backward-compat, never rewritten.
+ */
+export function readLedger(path: string = ledgerPath()): EvalLedgerEntry[] {
+  try {
+    const raw = readFileSync(path, 'utf8').trim();
+    if (raw.length === 0) return [];
+    return raw.split('\n').map((line) => {
+      const entry = JSON.parse(line) as EvalLedgerEntry;
+      if (!entry.tenantId) entry.tenantId = 'legacy';
+      return entry;
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Filter ledger entries by tenantId. Useful for per-tenant maturity tracking.
+ * Old records (no tenantId) surface as "legacy" via readLedger().
+ */
+export function filterLedgerByTenant(tenantId: string, path: string = ledgerPath()): EvalLedgerEntry[] {
+  return readLedger(path).filter((e) => e.tenantId === tenantId);
 }
 
 async function main(): Promise<void> {

--- a/packages/core/evals/runner/rollup.ts
+++ b/packages/core/evals/runner/rollup.ts
@@ -70,8 +70,26 @@ export function summarize(
   };
 }
 
+/**
+ * Resolve the tenantId from options or env, falling back to "default".
+ * Never returns null or empty — "default" is the guaranteed fallback.
+ */
+export function resolveTenantId(
+  explicit?: string,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  if (explicit && explicit.trim().length > 0) return explicit.trim();
+  const fromEnv = env['TAP_TENANT_ID'];
+  if (fromEnv && fromEnv.trim().length > 0) return fromEnv.trim();
+  return 'default';
+}
+
 /** Project a run summary into the single append-only ledger line. */
-export function toLedgerEntry(summary: EvalRunSummary, qulibVersion: string): EvalLedgerEntry {
+export function toLedgerEntry(
+  summary: EvalRunSummary,
+  qulibVersion: string,
+  tenantId: string = 'default'
+): EvalLedgerEntry {
   // Pull pinned judge identity + total cost from the first verdict that actually ran.
   const judged = summary.results.find((r) => r.judge && r.judge.outcome !== 'SKIP')?.judge;
   const cost = summary.results.reduce(
@@ -93,6 +111,7 @@ export function toLedgerEntry(summary: EvalRunSummary, qulibVersion: string): Ev
     score: summary.score,
     counts: summary.counts,
     qulibVersion,
+    tenantId,
   };
   if (judged) {
     entry.judgeModel = judged.judgeModel;

--- a/packages/core/evals/types.ts
+++ b/packages/core/evals/types.ts
@@ -107,4 +107,11 @@ export interface EvalLedgerEntry {
   qulibVersion: string;
   /** Total judge cost for the run, if a judge ran. */
   cost?: { inputTokens: number; outputTokens: number };
+  /**
+   * Tenant that produced this run. Source precedence:
+   *   explicit RunOptions.tenantId → env TAP_TENANT_ID → "default".
+   * Never null/empty on NEW records. Old records without this field are
+   * treated as "legacy" by readers — backward-compat, never rewritten.
+   */
+  tenantId: string;
 }


### PR DESCRIPTION
runSuite/runEval accept an optional `tenantId` (RunOptions → `TAP_TENANT_ID` → `default`) stamped on every evals/ledger.jsonl entry; reader helpers filter by it; old records read back as `legacy`. Multi-tenant from day one. No version bump, no publish. npm build clean; 418 tests pass (8 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)