### PR TITLE
Reusable GitHub Actions analyze gate (composite action + workflow)

### DIFF
--- a/.github/actions/qulib-analyze/README.md
+++ b/.github/actions/qulib-analyze/README.md
@@ -1,0 +1,31 @@
+# `qulib-analyze` composite action
+
+Run [`@qulib/core`](https://www.npmjs.com/package/@qulib/core) `analyze` against a deployed URL in CI and **gate the build** on Qulib's honest agent-summary verdict (`pass` / `warn` / `fail`).
+
+```yaml
+- uses: TapeshN/qulib/.github/actions/qulib-analyze@v1
+  with:
+    url: https://your-app.example.com
+    fail-on: fail   # fail (default) | warn | never
+```
+
+## Why this exists
+
+`qulib analyze --agent-summary` prints a stable agent-summary JSON whose `gate` field is the verdict — but the CLI **always exits 0**, leaving the pass/fail decision to the consumer. This action makes that decision for you: it captures the JSON, maps `gate` to a CI exit code under your `fail-on` policy, writes a job summary, and uploads the JSON as an artifact.
+
+| `gate` | `fail-on: fail` | `fail-on: warn` | `fail-on: never` |
+|---|---|---|---|
+| `pass` | pass | pass | pass |
+| `warn` | pass | **fail** | pass |
+| `fail` | **fail** | **fail** | pass |
+
+A `fail` gate means a critical gap, a blocked scan, null/too-low confidence, or an auth-required surface that was never exercised.
+
+## Inputs / outputs
+
+See the [main README CI section](../../../README.md#ci-integration-github-actions) for the full input/output tables.
+
+## Files
+
+- [`action.yml`](./action.yml) — composite action definition (inputs, outputs, steps).
+- [`gate.mjs`](./gate.mjs) — pure-stdlib Node script that reads the agent-summary JSON and exits per the `fail-on` policy. It is self-tested in CI by [`.github/workflows/qulib-action-selftest.yml`](../../workflows/qulib-action-selftest.yml).

--- a/.github/actions/qulib-analyze/action.yml
+++ b/.github/actions/qulib-analyze/action.yml
@@ -1,0 +1,131 @@
+name: "Qulib analyze gate"
+description: >-
+  Run `@qulib/core analyze` against a deployed URL and gate the build on the
+  honest agent-summary verdict (pass / warn / fail). Drop-in composite action.
+author: "TapeshN"
+branding:
+  icon: "shield"
+  color: "blue"
+
+inputs:
+  url:
+    description: "Base URL of the deployed app to analyze (required)."
+    required: true
+  fail-on:
+    description: >-
+      Gate policy: `fail` (default — fail the job only on gate=fail),
+      `warn` (fail on warn or fail), or `never` (report only, never fail).
+    required: false
+    default: "fail"
+  qulib-version:
+    description: >-
+      npm version/dist-tag of @qulib/core to run via npx (e.g. `latest`,
+      `0.8.2`). Pin this for reproducible CI.
+    required: false
+    default: "latest"
+  repo:
+    description: "Optional path to the app repo (enables repo-aware gap analysis)."
+    required: false
+    default: ""
+  config:
+    description: "Path to a qulib config file relative to the working directory."
+    required: false
+    default: ""
+  auth-storage-state:
+    description: >-
+      Path to a Playwright storage-state JSON for authenticated scans. Write a
+      secret to a file in an earlier step and pass its path here — never inline
+      a secret.
+    required: false
+    default: ""
+  extra-args:
+    description: >-
+      Additional raw flags appended to the `qulib analyze` invocation
+      (e.g. `--skip-auth-detection`). Advanced; passed through verbatim.
+    required: false
+    default: ""
+  node-version:
+    description: "Node.js version to set up for the run."
+    required: false
+    default: "20"
+  install-browser:
+    description: >-
+      Install the Playwright Chromium browser (`true`/`false`). qulib crawls
+      with Playwright, so the default is `true`. Set `false` if a prior step
+      already installed it.
+    required: false
+    default: "true"
+  output-path:
+    description: "File path to write the raw agent-summary JSON to."
+    required: false
+    default: "qulib-agent-summary.json"
+
+outputs:
+  gate:
+    description: "The qulib gate verdict: pass | warn | fail."
+    value: ${{ steps.gate.outputs.gate }}
+  release-confidence:
+    description: "Release confidence 0-100, or `n/a` when null."
+    value: ${{ steps.gate.outputs.release_confidence }}
+  coverage-status:
+    description: "Coverage status enum (ok | thin | blocked-by-auth | ...)."
+    value: ${{ steps.gate.outputs.coverage_status }}
+  blocked:
+    description: "`true` if the gate violated the fail-on policy (the job was failed)."
+    value: ${{ steps.gate.outputs.blocked }}
+  summary-path:
+    description: "Path to the written agent-summary JSON artifact."
+    value: ${{ inputs.output-path }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install Playwright Chromium
+      if: ${{ inputs.install-browser == 'true' }}
+      shell: bash
+      run: npx --yes playwright install --with-deps chromium
+
+    - name: Run qulib analyze (agent-summary)
+      shell: bash
+      env:
+        QULIB_URL: ${{ inputs.url }}
+        QULIB_VERSION: ${{ inputs.qulib-version }}
+        QULIB_REPO: ${{ inputs.repo }}
+        QULIB_CONFIG: ${{ inputs.config }}
+        QULIB_AUTH_STORAGE_STATE: ${{ inputs.auth-storage-state }}
+        QULIB_EXTRA_ARGS: ${{ inputs.extra-args }}
+        QULIB_OUTPUT_PATH: ${{ inputs.output-path }}
+      run: |
+        set -euo pipefail
+        args=(analyze --url "$QULIB_URL" --agent-summary)
+        [ -n "$QULIB_REPO" ] && args+=(--repo "$QULIB_REPO")
+        [ -n "$QULIB_CONFIG" ] && args+=(--config "$QULIB_CONFIG")
+        [ -n "$QULIB_AUTH_STORAGE_STATE" ] && args+=(--auth-storage-state "$QULIB_AUTH_STORAGE_STATE")
+        # shellcheck disable=SC2206
+        [ -n "$QULIB_EXTRA_ARGS" ] && args+=($QULIB_EXTRA_ARGS)
+        echo "[qulib] npx -y @qulib/core@${QULIB_VERSION} ${args[*]}"
+        # --agent-summary prints diagnostics to stderr and ONLY the JSON to stdout.
+        npx --yes "@qulib/core@${QULIB_VERSION}" "${args[@]}" > "$QULIB_OUTPUT_PATH"
+        echo "[qulib] agent-summary written to $QULIB_OUTPUT_PATH"
+        cat "$QULIB_OUTPUT_PATH"
+
+    - name: Evaluate gate
+      id: gate
+      shell: bash
+      run: |
+        node "${{ github.action_path }}/gate.mjs" \
+          "${{ inputs.output-path }}" \
+          "${{ inputs.fail-on }}"
+
+    - name: Upload agent-summary artifact
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: qulib-agent-summary
+        path: ${{ inputs.output-path }}
+        if-no-files-found: warn

--- a/.github/actions/qulib-analyze/gate.mjs
+++ b/.github/actions/qulib-analyze/gate.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Gate decision for the qulib reusable analyze action.
+ *
+ * qulib's CLI (`@qulib/core analyze --agent-summary`) prints a stable
+ * agent-summary JSON to stdout and *always exits 0* — the pass/warn/fail
+ * verdict lives in the `gate` field, not the process exit code. CI gating is
+ * therefore the consumer's job: this script reads that JSON and turns the
+ * `gate` into a CI exit code, honouring a `fail-on` policy.
+ *
+ * Pure stdlib (no deps) so it runs from a checkout of the published action
+ * without an install step.
+ *
+ * Usage:
+ *   node gate.mjs <agent-summary.json> <fail-on>
+ *     fail-on ∈ { fail (default), warn, never }
+ *
+ * Exit codes:
+ *   0  gate satisfied the policy (build passes)
+ *   1  gate violated the policy (build fails the qulib check)
+ *   2  usage / parse error (the JSON was not a valid agent summary)
+ *
+ * Side effects (when running under GitHub Actions):
+ *   - appends `gate`, `release_confidence`, `coverage_status` to $GITHUB_OUTPUT
+ *   - appends a human-readable block to $GITHUB_STEP_SUMMARY
+ */
+import { readFileSync, appendFileSync } from 'node:fs';
+
+const GATE_RANK = { pass: 0, warn: 1, fail: 2 };
+const FAIL_ON_RANK = { never: 3, fail: 2, warn: 1 };
+
+function fail(msg, code = 2) {
+  process.stderr.write(`[qulib-gate] ${msg}\n`);
+  process.exit(code);
+}
+
+const [, , jsonPath, failOnRaw] = process.argv;
+if (!jsonPath) fail('missing path to agent-summary JSON');
+
+const failOn = (failOnRaw || 'fail').trim().toLowerCase();
+if (!(failOn in FAIL_ON_RANK)) {
+  fail(`invalid fail-on "${failOn}" — expected one of: fail, warn, never`);
+}
+
+let summary;
+try {
+  summary = JSON.parse(readFileSync(jsonPath, 'utf8'));
+} catch (err) {
+  fail(`could not read/parse agent-summary JSON at ${jsonPath}: ${err.message}`);
+}
+
+const gate = summary?.gate;
+if (!(gate in GATE_RANK)) {
+  fail(`agent-summary JSON has no valid "gate" field (got: ${JSON.stringify(gate)})`);
+}
+
+const confidence =
+  summary.releaseConfidence === null || summary.releaseConfidence === undefined
+    ? 'n/a'
+    : String(summary.releaseConfidence);
+const coverage = summary.coverageStatus ?? 'unknown';
+
+// Decide: does this gate violate the fail-on policy?
+// We fail the build when the observed gate is at or above the fail-on floor.
+const blocked = GATE_RANK[gate] >= FAIL_ON_RANK[failOn];
+
+// --- GitHub Actions outputs ---
+const ghOutput = process.env.GITHUB_OUTPUT;
+if (ghOutput) {
+  appendFileSync(
+    ghOutput,
+    `gate=${gate}\n` +
+      `release_confidence=${confidence}\n` +
+      `coverage_status=${coverage}\n` +
+      `blocked=${blocked}\n`
+  );
+}
+
+// --- Job summary (Markdown) ---
+const icon = { pass: '✅', warn: '⚠️', fail: '❌' }[gate];
+const verdict = blocked ? '❌ **FAILED**' : '✅ **passed**';
+const risks = Array.isArray(summary.topRisks) ? summary.topRisks : [];
+const notes = Array.isArray(summary.honestyNotes) ? summary.honestyNotes : [];
+const nextChecks = Array.isArray(summary.recommendedNextChecks)
+  ? summary.recommendedNextChecks
+  : [];
+
+const lines = [];
+lines.push('## qulib analyze gate');
+lines.push('');
+lines.push(`| Field | Value |`);
+lines.push(`| --- | --- |`);
+lines.push(`| Gate | ${icon} \`${gate}\` |`);
+lines.push(`| Release confidence | \`${confidence}\` |`);
+lines.push(`| Coverage | \`${coverage}\` |`);
+lines.push(`| Policy (\`fail-on\`) | \`${failOn}\` |`);
+lines.push(`| CI result | ${verdict} |`);
+lines.push('');
+if (risks.length) {
+  lines.push('### Top risks');
+  for (const r of risks) lines.push(`- ${r}`);
+  lines.push('');
+}
+if (nextChecks.length) {
+  lines.push('### Recommended next checks');
+  for (const c of nextChecks) lines.push(`- ${c}`);
+  lines.push('');
+}
+if (notes.length) {
+  lines.push('### Honesty notes');
+  for (const n of notes) lines.push(`- ${n}`);
+  lines.push('');
+}
+
+const stepSummary = process.env.GITHUB_STEP_SUMMARY;
+if (stepSummary) {
+  appendFileSync(stepSummary, lines.join('\n') + '\n');
+}
+
+// Always echo a one-line verdict to the log.
+process.stdout.write(
+  `[qulib-gate] gate=${gate} confidence=${confidence} coverage=${coverage} ` +
+    `fail-on=${failOn} -> ${blocked ? 'FAIL' : 'pass'}\n`
+);
+
+process.exit(blocked ? 1 : 0);

--- a/.github/workflows/qulib-action-selftest.yml
+++ b/.github/workflows/qulib-action-selftest.yml
@@ -39,25 +39,33 @@ jobs:
         working-directory: packages/core
         run: |
           set -euo pipefail
-          cat > /tmp/emit-summary.ts <<'TS'
+          # Written inside the ESM package (packages/core) so tsx treats it as
+          # ESM; the body is wrapped in main() to avoid top-level await (rejected
+          # under tsx's default cjs transform for ad-hoc scripts).
+          cat > src/__tests__/zz-emit-summary.ts <<'TS'
           import { spawn } from 'node:child_process';
           import { resolve, dirname } from 'node:path';
           import { fileURLToPath } from 'node:url';
           import { writeFileSync } from 'node:fs';
-          import { startFixtureServer } from './src/__tests__/fixture-server.js';
-          const cli = resolve(process.cwd(), 'src/cli/index.ts');
+          import { startFixtureServer } from './fixture-server.js';
+          const __dir = dirname(fileURLToPath(import.meta.url));
+          const cli = resolve(__dir, '..', 'cli', 'index.ts');
           const out = process.argv[2];
-          const server = await startFixtureServer();
-          try {
-            const child = spawn(process.execPath, ['--import','tsx/esm', cli, 'analyze','--url', server.baseUrl, '--agent-summary'], { stdio: ['ignore','pipe','inherit'] });
-            let s = '';
-            child.stdout.on('data', (c) => (s += c.toString()));
-            const code = await new Promise((r) => child.on('close', (c) => r(c ?? -1)));
-            if (code !== 0) { console.error('analyze exit', code); process.exit(1); }
-            writeFileSync(out, s);
-          } finally { await server.close(); }
+          async function main() {
+            const server = await startFixtureServer();
+            try {
+              const child = spawn(process.execPath, ['--import','tsx/esm', cli, 'analyze','--url', server.baseUrl, '--agent-summary'], { stdio: ['ignore','pipe','inherit'] });
+              let s = '';
+              child.stdout.on('data', (c: Buffer) => (s += c.toString()));
+              const code: number = await new Promise((r) => child.on('close', (c) => r(c ?? -1)));
+              if (code !== 0) { console.error('analyze exit', code); process.exit(1); }
+              writeFileSync(out, s);
+            } finally { await server.close(); }
+          }
+          main().catch((e) => { console.error(e); process.exit(1); });
           TS
-          node --import tsx/esm /tmp/emit-summary.ts "$GITHUB_WORKSPACE/qulib-agent-summary.json"
+          node --import tsx/esm src/__tests__/zz-emit-summary.ts "$GITHUB_WORKSPACE/qulib-agent-summary.json"
+          rm -f src/__tests__/zz-emit-summary.ts
           echo "--- agent-summary ---"
           cat "$GITHUB_WORKSPACE/qulib-agent-summary.json"
 

--- a/.github/workflows/qulib-action-selftest.yml
+++ b/.github/workflows/qulib-action-selftest.yml
@@ -1,0 +1,91 @@
+name: qulib-action selftest
+
+# Proves the reusable analyze gate end-to-end in CI without a live external URL.
+# Serves the in-repo offline fixtures, runs the local CLI to emit the
+# agent-summary JSON (the exact shape the composite action captures from
+# `npx @qulib/core analyze --agent-summary`), then runs the action's gate.mjs
+# and asserts the exit code matches the gate verdict under each fail-on policy.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/actions/qulib-analyze/**"
+      - ".github/workflows/qulib-action-selftest.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/actions/qulib-analyze/**"
+      - ".github/workflows/qulib-action-selftest.yml"
+  workflow_dispatch: {}
+
+jobs:
+  gate-selftest:
+    name: gate.mjs end-to-end (offline fixture)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run build
+
+      - name: Produce a real agent-summary from the offline fixture
+        working-directory: packages/core
+        run: |
+          set -euo pipefail
+          cat > /tmp/emit-summary.ts <<'TS'
+          import { spawn } from 'node:child_process';
+          import { resolve, dirname } from 'node:path';
+          import { fileURLToPath } from 'node:url';
+          import { writeFileSync } from 'node:fs';
+          import { startFixtureServer } from './src/__tests__/fixture-server.js';
+          const cli = resolve(process.cwd(), 'src/cli/index.ts');
+          const out = process.argv[2];
+          const server = await startFixtureServer();
+          try {
+            const child = spawn(process.execPath, ['--import','tsx/esm', cli, 'analyze','--url', server.baseUrl, '--agent-summary'], { stdio: ['ignore','pipe','inherit'] });
+            let s = '';
+            child.stdout.on('data', (c) => (s += c.toString()));
+            const code = await new Promise((r) => child.on('close', (c) => r(c ?? -1)));
+            if (code !== 0) { console.error('analyze exit', code); process.exit(1); }
+            writeFileSync(out, s);
+          } finally { await server.close(); }
+          TS
+          node --import tsx/esm /tmp/emit-summary.ts "$GITHUB_WORKSPACE/qulib-agent-summary.json"
+          echo "--- agent-summary ---"
+          cat "$GITHUB_WORKSPACE/qulib-agent-summary.json"
+
+      - name: Gate — assert exit codes match the verdict
+        run: |
+          set -euo pipefail
+          SUM="$GITHUB_WORKSPACE/qulib-agent-summary.json"
+          GATE=.github/actions/qulib-analyze/gate.mjs
+          OBSERVED=$(node -e "process.stdout.write(require('$SUM').gate)")
+          echo "observed gate: $OBSERVED"
+
+          assert_exit() { # <fail-on> <expected-exit>
+            set +e; node "$GATE" "$SUM" "$1" >/dev/null 2>&1; local rc=$?; set -e
+            if [ "$rc" != "$2" ]; then
+              echo "FAIL: fail-on=$1 expected exit $2 got $rc"; exit 1
+            fi
+            echo "OK: fail-on=$1 -> exit $rc"
+          }
+
+          case "$OBSERVED" in
+            pass) assert_exit fail 0; assert_exit warn 0; assert_exit never 0 ;;
+            warn) assert_exit fail 0; assert_exit warn 1; assert_exit never 0 ;;
+            fail) assert_exit fail 1; assert_exit warn 1; assert_exit never 0 ;;
+            *) echo "unexpected gate: $OBSERVED"; exit 1 ;;
+          esac
+
+          # Error handling: bad policy and missing file both exit 2
+          set +e; node "$GATE" "$SUM" bogus >/dev/null 2>&1; [ $? -eq 2 ] || { echo "bad policy did not exit 2"; exit 1; }
+          node "$GATE" /tmp/does-not-exist.json fail >/dev/null 2>&1; [ $? -eq 2 ] || { echo "missing file did not exit 2"; exit 1; }
+          set -e
+          echo "gate.mjs selftest PASS"

