### PR TITLE
Add evidence golden eval suite for the P4 collectors and P5 dogfood path

### DIFF
--- a/packages/core/evals/golden/evidence/ci-all-green.json
+++ b/packages/core/evals/golden/evidence/ci-all-green.json
@@ -1,0 +1,27 @@
+{
+  "id": "ci-all-green",
+  "suite": "evidence",
+  "description": "ci-results collector: fresh run, build passed, 168/168 tests pass → applicable, score 100, no recommendations.",
+  "tags": ["ci-results", "applicable", "happy-path", "no-llm"],
+  "input": {
+    "collector": "ci-results",
+    "collectedAt": "2026-06-04T04:46:20.000Z",
+    "run": {
+      "completedAt": "2026-06-04T04:46:20.000Z",
+      "buildPassed": true,
+      "testsPassed": 168,
+      "testsFailed": 0,
+      "testsErrored": 0,
+      "runUrl": "https://github.com/TapeshN/notquality/actions/runs/26931370208",
+      "workflowName": "E2E (playwright)"
+    }
+  },
+  "expected": {
+    "source": "ci-results",
+    "applicability": "applicable",
+    "scoreExact": 100,
+    "blocking": false,
+    "evidenceIncludes": ["168/168 tests passed", "100% pass-rate"],
+    "evidenceExcludes": ["Build FAILED", "stale"]
+  }
+}

--- a/packages/core/evals/golden/evidence/ci-build-failed.json
+++ b/packages/core/evals/golden/evidence/ci-build-failed.json
@@ -1,0 +1,26 @@
+{
+  "id": "ci-build-failed",
+  "suite": "evidence",
+  "description": "ci-results collector: build FAILED → applicable, score 0, blocking recommendation, no fabricated pass-rate.",
+  "tags": ["ci-results", "applicable", "build-failure", "no-llm"],
+  "input": {
+    "collector": "ci-results",
+    "collectedAt": "2026-06-04T05:00:00.000Z",
+    "run": {
+      "completedAt": "2026-06-04T04:46:20.000Z",
+      "buildPassed": false,
+      "testsPassed": 0,
+      "testsFailed": 0,
+      "testsErrored": 0,
+      "workflowName": "CI (validate)"
+    }
+  },
+  "expected": {
+    "source": "ci-results",
+    "applicability": "applicable",
+    "scoreExact": 0,
+    "blocking": false,
+    "recommendationsMinLength": 1,
+    "evidenceIncludes": ["Build FAILED"]
+  }
+}

--- a/packages/core/evals/golden/evidence/ci-stale-run.json
+++ b/packages/core/evals/golden/evidence/ci-stale-run.json
@@ -1,0 +1,26 @@
+{
+  "id": "ci-stale-run",
+  "suite": "evidence",
+  "description": "ci-results collector: run older than the 24h stale threshold → coerced to unknown, score 0, re-run recommendation (honest abstention).",
+  "tags": ["ci-results", "unknown", "stale", "no-llm"],
+  "input": {
+    "collector": "ci-results",
+    "collectedAt": "2026-06-06T05:00:00.000Z",
+    "run": {
+      "completedAt": "2026-06-04T04:46:20.000Z",
+      "buildPassed": true,
+      "testsPassed": 168,
+      "testsFailed": 0,
+      "testsErrored": 0,
+      "workflowName": "E2E (playwright)"
+    }
+  },
+  "expected": {
+    "source": "ci-results",
+    "applicability": "unknown",
+    "scoreExact": 0,
+    "blocking": false,
+    "recommendationsMinLength": 1,
+    "evidenceIncludes": ["stale"]
+  }
+}

--- a/packages/core/evals/golden/evidence/ci-zero-tests.json
+++ b/packages/core/evals/golden/evidence/ci-zero-tests.json
@@ -1,0 +1,25 @@
+{
+  "id": "ci-zero-tests",
+  "suite": "evidence",
+  "description": "ci-results collector: build passed but 0 tests executed → unknown (no test signal), never PASS-by-default.",
+  "tags": ["ci-results", "unknown", "no-signal", "no-llm"],
+  "input": {
+    "collector": "ci-results",
+    "collectedAt": "2026-06-04T05:00:00.000Z",
+    "run": {
+      "completedAt": "2026-06-04T04:46:20.000Z",
+      "buildPassed": true,
+      "testsPassed": 0,
+      "testsFailed": 0,
+      "testsErrored": 0,
+      "workflowName": "CI (validate)"
+    }
+  },
+  "expected": {
+    "source": "ci-results",
+    "applicability": "unknown",
+    "scoreExact": 0,
+    "blocking": false,
+    "evidenceIncludes": ["0 tests executed"]
+  }
+}

