### PR TITLE
Docs truth-up: 7-tool table, flagship-first READMEs, and package metadata refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Qulib
 
-**Honest QA gap analysis for deployed web apps.**
+**Release confidence for deployed web apps — the one question: should we ship?**
 
-Qulib is an opinionated harness that answers one question: **is this app ready to ship?** It prefers **honest uncertainty** over fake confidence: if auth blocks the crawl, coverage is thin, or data is incomplete, the report says so.
+Qulib fuses live-app quality evidence, automation maturity, and API coverage into a single scored verdict: **ship / caution / hold / block**. It prefers **honest uncertainty** over fake confidence: if auth blocks the crawl, coverage is thin, or data is incomplete, the report says so.
 
 **Design line:** AI should explore unknown gaps; **deterministic checks** (crawl, axe, links, console) should scale. Cost Intelligence tracks LLM usage so repeated reasoning can graduate into checks you own in CI.
 
@@ -37,8 +37,36 @@ On npm: **`@qulib/core`** (engine + CLI `qulib`) and **`@qulib/mcp`** (MCP serve
 
 ## Quick start (CLI)
 
+**Release confidence — the flagship command:**
+
+```bash
+npx @qulib/core confidence --url https://example.com
+```
+
+Returns a verdict (`ship` / `caution` / `hold` / `block`) with a 0–100 score, top risks, and recommended next checks.
+
+Add `--repo` to also score test-automation maturity and API coverage:
+
+```bash
+npx @qulib/core confidence --url https://example.com --repo .
+```
+
+**Analyze (full gap report):**
+
 ```bash
 npx @qulib/core analyze --url https://example.com
+```
+
+**Scaffold a test suite:**
+
+```bash
+npx @qulib/core scaffold --url https://example.com --framework cypress-e2e
+```
+
+**Score automation maturity (repo only, no URL needed):**
+
+```bash
+npx @qulib/core score-automation --repo /path/to/repo
 ```
 
 From a clone (repo root):
@@ -46,8 +74,6 @@ From a clone (repo root):
 ```bash
 npm run analyze -w @qulib/core -- --url https://example.com
 ```
-
-Or `cd packages/core` and `npm run analyze -- --url https://example.com`.
 
 **Smoke (no disk writes):**
 
@@ -58,8 +84,12 @@ npm run smoke
 **Cost doctor** (after a normal analyze that wrote `output/report.json`):
 
 ```bash
-cd packages/core && npx tsx src/cli/index.ts cost doctor
+npx @qulib/core cost doctor
 ```
+
+> **Note:** the config-fallback improvement is landing in a parallel PR. Until it merges, run
+> these commands from `packages/core` (where a default `qulib.config.ts` exists) or pass
+> `--config <path>` explicitly.
 
 ---
 
@@ -97,11 +127,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Qulib analyze gate
-        uses: TapeshN/qulib/.github/actions/qulib-analyze@v1
+        uses: TapeshN/qulib/.github/actions/qulib-analyze@v0.9.0
         with:
           url: https://your-app.example.com
           fail-on: fail        # fail (default) | warn | never
-          qulib-version: latest # pin a version for reproducible CI
+          qulib-version: 0.9.0 # pin a version for reproducible CI
 ```
 
 ### Option B — reusable workflow (whole job in one line)
@@ -110,7 +140,7 @@ jobs:
 # .github/workflows/qa.yml
 jobs:
   qa:
-    uses: TapeshN/qulib/.github/workflows/qulib-analyze.yml@v1
+    uses: TapeshN/qulib/.github/workflows/qulib-analyze.yml@v0.9.0
     with:
       url: https://your-app.example.com
       fail-on: warn
@@ -157,7 +187,7 @@ Every run **uploads the agent-summary JSON as an artifact** (`qulib-agent-summar
 | `blocked` | `true` if the gate violated the `fail-on` policy (the job was failed). |
 | `summary-path` | Path to the written agent-summary JSON artifact. |
 
-> The composite action lives at [`.github/actions/qulib-analyze`](./.github/actions/qulib-analyze) and the reusable workflow at [`.github/workflows/qulib-analyze.yml`](./.github/workflows/qulib-analyze.yml). Reference them at a tag (`@v1`) for stability.
+> The composite action lives at [`.github/actions/qulib-analyze`](./.github/actions/qulib-analyze) and the reusable workflow at [`.github/workflows/qulib-analyze.yml`](./.github/workflows/qulib-analyze.yml). Reference them at a tag (e.g. `@v0.9.0`) for reproducible CI.
 
 ---
 
@@ -201,7 +231,7 @@ qulib confidence --url https://example.com [--repo /path/to/repo] [--json]
 
 **Honesty over fake confidence:** sources that are `not_applicable`, `unknown`, or `null` are excluded from the denominator but reported in `contributions` and `honestyNotes`. An auth wall or empty corpus forces `verdict=block` — qulib never silently passes an unevaluated surface.
 
-**Agent decisions are one evidence source.** The reserved `agent-evidence` kind in `EvidenceSourceKindSchema` lets tap-core/tap-client decisions feed into the same aggregator in P4 without touching the math.
+**Agent decisions are one evidence source.** The reserved `agent-evidence` kind in `EvidenceSourceKindSchema` lets external agentic decisions feed into the same aggregator in a future release without touching the math.
 
 ---
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -140,14 +140,36 @@ After a normal **`analyze`**, `output/report.json` includes **`gapAnalysis.costI
 Re-print that block from disk:
 
 ```bash
-npx tsx src/cli/index.ts cost doctor
-# or: npx tsx src/cli/index.ts cost doctor --report output/report.json
+qulib cost doctor
+# or: qulib cost doctor --report output/report.json
 ```
 
 ## CLI (from npm)
 
+**Release confidence — the flagship command:**
+
+```bash
+npx @qulib/core confidence --url https://example.com
+```
+
+Returns ship / caution / hold / block with a 0–100 score, top risks, and recommended next checks. Add `--repo` to also score test-automation maturity and API coverage.
+
+**Analyze (full gap report):**
+
 ```bash
 npx @qulib/core analyze --url https://example.com
+```
+
+**Scaffold a test suite:**
+
+```bash
+npx @qulib/core scaffold --url https://example.com --framework cypress-e2e
+```
+
+**Score automation maturity (repo-only, no URL needed):**
+
+```bash
+npx @qulib/core score-automation --repo /path/to/repo
 ```
 
 Use `npx playwright install chromium` the first time you scan (Playwright is a dependency).
@@ -344,10 +366,13 @@ Use these as conservative reference numbers:
 
 | Tool | When to use | Key input |
 |---|---|---|
-| `analyze_app` | Main QA scan for release confidence + gaps | `url`, optional `auth`, optional LLM knobs |
-| `detect_auth` | Fast single-pass auth pattern guess | `url`, optional `timeoutMs` |
+| **`qulib_score_confidence`** | **Flagship.** Fused verdict (ship/caution/hold/block) from all collectors | `url` and/or `repoPath`, optional `includeViews.replay` |
+| `analyze_app` | Live-app QA scan: release confidence + gaps + a11y | `url`, optional `auth`, optional LLM knobs |
+| `qulib_score_automation` | Score local repo test-automation maturity | absolute `repoPath`, optional `includeFullDimensions` |
+| `qulib_score_api` | Discover API endpoints and score their test coverage | absolute `repoPath`, optional `enableTier3`, `includeEndpointDetail` |
+| `qulib_scaffold_tests` | Generate Cypress/Playwright scaffold from a live URL | `url`, optional `framework`, `maxPagesToScan`, `recipes` |
 | `explore_auth` | Deeper auth-path discovery on unfamiliar apps | `url`, optional `timeoutMs` |
-| `qulib_score_automation` | Score local repo automation maturity | absolute `repoPath`, optional `includeFullDimensions` |
+| `detect_auth` | Fast single-pass auth pattern guess | `url`, optional `timeoutMs` |
 
 ## Output directories
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qulib/core",
   "version": "0.8.2",
-  "description": "Qulib — analyze deployed web apps for honest quality gaps (CLI + programmatic API)",
+  "description": "Qulib — release confidence for deployed web apps. Fuses live-app quality, automation maturity, and API coverage into a single ship/caution/hold/block verdict.",
   "license": "MIT",
   "author": "Tapesh Nagarwal",
   "homepage": "https://github.com/TapeshN/qulib#readme",
@@ -14,11 +14,13 @@
     "url": "https://github.com/TapeshN/qulib/issues"
   },
   "keywords": [
+    "release-confidence",
     "qa",
     "quality",
-    "accessibility",
+    "ship-verdict",
+    "automation-maturity",
     "gap-analysis",
-    "release-confidence",
+    "accessibility",
     "playwright",
     "mcp",
     "ai"

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -43,22 +43,48 @@ For verbose server-side stderr logs while troubleshooting host wiring, add:
 }
 ```
 
-## What it does
+## MCP tools
 
-Tools:
+| Tool | Purpose |
+|---|---|
+| **`qulib_score_confidence`** | **Flagship.** Fuses evidence from `analyze_app`, `qulib_score_automation`, and `qulib_score_api` into one verdict: **ship / caution / hold / block** with a 0–100 confidence score, L1–L5 level, per-source contributions, honesty notes, and recommended next checks. Pass `url` and/or `repoPath`. |
+| `analyze_app` | Live-app quality scan: release confidence (0–100), axe-core a11y, broken links, console errors, prioritized gaps. Default payload is summary-first; pass `includeFullReport: true` for all scenarios. Optional form-login / storage-state auth. |
+| `qulib_score_automation` | Score a local repo's test-automation maturity across six dimensions (test coverage breadth, framework adoption, test-id hygiene, CI integration, auth test coverage, component test ratio) — plus a conditional 7th dimension (API coverage) when API endpoints are detected. Returns overall 0–100, level (L1–L5), and top recommendations. Each dimension carries `applicability`; score normalizes over applicable dimensions only. |
+| `qulib_score_api` | Discover API endpoints in a repo and score their test coverage. Tier1=OpenAPI specs, Tier2=framework routes (Next.js, Express, Fastify, NestJS), Tier3=heuristic opt-in (tRPC). Returns an api-test-coverage dimension score with per-endpoint evidence. |
+| `qulib_scaffold_tests` | Generate a ready-to-run test scaffold (Cypress or Playwright config + spec files) by crawling a deployed URL. Returns `generatedTests` and `projectConfig` so an agent can write files directly. Pass `recipes` (e.g. `["auth","a11y"]`) to append proven test patterns. |
+| `explore_auth` | List all sign-in paths (OAuth, SSO, forms, magic link) and what the agent must collect before `analyze_app`. Prefer on unfamiliar apps. |
+| `detect_auth` | Single-pass auth pattern guess with a recommendation. Lighter than `explore_auth`. |
 
-- **`explore_auth(url, timeoutMs?)`** — list all sign-in paths (OAuth, unknown SSO heuristics, forms, magic link) and what the agent must collect before `analyze_app`. Prefer this on unfamiliar apps.
-- **`analyze_app`** — quality scan (optional form-login or storage-state auth). **Default payload is summary-first:** `summary`, `topGaps`, `costIntelligenceSummary`, `nextDeterministicChecks`, small previews. Set **`includeFullReport: true`** for the full `analyzeApp` result (all scenarios). Optional harness overrides: **`llmMaxOutputTokensPerCall`**, **`llmTokenBudget`** (legacy), **`testGenerationLimit`**, **`enableLlmScenarios`** (default true when omitted).
-- **`detect_auth(url, timeoutMs?)`** — single-pattern auth guess with a short recommendation (lighter than `explore_auth`).
-- **`qulib_score_automation(repoPath, includeFullDimensions?)`** — score a local automation repo across six dimensions (test coverage breadth, framework adoption, test-id hygiene, CI integration, auth test coverage, component test ratio). Returns an overall 0–100 score, maturity level (L1–L5), and top recommendations. Each dimension carries an **`applicability`** field (`applicable` / `not_applicable` / `unknown`); the overall score normalizes across applicable dimensions only so absent capabilities never get silent partial credit. **`repoPath`** must be an absolute path on the MCP host. Pass **`includeFullDimensions: true`** for per-dimension evidence and reasons.
+**Example — flagship confidence call:**
 
-Returns from `analyze_app`:
+```
+qulib_score_confidence({ url: "https://example.com", repoPath: "/path/to/repo" })
+```
 
-- Release confidence score (0-100)
-- Accessibility violations (axe-core, WCAG 2 A/AA)
-- Broken links
-- Console errors and coverage warnings
-- Prioritized gaps with severity
+Returns a verdict like:
+
+```json
+{
+  "releaseConfidence": {
+    "verdict": "caution",
+    "confidenceScore": 54,
+    "level": 3,
+    "label": "Moderate confidence — proceed with known risks",
+    "topRisks": ["Low crawl coverage (2 pages)", "No CI integration detected"],
+    "recommendedNextChecks": ["Add CI pipeline", "Increase crawl depth"],
+    "honestyNotes": ["API coverage: not_applicable (no API endpoints found — excluded from score)"]
+  }
+}
+```
+
+### `analyze_app` detail
+
+- **Default payload:** `summary`, `topGaps`, `costIntelligenceSummary`, `nextDeterministicChecks`, small previews.
+- **`includeFullReport: true`** — full `gapAnalysis` (all scenarios) and full `repoInventory`.
+- **`agentSummary: true`** — compact gate-decision payload (`pass`/`warn`/`fail`) for CI orchestrators.
+- Optional harness overrides: **`llmMaxOutputTokensPerCall`**, **`llmTokenBudget`** (legacy), **`testGenerationLimit`**, **`enableLlmScenarios`**.
+
+Returns: release confidence score (0–100), accessibility violations (axe-core, WCAG 2 A/AA), broken links, console errors and coverage warnings, prioritized gaps with severity.
 
 Supports optional form-login auth for scanning authenticated pages. If auth is required but not configured, the scan can stop early with `mode: auth-required` and guidance in `detectedAuth` / the decision log.
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qulib/mcp",
   "version": "0.8.2",
-  "description": "MCP server for Qulib — AI-callable QA gap analysis",
+  "description": "MCP server for Qulib — AI-callable release confidence. Seven tools: fused verdict, live-app scan, automation maturity, API coverage, test scaffold, and auth tools.",
   "license": "MIT",
   "author": "Tapesh Nagarwal",
   "homepage": "https://github.com/TapeshN/qulib#readme",
@@ -44,10 +44,12 @@
   },
   "keywords": [
     "mcp",
+    "release-confidence",
     "qa",
     "quality",
+    "ship-verdict",
+    "automation-maturity",
     "accessibility",
-    "release-confidence",
     "ai"
   ]
 }