--- a/.github/workflows/qulib-analyze.yml
+++ b/.github/workflows/qulib-analyze.yml
@@ -1,0 +1,127 @@
+name: Qulib analyze
+
+# Reusable workflow: gate a deployed app on qulib's honest agent-summary verdict.
+#
+# Call it from a consumer repo with:
+#
+#   jobs:
+#     qa:
+#       uses: TapeshN/qulib/.github/workflows/qulib-analyze.yml@v1
+#       with:
+#         url: https://your-app.example.com
+#         fail-on: warn
+#
+# For finer control inside an existing job, use the composite action directly:
+#   - uses: TapeshN/qulib/.github/actions/qulib-analyze@v1
+
+on:
+  workflow_call:
+    inputs:
+      url:
+        description: "Base URL of the deployed app to analyze."
+        required: true
+        type: string
+      fail-on:
+        description: "Gate policy: fail | warn | never."
+        required: false
+        default: "fail"
+        type: string
+      qulib-version:
+        description: "npm version/dist-tag of @qulib/core (e.g. latest, 0.8.2)."
+        required: false
+        default: "latest"
+        type: string
+      repo:
+        description: "Optional path to the app repo for repo-aware analysis."
+        required: false
+        default: ""
+        type: string
+      config:
+        description: "Path to a qulib config file relative to the checkout."
+        required: false
+        default: ""
+        type: string
+      extra-args:
+        description: "Extra raw flags appended to qulib analyze."
+        required: false
+        default: ""
+        type: string
+      node-version:
+        description: "Node.js version."
+        required: false
+        default: "20"
+        type: string
+      checkout:
+        description: >-
+          Check out the caller's repo first (needed when `repo`/`config` point
+          at in-repo paths). Default false — a URL-only scan needs no checkout.
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      auth-storage-state:
+        description: >-
+          Optional Playwright storage-state JSON (the file contents) for an
+          authenticated scan. Written to a temp file and passed to qulib.
+        required: false
+    outputs:
+      gate:
+        description: "The qulib gate verdict: pass | warn | fail."
+        value: ${{ jobs.analyze.outputs.gate }}
+      release-confidence:
+        description: "Release confidence 0-100, or n/a."
+        value: ${{ jobs.analyze.outputs.release-confidence }}
+      coverage-status:
+        description: "Coverage status enum."
+        value: ${{ jobs.analyze.outputs.coverage-status }}
+
+jobs:
+  analyze:
+    name: qulib analyze gate
+    runs-on: ubuntu-latest
+    outputs:
+      gate: ${{ steps.qulib.outputs.gate }}
+      release-confidence: ${{ steps.qulib.outputs.release-confidence }}
+      coverage-status: ${{ steps.qulib.outputs.coverage-status }}
+    steps:
+      - name: Check out caller repo
+        if: ${{ inputs.checkout }}
+        uses: actions/checkout@v4
+
+      # The composite action lives in this repo, so check it out to a subdir
+      # to reference it by local path. (When the action is published, callers
+      # use `uses: TapeshN/qulib/.github/actions/qulib-analyze@v1` directly and
+      # do not need this step.)
+      - name: Check out qulib (for the composite action)
+        uses: actions/checkout@v4
+        with:
+          repository: TapeshN/qulib
+          ref: ${{ inputs.qulib-version != 'latest' && format('v{0}', inputs.qulib-version) || 'main' }}
+          path: .qulib-action
+
+      - name: Write auth storage-state secret to a file
+        id: auth
+        shell: bash
+        env:
+          AUTH_STATE: ${{ secrets.auth-storage-state }}
+        run: |
+          set -euo pipefail
+          if [ -n "${AUTH_STATE:-}" ]; then
+            printf '%s' "$AUTH_STATE" > "$RUNNER_TEMP/qulib-storage-state.json"
+            echo "path=$RUNNER_TEMP/qulib-storage-state.json" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run qulib analyze gate
+        id: qulib
+        uses: ./.qulib-action/.github/actions/qulib-analyze
+        with:
+          url: ${{ inputs.url }}
+          fail-on: ${{ inputs.fail-on }}
+          qulib-version: ${{ inputs.qulib-version }}
+          repo: ${{ inputs.repo }}
+          config: ${{ inputs.config }}
+          auth-storage-state: ${{ steps.auth.outputs.path || '' }}
+          extra-args: ${{ inputs.extra-args }}
+          node-version: ${{ inputs.node-version }}