--- a/packages/core/evals/golden/evidence/fusion-notquality-dogfood.json
+++ b/packages/core/evals/golden/evidence/fusion-notquality-dogfood.json
@@ -1,0 +1,63 @@
+{
+  "id": "fusion-notquality-dogfood",
+  "suite": "evidence",
+  "description": "P5 dogfood fusion: notquality real CI + PR + automation signals → computeReleaseConfidence emits verdict=caution, score~76, level 4. Judge grades the narrative (SKIP without key).",
+  "tags": ["fusion", "dogfood", "p5", "judge"],
+  "input": {
+    "collector": "fusion",
+    "collectedAt": "2026-06-04T09:00:00.000Z",
+    "fusion": {
+      "run": {
+        "completedAt": "2026-06-04T04:46:20.000Z",
+        "buildPassed": true,
+        "testsPassed": 168,
+        "testsFailed": 0,
+        "testsErrored": 0,
+        "testsFlaky": 0,
+        "runUrl": "https://github.com/TapeshN/notquality/actions/runs/26931370208",
+        "workflowName": "E2E (playwright)"
+      },
+      "pr": {
+        "number": 52,
+        "url": "https://github.com/TapeshN/notquality/pull/52",
+        "reviewDecision": null,
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [
+          { "state": "SUCCESS", "name": "validate" },
+          { "state": "SUCCESS", "name": "playwright" },
+          { "state": "SUCCESS", "name": "Vercel" },
+          { "state": "SUCCESS", "name": "Vercel Preview Comments" }
+        ],
+        "noPr": false
+      },
+      "automation": {
+        "source": "test-automation",
+        "score": 65,
+        "weight": 0.22,
+        "applicability": "applicable",
+        "blocking": false,
+        "evidence": [
+          "Automation maturity: L3 — building maturity (score 65)",
+          "29 E2E spec files, 168 runnable tests, Playwright + CI wired.",
+          "No vitest/jest unit tests yet (component-test-ratio = 0)."
+        ],
+        "recommendations": [
+          "Add vitest/jest unit tests for lib/ to raise component-test-ratio."
+        ],
+        "collector": { "tool": "qulib_score_automation.pre-scored" }
+      },
+      "policy": {
+        "passThreshold": 80,
+        "failThreshold": 30,
+        "maxListLength": 5,
+        "requiredSources": []
+      }
+    }
+  },
+  "expected": {
+    "verdict": "caution",
+    "confidenceScore": { "min": 70, "max": 82 },
+    "level": { "min": 4, "max": 4 },
+    "contributionSources": ["ci-results", "deploy-metadata", "test-automation"]
+  }
+}

--- a/packages/core/evals/golden/evidence/pr-all-green.json
+++ b/packages/core/evals/golden/evidence/pr-all-green.json
@@ -1,0 +1,30 @@
+{
+  "id": "pr-all-green",
+  "suite": "evidence",
+  "description": "pr-metadata collector: mergeable PR #52, all 4 status checks SUCCESS, no blocking review → applicable, deploy-metadata, score 80.",
+  "tags": ["pr-metadata", "applicable", "happy-path", "no-llm"],
+  "input": {
+    "collector": "pr-metadata",
+    "collectedAt": "2026-06-04T09:00:00.000Z",
+    "pr": {
+      "number": 52,
+      "url": "https://github.com/TapeshN/notquality/pull/52",
+      "reviewDecision": null,
+      "mergeable": "MERGEABLE",
+      "statusCheckRollup": [
+        { "state": "SUCCESS", "name": "validate" },
+        { "state": "SUCCESS", "name": "playwright" },
+        { "state": "SUCCESS", "name": "Vercel" },
+        { "state": "SUCCESS", "name": "Vercel Preview Comments" }
+      ],
+      "noPr": false
+    }
+  },
+  "expected": {
+    "source": "deploy-metadata",
+    "applicability": "applicable",
+    "scoreExact": 80,
+    "blocking": false,
+    "evidenceIncludes": ["PR #52", "4 passed, 0 failed"]
+  }
+}

--- a/packages/core/evals/golden/evidence/pr-changes-requested.json
+++ b/packages/core/evals/golden/evidence/pr-changes-requested.json
@@ -1,0 +1,29 @@
+{
+  "id": "pr-changes-requested",
+  "suite": "evidence",
+  "description": "pr-metadata collector: CHANGES_REQUESTED + one failing check → applicable, score deducted, address-review recommendation.",
+  "tags": ["pr-metadata", "applicable", "review-blocked", "no-llm"],
+  "input": {
+    "collector": "pr-metadata",
+    "collectedAt": "2026-06-04T09:00:00.000Z",
+    "pr": {
+      "number": 77,
+      "url": "https://github.com/TapeshN/notquality/pull/77",
+      "reviewDecision": "CHANGES_REQUESTED",
+      "mergeable": "MERGEABLE",
+      "statusCheckRollup": [
+        { "state": "SUCCESS", "name": "validate" },
+        { "state": "FAILURE", "name": "playwright" }
+      ],
+      "noPr": false
+    }
+  },
+  "expected": {
+    "source": "deploy-metadata",
+    "applicability": "applicable",
+    "scoreBand": { "min": 25, "max": 45 },
+    "blocking": false,
+    "recommendationsMinLength": 2,
+    "evidenceIncludes": ["CHANGES_REQUESTED", "Check FAILED: playwright"]
+  }
+}