### PR DESCRIPTION
## Summary

- **7-tool MCP table** added to `packages/mcp/README.md` and `packages/core/README.md`, led by `qulib_score_confidence` (the flagship fused-verdict tool) with a concrete `ship/caution/hold/block` example response
- **CLI surfaces documented** — `qulib confidence`, `qulib scaffold`, `qulib score-automation` now appear in all three READMEs with working command examples
- **Root README quickstart** updated to installed-consumer form (`npx @qulib/core confidence --url ...`); includes a note that the config-fallback PR must land first for zero-config usage
- **`qulib cost doctor`** example fixed to the real command form (was using `npx tsx src/cli/index.ts cost doctor`)
- **CI snippet refs** pinned from floating `@v1` to `@v0.9.0` (releasing Thursday) — both composite action and reusable workflow
- **Seven-dimension claim** — `qulib_score_automation` description now mentions the conditional 7th dimension (API coverage) when endpoints are detected
- **Internal companion project reference** removed from public root README (was naming private repos)
- **`package.json` description and keywords** refreshed for both packages to the release-confidence story (no version bumps)
- **Docs-parity verified**: 7 `mcpServer.registerTool()` calls in `packages/mcp/src/index.ts` = 7 rows in MCP tool table

## Witnesses

All commands executed against the locally built CLI from `dist/`:

```
$ node bin/qulib.js --version
0.8.2

$ node bin/qulib.js --help
Commands: scaffold, score-automation, confidence, clean, cost, analyze, explore-auth, detect-auth, auth

$ node bin/qulib.js confidence --help
Options: --url <url>, --repo <path>, --json

$ node bin/qulib.js cost doctor --help
Usage: qulib cost doctor [options]
Options: --report <file>  Path to report.json relative to cwd (default: "output/report.json")

$ node bin/qulib.js score-automation --repo /path/to/qulib
[qulib] Automation maturity for ...
  overall: 95/100  —  L5 — advanced QA automation (level 5)
  dimensions:
  - test-coverage-breadth [w=28%]: 100/100
  - framework-adoption [w=22%]: 100/100
  - test-id-hygiene [w=18%]: 100/100
  - ci-integration [w=14%]: 100/100
  - auth-test-coverage [w=10%]: 90/100
  - component-test-ratio [w=8%]: 50/100
```

**Docs parity check:**
```
grep -c "mcpServer.registerTool" packages/mcp/src/index.ts → 7
Tool table rows in packages/mcp/README.md → 7
```

**Build and tests:**
```
npm run build → clean (0 tsc errors)
npm test      → 17 pass, 0 fail
```

> **Dependency note:** the quickstart note references the config-fallback PR landing in parallel. Until that merges, consumers must run from `packages/core` (where a default `qulib.config.ts` exists) or pass `--config` explicitly. This PR does not block on that — it documents the expected post-merge state honestly.

## Test plan

- [ ] Review the 7-tool table in `packages/mcp/README.md` matches tools in `packages/mcp/src/index.ts`
- [ ] Check root README quickstart uses the installed CLI form (`npx @qulib/core confidence`)
- [ ] Confirm CI snippet uses `@v0.9.0` tag (not `@v1`)
- [ ] Confirm no reference to private/internal repos in public README
- [ ] Confirm `package.json` versions are unchanged (only description/keywords updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)