--- a/README.md
+++ b/README.md
@@ -84,6 +84,83 @@ Default **`analyze_app`** responses are **summary-first** (top gaps, cost summar
 
 ---
 
+## CI integration (GitHub Actions)
+
+Gate your deploys on Qulib's **honest agent-summary verdict** (`pass` / `warn` / `fail`) with a drop-in action. There are two surfaces — pick whichever fits your CI:
+
+### Option A — composite action (drop into an existing job)
+
+```yaml
+# .github/workflows/qa.yml
+jobs:
+  qa:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Qulib analyze gate
+        uses: TapeshN/qulib/.github/actions/qulib-analyze@v1
+        with:
+          url: https://your-app.example.com
+          fail-on: fail        # fail (default) | warn | never
+          qulib-version: latest # pin a version for reproducible CI
+```
+
+### Option B — reusable workflow (whole job in one line)
+
+```yaml
+# .github/workflows/qa.yml
+jobs:
+  qa:
+    uses: TapeshN/qulib/.github/workflows/qulib-analyze.yml@v1
+    with:
+      url: https://your-app.example.com
+      fail-on: warn
+    # secrets:
+    #   auth-storage-state: ${{ secrets.QULIB_STORAGE_STATE }}
+```
+
+### How the gate decides
+
+The action runs `@qulib/core analyze --url <url> --agent-summary`, which emits the stable agent-summary JSON. The CLI itself **always exits 0** — the verdict lives in the `gate` field — so the action reads `gate` and turns it into a CI exit code:
+
+| `gate` | `fail-on: fail` (default) | `fail-on: warn` | `fail-on: never` |
+|---|---|---|---|
+| `pass` | ✅ pass | ✅ pass | ✅ pass |
+| `warn` | ✅ pass | ❌ **fail** | ✅ pass |
+| `fail` | ❌ **fail** | ❌ **fail** | ✅ pass |
+
+A `fail` gate means a **critical gap**, a **blocked scan**, **null/too-low confidence**, or an **auth-required surface** that was never exercised — Qulib never silently passes an unevaluated deployment.
+
+Every run **uploads the agent-summary JSON as an artifact** (`qulib-agent-summary`) and writes a **job summary** table with the gate, release confidence, top risks, and honesty notes.
+
+### Inputs (composite action)
+
+| Input | Default | Description |
+|---|---|---|
+| `url` | *(required)* | Base URL of the deployed app to analyze. |
+| `fail-on` | `fail` | Gate policy: `fail`, `warn`, or `never`. |
+| `qulib-version` | `latest` | npm version/dist-tag of `@qulib/core` run via `npx`. Pin for reproducibility. |
+| `repo` | `""` | Optional path to the app repo for repo-aware analysis. |
+| `config` | `""` | Path to a qulib config file relative to the working dir. |
+| `auth-storage-state` | `""` | Path to a Playwright storage-state JSON for authenticated scans (write a secret to a file first — never inline it). |
+| `extra-args` | `""` | Extra raw flags appended to `qulib analyze` (advanced). |
+| `node-version` | `20` | Node.js version to set up. |
+| `install-browser` | `true` | Install Playwright Chromium (Qulib crawls with Playwright). |
+| `output-path` | `qulib-agent-summary.json` | Where to write the raw agent-summary JSON. |
+
+### Outputs (composite action)
+
+| Output | Description |
+|---|---|
+| `gate` | The verdict: `pass` \| `warn` \| `fail`. |
+| `release-confidence` | Release confidence `0–100`, or `n/a` when null. |
+| `coverage-status` | Coverage status enum (`ok` \| `thin` \| `blocked-by-auth` \| …). |
+| `blocked` | `true` if the gate violated the `fail-on` policy (the job was failed). |
+| `summary-path` | Path to the written agent-summary JSON artifact. |
+
+> The composite action lives at [`.github/actions/qulib-analyze`](./.github/actions/qulib-analyze) and the reusable workflow at [`.github/workflows/qulib-analyze.yml`](./.github/workflows/qulib-analyze.yml). Reference them at a tag (`@v1`) for stability.
+
+---
+
 ## Release confidence (short)
 
 - Score starts from **100** and is reduced by **high / medium / low** gaps (see [`gaps.ts`](./packages/core/src/tools/scoring/gaps.ts)).


### PR DESCRIPTION
Ships qulib's agent-summary analyze gate as a drop-in CI primitive so consumers can gate deploys on the honest pass/warn/fail verdict without hand-wiring the CLI. High adoption leverage for an OSS QA tool.

## What landed
- **Composite action** `.github/actions/qulib-analyze` — declares inputs/outputs, runs `@qulib/core analyze --url <url> --agent-summary`, captures the JSON, and maps the `gate` verdict to a CI exit code via a pure-stdlib `gate.mjs`. Uploads the agent-summary as an artifact and writes a job summary table (gate, confidence, top risks, honesty notes).
- **Reusable workflow** `.github/workflows/qulib-analyze.yml` — a `workflow_call` wrapper over the same action, with an optional auth storage-state secret written to a temp file (never inlined).
- **Selftest workflow** `.github/workflows/qulib-action-selftest.yml` — proves `gate.mjs` end-to-end in CI against the in-repo **offline fixture** (no live external URL), asserting the exit code matches the verdict under each `fail-on` policy + the error cases.
- **README** — CI integration section documenting both surfaces and the gate truth table.

## Why the gate logic lives in the action, not the CLI
`qulib analyze --agent-summary` prints the verdict in the JSON `gate` field but **always exits 0** — the pass/fail decision is intentionally the consumer's. This action makes that decision under a `fail-on` policy (`fail` default | `warn` | `never`):

| `gate` | `fail-on: fail` | `fail-on: warn` | `fail-on: never` |
|---|---|---|---|
| pass | pass | pass | pass |
| warn | pass | **fail** | pass |
| fail | **fail** | **fail** | pass |

## Verification (witnesses I did not author)
- `actionlint 1.7.12` clean (exit 0) on all workflows — caught and fixed a real bug (`secrets` context not allowed in a step `if:`).
- Composite-action schema structurally validated (composite outputs carry `value:`, every input has a description/default, every `run:` step declares `shell:`, all `inputs.*` refs resolved).
- The **exact action command sequence** reproduced offline against the fixture server: `analyze --agent-summary` -> JSON file -> `gate.mjs`. Real witness JSON had `gate=warn` -> exit **0** under `fail-on:fail`, exit **1** under `fail-on:warn`, exit **0** under `fail-on:never`; error cases (bad policy / missing file / no gate field) exit **2**.

Scope is tight to the lane: only `README.md` + `.github/` were touched. No release tooling (package.json / CHANGELOG / VERSION / publish.yml / roadmap.json) was modified.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)