--- a/packages/core/evals/golden/evidence/pr-checks-pending.json
+++ b/packages/core/evals/golden/evidence/pr-checks-pending.json
@@ -1,0 +1,29 @@
+{
+  "id": "pr-checks-pending",
+  "suite": "evidence",
+  "description": "pr-metadata collector: all status checks still PENDING → unknown (cannot score readiness honestly), wait recommendation.",
+  "tags": ["pr-metadata", "unknown", "pending", "no-llm"],
+  "input": {
+    "collector": "pr-metadata",
+    "collectedAt": "2026-06-04T09:00:00.000Z",
+    "pr": {
+      "number": 88,
+      "url": "https://github.com/TapeshN/notquality/pull/88",
+      "reviewDecision": null,
+      "mergeable": "MERGEABLE",
+      "statusCheckRollup": [
+        { "state": "PENDING", "name": "validate" },
+        { "state": "PENDING", "name": "playwright" }
+      ],
+      "noPr": false
+    }
+  },
+  "expected": {
+    "source": "deploy-metadata",
+    "applicability": "unknown",
+    "scoreExact": 0,
+    "blocking": false,
+    "recommendationsMinLength": 1,
+    "evidenceIncludes": ["still pending"]
+  }
+}

--- a/packages/core/evals/golden/evidence/pr-none.json
+++ b/packages/core/evals/golden/evidence/pr-none.json
@@ -1,0 +1,21 @@
+{
+  "id": "pr-none",
+  "suite": "evidence",
+  "description": "pr-metadata collector: no PR for this ref (direct push) → not_applicable, abstains honestly, fabricates no PR number or URL.",
+  "tags": ["pr-metadata", "not-applicable", "no-fabrication", "no-llm"],
+  "input": {
+    "collector": "pr-metadata",
+    "collectedAt": "2026-06-04T09:00:00.000Z",
+    "pr": {
+      "noPr": true
+    }
+  },
+  "expected": {
+    "source": "deploy-metadata",
+    "applicability": "not_applicable",
+    "scoreExact": 0,
+    "blocking": false,
+    "evidenceIncludes": ["No pull request exists"],
+    "evidenceExcludes": ["PR #", "https://github.com/"]
+  }
+}

--- a/packages/core/evals/ledger.jsonl
+++ b/packages/core/evals/ledger.jsonl
@@ -5,3 +5,7 @@
 {"ts":"2026-06-04T09:12:11.944Z","suite":"scaffold","outcome":"PASS","score":0,"counts":{"pass":6,"warn":0,"fail":0,"skip":0,"total":6},"qulibVersion":"0.8.2"}
 {"ts":"2026-06-04T09:12:11.947Z","suite":"score-automation","outcome":"PASS","score":0,"counts":{"pass":4,"warn":0,"fail":0,"skip":0,"total":4},"qulibVersion":"0.8.2"}
 {"ts":"2026-06-04T09:12:11.948Z","suite":"confidence","outcome":"PASS","score":0,"counts":{"pass":4,"warn":0,"fail":0,"skip":0,"total":4},"qulibVersion":"0.8.2"}
+{"ts":"2026-06-08T05:42:42.168Z","suite":"scaffold","outcome":"PASS","score":0,"counts":{"pass":6,"warn":0,"fail":0,"skip":0,"total":6},"qulibVersion":"0.8.2","tenantId":"default"}
+{"ts":"2026-06-08T05:42:42.170Z","suite":"score-automation","outcome":"PASS","score":0,"counts":{"pass":4,"warn":0,"fail":0,"skip":0,"total":4},"qulibVersion":"0.8.2","tenantId":"default"}
+{"ts":"2026-06-08T05:42:42.172Z","suite":"confidence","outcome":"PASS","score":0,"counts":{"pass":4,"warn":0,"fail":0,"skip":0,"total":4},"qulibVersion":"0.8.2","tenantId":"default"}
+{"ts":"2026-06-08T05:42:42.173Z","suite":"evidence","outcome":"PASS","score":0,"counts":{"pass":9,"warn":0,"fail":0,"skip":0,"total":9},"qulibVersion":"0.8.2","tenantId":"default"}

--- a/packages/core/evals/runner/index.ts
+++ b/packages/core/evals/runner/index.ts
@@ -25,6 +25,7 @@ import { EVAL_SUITES, loadCases, ledgerPath } from './load-cases.js';
 import { runScaffoldCase } from './run-scaffold.js';
 import { runScoreAutomationCase } from './run-score-automation.js';
 import { runConfidenceCase } from './run-confidence.js';
+import { runEvidenceCase } from './run-evidence.js';
 import { judgeConfigured, type JudgeImpl } from './judge-bridge.js';
 import { summarize, toLedgerEntry, resolveTenantId } from './rollup.js';
 
@@ -60,6 +61,7 @@ export async function runSuite(suite: EvalSuite, opts: RunOptions = {}): Promise
   for (const c of cases) {
     if (suite === 'scaffold') results.push(await runScaffoldCase(c, opts.judge));
     else if (suite === 'score-automation') results.push(await runScoreAutomationCase(c, opts.judge));
+    else if (suite === 'evidence') results.push(await runEvidenceCase(c, opts.judge));
     else results.push(await runConfidenceCase(c, opts.judge));
   }
   const finishedAt = new Date().toISOString();
@@ -100,7 +102,12 @@ function parseArgs(argv: string[]): { suites?: EvalSuite[]; appendLedger: boolea
     const arg = argv[i];
     if (arg === '--suite') {
       const next = argv[i + 1];
-      if (next === 'scaffold' || next === 'score-automation' || next === 'confidence') {
+      if (
+        next === 'scaffold' ||
+        next === 'score-automation' ||
+        next === 'confidence' ||
+        next === 'evidence'
+      ) {
         suites.push(next);
         i += 1;
       } else {

--- a/packages/core/evals/runner/load-cases.ts
+++ b/packages/core/evals/runner/load-cases.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import type { EvalCase, EvalSuite } from '../types.js';
 
-export const EVAL_SUITES: readonly EvalSuite[] = ['scaffold', 'score-automation', 'confidence'] as const;
+export const EVAL_SUITES: readonly EvalSuite[] = ['scaffold', 'score-automation', 'confidence', 'evidence'] as const;
 
 /** Shared envelope validator. `input`/`expected` are passthrough objects (suite narrows them). */
 const EvalCaseSchema = z.object({
@@ -22,7 +22,7 @@ const EvalCaseSchema = z.object({
     .string()
     .min(1)
     .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'case id must be kebab-case'),
-  suite: z.enum(['scaffold', 'score-automation', 'confidence']),
+  suite: z.enum(['scaffold', 'score-automation', 'confidence', 'evidence']),
   description: z.string().min(1),
   input: z.record(z.unknown()),
   expected: z.record(z.unknown()),

--- a/packages/core/evals/runner/run-evidence.ts
+++ b/packages/core/evals/runner/run-evidence.ts
@@ -1,0 +1,335 @@
+/**
+ * `evidence` suite executor for the eval runner.
+ *
+ * Closes the P4/P5 eval-coverage gap: the evidence COLLECTORS that feed
+ * `computeReleaseConfidence` (ci-results-adapter, pr-metadata-adapter) and the P5
+ * notquality DOGFOOD fusion path shipped after qulibVersion 0.8.2 with unit tests
+ * but no golden eval suite wired into `npm run eval` / the ledger. Root doctrine #11:
+ * everything ships wrapped in evaluation — a collector with no scored golden run is
+ * an un-evaluated surface. This suite scores those collectors against a frozen golden
+ * corpus and appends a real ledger row.
+ *
+ * Three collector kinds, discriminated by `input.collector`:
+ *   - "ci-results"  → runs `ciResultsToEvidence(input.run)`           → asserts EvidenceItem
+ *   - "pr-metadata" → runs `prMetadataToEvidence(input.pr)`           → asserts EvidenceItem
+ *   - "fusion"      → runs the FULL dogfood path (collectors → computeReleaseConfidence)
+ *                     → asserts the fused ReleaseConfidence, then the judge grades the
+ *                       narrative against confidence-narrative-v1 (SKIP without a key).
+ *
+ * Honesty: deterministic asserts are the hard CI gate and ALWAYS run. The LLM-judge
+ * only grades the fusion narrative and can only downgrade a PASS; it SKIPs without an
+ * ANTHROPIC_API_KEY (the deterministic asserts still gate). A collector-only case
+ * carries no judge — its outcome is purely the deterministic verdict.
+ *
+ * Golden case shape (suite-specific `input`/`expected`):
+ *   input.collector  : "ci-results" | "pr-metadata" | "fusion"
+ *   input.run        : CiRunInput            (ci-results cases)
+ *   input.pr         : PrMetadataInput       (pr-metadata cases)
+ *   input.fusion     : { run, pr, automation, policy? } (fusion cases)
+ *   input.collectedAt: ISO-8601 freeze timestamp (keeps freshness deterministic)
+ *
+ *   expected.source              : the EvidenceSourceKind the collector must emit
+ *   expected.applicability       : 'applicable' | 'not_applicable' | 'unknown'
+ *   expected.scoreExact?         : exact 0..100 score (collector cases)
+ *   expected.scoreBand?          : { min, max } score band (collector cases)
+ *   expected.scoreNull?          : true if score must be null
+ *   expected.blocking?           : exact blocking flag
+ *   expected.evidenceIncludes?   : substrings every one of which must appear in some evidence line
+ *   expected.evidenceExcludes?   : substrings NONE of which may appear (no-fabrication guard)
+ *   expected.recommendationsMinLength? : minimum recommendations[] count
+ *   // fusion-only:
+ *   expected.verdict?            : the fused ConfidenceVerdict
+ *   expected.confidenceScore?    : { min, max } band on the fused score
+ *   expected.level?              : { min, max } band on the fused level
+ *   expected.contributionSources?: every source that must appear in contributions[]
+ */
+import { z } from 'zod';
+import type { EvalCase, EvalCaseResult, EvalOutcome } from '../types.js';
+import {
+  EvidenceItemSchema,
+  ConfidenceInputSchema,
+  ReleaseConfidenceSchema,
+  ConfidenceVerdictSchema,
+  type EvidenceItem,
+} from '../../src/schemas/confidence.schema.js';
+import { ciResultsToEvidence, type CiRunInput } from '../../src/adapters/ci-results-adapter.js';
+import { prMetadataToEvidence, type PrMetadataInput } from '../../src/adapters/pr-metadata-adapter.js';
+import { computeReleaseConfidence } from '../../src/tools/scoring/confidence.js';
+import { combineCaseOutcome } from './rollup.js';
+import { judgeOrSkip, type JudgeImpl } from './judge-bridge.js';
+
+// --- Suite-specific input/expected validators -------------------------------
+
+const CollectorKind = z.enum(['ci-results', 'pr-metadata', 'fusion']);
+
+/**
+ * Loose validator — the precise CiRunInput/PrMetadataInput shapes are owned by the
+ * adapters themselves (and re-validated via EvidenceItemSchema on their output). We
+ * only assert the envelope here so a malformed case fails loud (GL-005 / fail-once).
+ */
+const InputSchema = z
+  .object({
+    collector: CollectorKind,
+    collectedAt: z.string().datetime().optional(),
+    run: z.record(z.unknown()).optional(),
+    pr: z.record(z.unknown()).optional(),
+    fusion: z
+      .object({
+        run: z.record(z.unknown()),
+        pr: z.record(z.unknown()),
+        automation: z.record(z.unknown()).optional(),
+        policy: z.record(z.unknown()).optional(),
+      })
+      .optional(),
+  })
+  .passthrough();
+
+const ExpectedSchema = z.object({
+  source: z.string().optional(),
+  applicability: z.enum(['applicable', 'not_applicable', 'unknown']).optional(),
+  scoreExact: z.number().min(0).max(100).optional(),
+  scoreBand: z.object({ min: z.number().min(0).max(100), max: z.number().min(0).max(100) }).optional(),
+  scoreNull: z.boolean().optional(),
+  blocking: z.boolean().optional(),
+  evidenceIncludes: z.array(z.string()).optional(),
+  evidenceExcludes: z.array(z.string()).optional(),
+  recommendationsMinLength: z.number().int().min(0).optional(),
+  // fusion-only
+  verdict: ConfidenceVerdictSchema.optional(),
+  confidenceScore: z.object({ min: z.number().min(0).max(100), max: z.number().min(0).max(100) }).optional(),
+  level: z.object({ min: z.number().int().min(1).max(5), max: z.number().int().min(1).max(5) }).optional(),
+  contributionSources: z.array(z.string()).optional(),
+});
+
+type Expected = z.infer<typeof ExpectedSchema>;
+
+/**
+ * Run one evidence golden case end-to-end. Never throws — asserts capture failure.
+ * `judge` is injectable so the judge-active path is testable offline (defaults to the
+ * real judge, which SKIPs without an ANTHROPIC_API_KEY).
+ */
+export async function runEvidenceCase(c: EvalCase, judge?: JudgeImpl): Promise<EvalCaseResult> {
+  const start = Date.now();
+  const notes: string[] = [];
+  let outcome: EvalOutcome = 'PASS';
+
+  const fail = (msg: string): void => {
+    notes.push(`FAIL: ${msg}`);
+    outcome = 'FAIL';
+  };
+
+  const inputParsed = InputSchema.safeParse(c.input);
+  const expectedParsed = ExpectedSchema.safeParse(c.expected);
+  if (!inputParsed.success) {
+    fail(`malformed evidence input: ${inputParsed.error.message}`);
+    return finalize(c, outcome, notes, start);
+  }
+  if (!expectedParsed.success) {
+    fail(`malformed expected block: ${expectedParsed.error.message}`);
+    return finalize(c, outcome, notes, start);
+  }
+  const input = inputParsed.data;
+  const expected = expectedParsed.data;
+  const collectedAt = input.collectedAt;
+
+  // ---- Collector cases (ci-results | pr-metadata) ----
+  if (input.collector === 'ci-results' || input.collector === 'pr-metadata') {
+    let item: EvidenceItem;
+    try {
+      item =
+        input.collector === 'ci-results'
+          ? ciResultsToEvidence(input.run as unknown as CiRunInput, collectedAt)
+          : prMetadataToEvidence(input.pr as unknown as PrMetadataInput, collectedAt);
+    } catch (err) {
+      const m = err instanceof Error ? err.message : String(err);
+      fail(`collector threw: ${m}`);
+      return finalize(c, outcome, notes, start);
+    }
+
+    // 1) The produced EvidenceItem must satisfy its own schema (shape gate — the item
+    //    is what the scorer consumes, so a malformed item poisons every downstream score).
+    const shape = EvidenceItemSchema.safeParse(item);
+    if (!shape.success) {
+      fail(`EvidenceItem fails EvidenceItemSchema: ${shape.error.message}`);
+    } else {
+      notes.push('shape: EvidenceItemSchema OK');
+    }
+
+    assertEvidenceItem(item, expected, notes, fail);
+    return finalize(c, outcome, notes, start);
+  }
+
+  // ---- Fusion case (full dogfood path) ----
+  const fusion = input.fusion;
+  if (!fusion) {
+    fail('collector="fusion" requires input.fusion { run, pr, automation? }');
+    return finalize(c, outcome, notes, start);
+  }
+
+  let rc: ReturnType<typeof computeReleaseConfidence>;
+  let evidence: EvidenceItem[];
+  try {
+    const e2e = ciResultsToEvidence(fusion.run as unknown as CiRunInput, collectedAt);
+    const pr = prMetadataToEvidence(fusion.pr as unknown as PrMetadataInput, collectedAt);
+    evidence = [e2e, pr];
+    if (fusion.automation) {
+      const automation = EvidenceItemSchema.parse({
+        collectedAt: collectedAt ?? new Date().toISOString(),
+        ...fusion.automation,
+      });
+      evidence.push(automation);
+    }
+    const confInput = ConfidenceInputSchema.parse({
+      subject: { kind: 'release', ref: c.id, tenantId: 'notquality' },
+      evidence,
+      ...(fusion.policy ? { policy: fusion.policy } : {}),
+    });
+    rc = computeReleaseConfidence(confInput);
+  } catch (err) {
+    const m = err instanceof Error ? err.message : String(err);
+    fail(`fusion path threw: ${m}`);
+    return finalize(c, outcome, notes, start);
+  }
+
+  // Output must satisfy ReleaseConfidenceSchema (shape gate).
+  const shape = ReleaseConfidenceSchema.safeParse(rc);
+  if (!shape.success) {
+    fail(`ReleaseConfidence output fails its own schema: ${shape.error.message}`);
+  } else {
+    notes.push('shape: ReleaseConfidenceSchema OK');
+  }
+
+  if (expected.verdict !== undefined) {
+    if (rc.verdict !== expected.verdict) fail(`verdict expected "${expected.verdict}", got "${rc.verdict}"`);
+    else notes.push(`verdict: ${rc.verdict} OK`);
+  }
+  if (expected.confidenceScore !== undefined) {
+    const { min, max } = expected.confidenceScore;
+    if (rc.confidenceScore === null) fail(`confidenceScore expected in [${min}, ${max}], got null`);
+    else if (rc.confidenceScore < min || rc.confidenceScore > max)
+      fail(`confidenceScore ${rc.confidenceScore} outside [${min}, ${max}]`);
+    else notes.push(`confidenceScore: ${rc.confidenceScore} ∈ [${min}, ${max}] OK`);
+  }
+  if (expected.level !== undefined) {
+    const { min, max } = expected.level;
+    if (rc.level < min || rc.level > max) fail(`level ${rc.level} outside [${min}, ${max}]`);
+    else notes.push(`level: ${rc.level} ∈ [${min}, ${max}] OK`);
+  }
+  if (expected.contributionSources !== undefined) {
+    const got = new Set(rc.contributions.map((cc) => cc.source));
+    for (const src of expected.contributionSources) {
+      if (!got.has(src as never)) fail(`expected contribution source "${src}" not found in [${[...got].join(', ')}]`);
+      else notes.push(`contribution source: ${src} OK`);
+    }
+  }
+
+  // Judge (P4): grade the dogfood narrative for faithfulness to the fused result.
+  // SKIPs gracefully without ANTHROPIC_API_KEY — deterministic asserts remain the gate.
+  const narrative = buildFusionNarrative(rc, evidence);
+  const verdict = await judgeOrSkip({ suite: 'confidence', narrative, releaseConfidence: rc }, judge);
+  const caseOutcome = combineCaseOutcome(outcome, verdict.outcome);
+  return {
+    caseId: c.id,
+    suite: 'evidence',
+    outcome: caseOutcome,
+    deterministic: { outcome, notes },
+    judge: verdict,
+    latencyMs: Date.now() - start,
+  };
+}
+
+/** Apply the EvidenceItem-level deterministic asserts shared by collector cases. */
+function assertEvidenceItem(
+  item: EvidenceItem,
+  expected: Expected,
+  notes: string[],
+  fail: (msg: string) => void
+): void {
+  if (expected.source !== undefined) {
+    if (item.source !== expected.source) fail(`source expected "${expected.source}", got "${item.source}"`);
+    else notes.push(`source: ${item.source} OK`);
+  }
+  if (expected.applicability !== undefined) {
+    if (item.applicability !== expected.applicability)
+      fail(`applicability expected "${expected.applicability}", got "${item.applicability}"`);
+    else notes.push(`applicability: ${item.applicability} OK`);
+  }
+  if (expected.scoreNull === true) {
+    if (item.score !== null) fail(`score expected null, got ${item.score}`);
+    else notes.push('score: null OK');
+  }
+  if (expected.scoreExact !== undefined) {
+    if (item.score !== expected.scoreExact) fail(`score expected exactly ${expected.scoreExact}, got ${item.score}`);
+    else notes.push(`score: ${item.score} OK`);
+  }
+  if (expected.scoreBand !== undefined) {
+    const { min, max } = expected.scoreBand;
+    if (item.score === null) fail(`score expected in [${min}, ${max}], got null`);
+    else if (item.score < min || item.score > max) fail(`score ${item.score} outside [${min}, ${max}]`);
+    else notes.push(`score: ${item.score} ∈ [${min}, ${max}] OK`);
+  }
+  if (expected.blocking !== undefined) {
+    if (item.blocking !== expected.blocking) fail(`blocking expected ${expected.blocking}, got ${item.blocking}`);
+    else notes.push(`blocking: ${item.blocking} OK`);
+  }
+  if (expected.recommendationsMinLength !== undefined) {
+    if (item.recommendations.length < expected.recommendationsMinLength)
+      fail(`recommendations.length expected >= ${expected.recommendationsMinLength}, got ${item.recommendations.length}`);
+    else notes.push(`recommendations.length: ${item.recommendations.length} OK`);
+  }
+  const blob = item.evidence.join('\n');
+  if (expected.evidenceIncludes !== undefined) {
+    for (const sub of expected.evidenceIncludes) {
+      if (!blob.includes(sub)) fail(`evidence missing required substring "${sub}"`);
+      else notes.push(`evidence includes: "${sub}" OK`);
+    }
+  }
+  if (expected.evidenceExcludes !== undefined) {
+    for (const sub of expected.evidenceExcludes) {
+      // No-fabrication guard: a forbidden substring (e.g. a PR URL the input never gave)
+      // appearing means the collector invented data — a hard FAIL.
+      if (blob.includes(sub)) fail(`evidence contains forbidden (fabricated?) substring "${sub}"`);
+      else notes.push(`evidence excludes: "${sub}" OK`);
+    }
+  }
+}
+
+function finalize(c: EvalCase, outcome: EvalOutcome, notes: string[], start: number): EvalCaseResult {
+  return {
+    caseId: c.id,
+    suite: 'evidence',
+    outcome,
+    deterministic: { outcome, notes },
+    latencyMs: Date.now() - start,
+  };
+}
+
+/**
+ * Synthesize a faithful dogfood-style narrative for the judge. Mirrors the
+ * notquality-dogfood report: states the fused verdict/score/level and surfaces each
+ * collector's contribution honestly (excluded sources are named as excluded, never
+ * as failures). Faithful by construction — every number comes straight from `rc`.
+ */
+function buildFusionNarrative(
+  rc: ReturnType<typeof computeReleaseConfidence>,
+  evidence: EvidenceItem[]
+): string {
+  const lines: string[] = [];
+  const scoreStr = rc.confidenceScore !== null ? `${rc.confidenceScore}/100` : 'null (insufficient evidence)';
+  lines.push(`Dogfood release confidence: ${rc.verdict} — ${rc.label} (score ${scoreStr}, level ${rc.level}/5).`);
+  lines.push(`Fused from ${evidence.length} real delivery signals:`);
+  for (const c of rc.contributions) {
+    const scoreLabel = c.score !== null ? `${c.score}/100` : 'null';
+    const ewLabel = c.effectiveWeight > 0 ? `ew=${c.effectiveWeight.toFixed(3)}` : 'excluded';
+    lines.push(`  - ${c.source}: applicability=${c.applicability} score=${scoreLabel} ${ewLabel}`);
+  }
+  if (rc.blockers.length > 0) {
+    lines.push('Blockers:');
+    for (const b of rc.blockers) lines.push(`  - ${b}`);
+  }
+  if (rc.honestyNotes.length > 0) {
+    lines.push('Honesty notes:');
+    for (const n of rc.honestyNotes) lines.push(`  - ${n}`);
+  }
+  return lines.join('\n');
+}

--- a/packages/core/evals/types.ts
+++ b/packages/core/evals/types.ts
@@ -21,7 +21,7 @@
 export type EvalOutcome = 'PASS' | 'WARN' | 'FAIL' | 'SKIP';
 
 /** Which qulib surface a golden case exercises. One suite per CLI under eval. */
-export type EvalSuite = 'scaffold' | 'score-automation' | 'confidence';
+export type EvalSuite = 'scaffold' | 'score-automation' | 'confidence' | 'evidence';
 
 /**
  * A single golden case: an input the CLI is run against plus the expectation the
@@ -32,7 +32,7 @@ export type EvalSuite = 'scaffold' | 'score-automation' | 'confidence';
 export interface EvalCase {
   /** Stable id, kebab-case, unique within a suite. e.g. "scaffold-static-marketing". */
   id: string;
-  suite: 'scaffold' | 'score-automation' | 'confidence';
+  suite: 'scaffold' | 'score-automation' | 'confidence' | 'evidence';
   /** One-line human description of what this case probes. */
   description: string;
   /** Suite-specific input (e.g. { url, framework } for scaffold). */
@@ -97,7 +97,7 @@ export interface EvalRunSummary {
 /** One line appended to evals/ledger.jsonl per run — the self-optimizing maturity loop reads this. */
 export interface EvalLedgerEntry {
   ts: string;
-  suite: 'scaffold' | 'score-automation' | 'confidence';
+  suite: 'scaffold' | 'score-automation' | 'confidence' | 'evidence';
   outcome: EvalOutcome;
   score: number;
   counts: EvalRunSummary['counts'];


### PR DESCRIPTION
## Why

The P4 evidence collectors (`ci-results-adapter`, `pr-metadata-adapter`) and the P5 notquality dogfood fusion path merged after qulibVersion 0.8.2 with unit tests but **no golden eval suite** wired into `npm run eval` / `evals/ledger.jsonl`. The ledger's newest rows only cover `scaffold`, `score-automation`, and `confidence` — the collectors that feed `computeReleaseConfidence` and the dogfood fusion were an un-evaluated surface. Root doctrine #11: everything ships wrapped in evaluation.

## What

- **New `evidence` eval suite** — additive to the `EvalSuite` union, `EVAL_SUITES`, the loader's zod enum, `parseArgs`, and the runner dispatch. No schema field removed or renamed (additive-only).
- **`evals/runner/run-evidence.ts`** executor, three collector kinds discriminated by `input.collector`:
  - `ci-results` → runs the real `ciResultsToEvidence`, asserts the produced `EvidenceItem`.
  - `pr-metadata` → runs the real `prMetadataToEvidence`, asserts the produced `EvidenceItem`.
  - `fusion` → runs the **full dogfood path** through `computeReleaseConfidence`, asserts the fused verdict/score/level/contribution-sources, then the LLM-judge grades the narrative against `confidence-narrative-v1` (SKIP without a key).
- **Deterministic asserts are the hard gate**: schema shape (`EvidenceItemSchema` / `ReleaseConfidenceSchema`), applicability, exact/banded score, blocking flag, evidence-substring **include** + a **no-fabrication exclude** guard (a forbidden URL/PR-id appearing means the collector invented data → FAIL), and contribution sources. The judge can only downgrade a PASS; it SKIPs without `ANTHROPIC_API_KEY`.
- **9 golden cases** under `evals/golden/evidence/`: CI all-green / build-failed / stale / zero-tests; PR all-green / changes-requested / none / checks-pending; and `fusion-notquality-dogfood` (verdict=caution, score~76, level 4 — mirrors the real P5 dogfood signals).

## Witness (DoD — behavior verified vs an output I did not author)

`npm run eval` now rolls up four suites and appends a real `evidence` ledger row for HEAD:

```
[qulib:eval] judge: SKIP (no ANTHROPIC_API_KEY — deterministic asserts still gate)
[qulib:eval] scaffold: PASS  (6 pass / 0 warn / 0 fail / 0 skip of 6)
[qulib:eval] score-automation: PASS  (4 pass / 0 warn / 0 fail / 0 skip of 4)
[qulib:eval] confidence: PASS  (4 pass / 0 warn / 0 fail / 0 skip of 4)
[qulib:eval] evidence: PASS  (9 pass / 0 warn / 0 fail / 0 skip of 9)
[qulib:eval] ROLLUP: PASS
```

New ledger row on disk:
```json
{"ts":"2026-06-08T05:42:42.173Z","suite":"evidence","outcome":"PASS","score":0,"counts":{"pass":9,"warn":0,"fail":0,"skip":0,"total":9},"qulibVersion":"0.8.2","tenantId":"default"}
```

**Gate-fires proof:** deliberately mutating an expected score (100 → 42) produced `evidence: FAIL`, `ROLLUP: FAIL`, and a non-zero process exit — the deterministic asserts genuinely gate, they do not read green by default. (Reverted.)

Core tests **401/401**, mcp **17/17**, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)