### PR TITLE
Add Friday demo kit: fallback JSONs and 5-minute crib sheet

### DIFF
--- a/docs/demo/CRIB-SHEET.md
+++ b/docs/demo/CRIB-SHEET.md
@@ -1,0 +1,201 @@
+# qulib Friday Demo — Crib Sheet
+## "Should We Ship?" — 5-minute script
+
+> Everything runs from `@qulib/core@0.9.0` and `@qulib/mcp@0.9.0` (published Thursday).
+> MCP pre-registered in Claude Code before taking the stage.
+> Fallback JSONs in this directory — narrate one if a live step fails twice, never debug on stage.
+
+---
+
+## Setup (before you walk on stage)
+
+```
+# Register qulib in Claude Code — one-liner, do this during rehearsal:
+claude mcp add qulib -- npx -y @qulib/mcp
+
+# Confirm it registered:
+# Claude Code → /mcp → should list 7 qulib tools
+```
+
+Pre-stage checklist:
+- `notquality` repo checked out at `~/demo/notquality`
+- Claude Code open, qulib MCP registered (7 tools visible)
+- Browser tab with Thursday's green Actions run open (NOT a live run)
+- Fallback JSONs staged in a terminal: `cat ~/path/to/analyze-notquality.json`
+- Hotspot active, terminal font size 20+
+
+---
+
+## [0:00 – 0:30] Hook — prove this is a real npm package
+
+**Say:** "Every release meeting ends with one question — should we ship? qulib answers it with evidence, not vibes."
+
+**Command:**
+```
+npx -y @qulib/core@0.9.0 --version
+```
+
+**Expected output:** `0.9.0`
+
+**Measured local timing:** < 5s (npx cold-start; package is ~2MB)
+
+**Failure drill:** If `npx` fails or hangs — say "let me show you what 0.9.0 outputs" and run:
+```
+cat docs/demo/analyze-notquality.json | jq '.status, .detectedAuth.type'
+```
+
+---
+
+## [0:30 – 2:00] Evidence pass — analyze notquality.com
+
+**Say:** "Real deployed app, auth walls, fifty intentional bugs. Watch what it finds — and what it tells you it *couldn't* verify."
+
+**Command:**
+```
+npx -y @qulib/core@0.9.0 analyze --url https://notquality.com
+```
+
+**Expected output shape:**
+```
+status: partial
+detectedAuth: { type: "oauth", provider: "github" }
+gaps: [
+  { severity: "critical", category: "coverage",
+    reason: "Scan blocked by authentication…" },
+  { severity: "medium", category: "auth-surface",
+    reason: "OAuth-only entry with no password fallback…" }
+]
+decisionLog: [ "exploration-complete", "auth-required", … ]
+```
+
+**Key beat to land:** Point to the `status: partial` + the `auth-required` decision log entry.
+"It doesn't pretend it scanned everything. False confidence is a QA tool's worst failure mode."
+
+**Measured local timing:** ~22s (Playwright crawl + auth detection)
+
+**Failure drill (if live command fails twice):** Open `docs/demo/analyze-notquality.json` and narrate:
+- `status: partial` — partial scan
+- `detectedAuth.type: oauth` — caught the GitHub OAuth wall
+- Three gaps: `critical` auth-block, `medium` no-fallback-login, `low` no-recovery-link
+- `releaseConfidence: 0` — honestly zero because the protected surface was not seen
+
+---
+
+## [2:00 – 3:30] The verdict — confidence command (flagship)
+
+**Say:** "Now the actual product. One command fuses all the evidence — live-app quality, repo test maturity, API coverage — into a single falsifiable verdict."
+
+**Command:**
+```
+cd ~/demo/notquality
+npx -y @qulib/core@0.9.0 confidence --url https://notquality.com --repo .
+```
+
+**Expected output shape:**
+```
+[qulib] Release confidence for https://notquality.com
+  verdict: block  —  L5 — advanced QA automation (score 92/100, level 5/5)
+  blockers:
+    • 'live-app-quality' is a hard blocker: Auth wall prevented scanning…
+  contributions:
+    - live-app-quality [unknown] [BLOCKER]: n/a  excluded
+    - accessibility [unknown]: n/a  excluded
+    - crawl-coverage [unknown]: n/a  excluded
+    - test-automation [applicable]: 86/100  ew=50.0%
+    - api-coverage [applicable]: 100/100  ew=50.0%
+  honesty notes:
+    • 'live-app-quality' source could not produce a reliable score: Auth wall…
+```
+
+**Key beat to land:**
+"score 92/100 from the repo side — great test automation — but the verdict is `block` because
+we cannot honestly score the live app without authenticated access. The tool blocks itself when
+it would be lying. That's the product."
+
+**Measured local timing:** ~18s (analyze + repo scan in parallel)
+
+**Failure drill (if live command fails twice):** Open `docs/demo/confidence-notquality.json` and narrate:
+- `verdict: block` with `confidenceScore: 92` — strong repo side, blocked by auth wall
+- `contributions[test-automation].score: 86` — L5 automation maturity (advanced)
+- `contributions[api-coverage].score: 100` — all 20 API endpoints traced
+- `blockers[0]` — live-app-quality hard blocker: auth wall honesty note
+
+---
+
+## [3:30 – 4:30] The agent path — Claude Code MCP demo
+
+**Say:** "Same verdict, agent path. Any MCP host gets all seven tools from one install."
+
+**Action:** Switch to Claude Code. Type:
+```
+Should we ship notquality.com? Use qulib.
+```
+
+**Expected behavior:** Claude calls `qulib_score_confidence`, narrates the `block` verdict with
+per-source evidence weights and honesty notes. No extra setup — the MCP registered with one line.
+
+**MCP registration one-liner (slide or fallback):**
+```
+claude mcp add qulib -- npx -y @qulib/mcp
+```
+
+**Failure drill:** If Claude Code / MCP is unavailable — say "the MCP registration is one command"
+and show the one-liner above. The JSON output from beat 3 already proves the same verdict.
+
+---
+
+## [4:30 – 5:00] The habit — GitHub Actions gate
+
+**Say:** "The same verdict as a merge gate — six lines of YAML, pinned to v0.9.0."
+
+**Action:** Switch to the pre-open browser tab showing Thursday's green `qulib-action selftest`
+Actions run. Do NOT trigger a live CI run.
+
+**YAML snippet to show (on screen or slide):**
+```yaml
+jobs:
+  qa:
+    uses: TapeshN/qulib/.github/workflows/qulib-analyze.yml@v0.9.0
+    with:
+      url: https://your-app.example.com
+      fail-on: warn
+```
+
+**Close:** "Install one-liner: `npx -y @qulib/core@0.9.0 analyze --url <your-app>`. Ship evidence, not vibes."
+
+---
+
+## Fallback file map
+
+| Beat | Fallback file | Key fields to narrate |
+|------|--------------|----------------------|
+| Evidence pass (analyze) | `docs/demo/analyze-notquality.json` | `status`, `detectedAuth.type`, `gaps[].severity`, `decisionLog` |
+| Verdict (confidence) | `docs/demo/confidence-notquality.json` | `verdict`, `confidenceScore`, `blockers`, `contributions[].score` |
+| Simple app baseline | `docs/demo/analyze-example.json` | `status: complete`, `releaseConfidence: 100` — contrast with partial |
+
+---
+
+## Timing summary (measured locally on current main / same code as 0.9.0)
+
+> Note: `npx -y @qulib/core@0.9.0` requires Thursday's publish. Local runs below use the
+> same built code via `node packages/core/bin/qulib.js` — identical behavior, same timings.
+
+| Command | Measured wall-clock |
+|---------|-------------------|
+| `qulib analyze --url https://notquality.com` | 22s |
+| `qulib analyze --url https://example.com` | 3s |
+| `qulib confidence --url https://notquality.com --repo .` | 18s |
+
+Total live demo commands: ~40s of active execution, well within the 5-minute window.
+
+---
+
+## Things that must be true on Friday morning
+
+- [ ] `npm view @qulib/core version` returns `0.9.0` (Thursday publish done)
+- [ ] `npm view @qulib/mcp version` returns `0.9.0`
+- [ ] Claude Code MCP shows 7 qulib tools after `claude mcp add qulib -- npx -y @qulib/mcp`
+- [ ] Browser tab has Thursday's green `qulib-action selftest` Actions run preloaded
+- [ ] Fallback JSONs are on conference laptop (copy this `docs/demo/` directory)
+- [ ] `~/demo/notquality` repo checkout exists on conference laptop
+- [ ] Rehearsed twice end-to-end over hotspot; any step that fails twice is cut and replaced by its fallback JSON

--- a/docs/demo/analyze-example.json
+++ b/docs/demo/analyze-example.json
@@ -1,0 +1,149 @@
+{
+  "status": "complete",
+  "coverageScore": 100,
+  "releaseConfidence": 100,
+  "gaps": [],
+  "gapAnalysis": {
+    "analyzedAt": "2026-06-10T13:25:01.052Z",
+    "mode": "url-only",
+    "releaseConfidence": 100,
+    "coveragePagesScanned": 1,
+    "coverageBudgetExceeded": false,
+    "coverageWarning": "low-coverage",
+    "gaps": [],
+    "scenarios": [],
+    "generatedTests": [],
+    "costIntelligence": {
+      "maxOutputTokensPerLlmCall": 4000,
+      "budgetRole": "max-output-tokens-per-llm-call",
+      "records": [
+        {
+          "provider": "none",
+          "model": "none",
+          "inputTokens": 0,
+          "outputTokens": 0,
+          "operationType": "scenario-generation",
+          "timestamp": "2026-06-10T13:25:01.052Z",
+          "dataQuality": "none",
+          "notes": "No LLM call: ANTHROPIC_API_KEY not set; template scenarios only."
+        }
+      ],
+      "budgetWarnings": [],
+      "usageSummary": {
+        "totalInputTokens": 0,
+        "totalOutputTokens": 0,
+        "dataQuality": "none"
+      },
+      "repeatedOperations": [],
+      "deterministicMaturity": {
+        "level": 1,
+        "label": "L1 — deterministic scan inventory",
+        "rationale": "Structured gaps came from deterministic crawling and checks (links, console, a11y, coverage). This is the baseline Qulib release-confidence story.",
+        "ceilingNote": "L4 (reviewed self-healing) and L5 (adaptive quality intelligence) are not inferred from a snapshot scan. They require documented review, ownership, and sustained automation feedback."
+      },
+      "conversionRecommendations": [
+        "Scenarios were generated from built-in templates (no LLM). This is the lowest-cost path; keep expanding template coverage for recurring gap categories."
+      ]
+    }
+  },
+  "discoveredRoutes": {
+    "scannedAt": "2026-06-10T13:25:01.048Z",
+    "baseUrl": "https://example.com",
+    "routes": [
+      {
+        "path": "/",
+        "pageTitle": "Example Domain",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      }
+    ],
+    "pagesSkipped": 0,
+    "budgetExceeded": false
+  },
+  "publicSurface": {
+    "pages": [
+      {
+        "path": "/",
+        "pageTitle": "Example Domain",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      }
+    ],
+    "gaps": [],
+    "accessibilityViolations": [],
+    "brokenLinks": []
+  },
+  "repoInventory": null,
+  "decisionLog": [
+    {
+      "timestamp": "2026-06-10T13:25:01.051Z",
+      "phase": "observe",
+      "decision": "exploration-complete",
+      "reason": "Discovered 1 routes; budgetExceeded=false",
+      "metadata": {
+        "baseUrl": "https://example.com/",
+        "scannedRoutes": 1,
+        "budgetExceeded": false,
+        "pagesSkipped": 0
+      }
+    },
+    {
+      "timestamp": "2026-06-10T13:25:01.052Z",
+      "phase": "think",
+      "decision": "gap-analysis-complete",
+      "reason": "Computed 0 gaps with release confidence 100",
+      "metadata": {
+        "mode": "url-only",
+        "gapCount": 0,
+        "releaseConfidence": 100
+      }
+    },
+    {
+      "timestamp": "2026-06-10T13:25:01.052Z",
+      "phase": "think",
+      "decision": "llm-scenarios-skipped",
+      "reason": "Skipped LLM scenario generation because ANTHROPIC_API_KEY is not set"
+    },
+    {
+      "timestamp": "2026-06-10T13:25:01.052Z",
+      "phase": "think",
+      "decision": "scenario-generation-complete",
+      "reason": "Generated 0 scenarios via template",
+      "metadata": {
+        "source": "template",
+        "scenarioCount": 0
+      }
+    },
+    {
+      "timestamp": "2026-06-10T13:25:01.053Z",
+      "phase": "act",
+      "decision": "reports-written",
+      "reason": "Skipped writing reports (ephemeral run)",
+      "metadata": {
+        "gapCount": 0,
+        "scenarioCount": 0,
+        "releaseConfidence": 100,
+        "requireHumanReview": true
+      }
+    }
+  ],
+  "detectedAuth": {
+    "hasAuth": false,
+    "type": "none",
+    "provider": null,
+    "loginUrl": null,
+    "observedSelectors": null,
+    "oauthButtons": [],
+    "recommendation": "No authentication required for the entry URL. Qulib can scan anonymously."
+  }
+}

--- a/docs/demo/analyze-notquality.json
+++ b/docs/demo/analyze-notquality.json
@@ -1,0 +1,760 @@
+{
+  "status": "partial",
+  "coverageScore": 95,
+  "releaseConfidence": 0,
+  "gaps": [
+    {
+      "id": "87106f51-e3b9-4fd9-bf28-da634b1eb955",
+      "path": "/",
+      "severity": "medium",
+      "reason": "OAuth-only entry with no visible password or magic-link fallback.",
+      "category": "auth-surface",
+      "description": "Users who cannot use a social IdP need another path (email/password, help, or support).",
+      "recommendation": "Add a documented fallback (email/password, help desk link, or alternate IdP)."
+    },
+    {
+      "id": "3e4da1ef-c13a-490e-ade2-02d5c5cd3d7b",
+      "path": "/",
+      "severity": "low",
+      "reason": "No visible “forgot password” or help path detected near OAuth controls.",
+      "category": "auth-surface",
+      "description": "Users locked out of an IdP need a support or recovery affordance.",
+      "recommendation": "Link to account recovery, IT help, or a support URL near the sign-in actions."
+    },
+    {
+      "id": "auth-block",
+      "path": "/",
+      "severity": "critical",
+      "reason": "Scan blocked by authentication. No authenticated pages were evaluated for notquality.com.",
+      "category": "coverage",
+      "description": "Scan blocked by authentication. 0 authenticated pages were evaluated.",
+      "recommendation": "Run `qulib auth init --base-url https://notquality.com/` to capture a storage state, then re-run with --auth storage-state."
+    }
+  ],
+  "gapAnalysis": {
+    "analyzedAt": "2026-06-10T13:24:41.522Z",
+    "mode": "auth-required",
+    "releaseConfidence": 0,
+    "coveragePagesScanned": 0,
+    "coverageBudgetExceeded": false,
+    "coverageWarning": "auth-required",
+    "gaps": [
+      {
+        "id": "87106f51-e3b9-4fd9-bf28-da634b1eb955",
+        "path": "/",
+        "severity": "medium",
+        "reason": "OAuth-only entry with no visible password or magic-link fallback.",
+        "category": "auth-surface",
+        "description": "Users who cannot use a social IdP need another path (email/password, help, or support).",
+        "recommendation": "Add a documented fallback (email/password, help desk link, or alternate IdP)."
+      },
+      {
+        "id": "3e4da1ef-c13a-490e-ade2-02d5c5cd3d7b",
+        "path": "/",
+        "severity": "low",
+        "reason": "No visible “forgot password” or help path detected near OAuth controls.",
+        "category": "auth-surface",
+        "description": "Users locked out of an IdP need a support or recovery affordance.",
+        "recommendation": "Link to account recovery, IT help, or a support URL near the sign-in actions."
+      },
+      {
+        "id": "auth-block",
+        "path": "/",
+        "severity": "critical",
+        "reason": "Scan blocked by authentication. No authenticated pages were evaluated for notquality.com.",
+        "category": "coverage",
+        "description": "Scan blocked by authentication. 0 authenticated pages were evaluated.",
+        "recommendation": "Run `qulib auth init --base-url https://notquality.com/` to capture a storage state, then re-run with --auth storage-state."
+      }
+    ],
+    "scenarios": [
+      {
+        "id": "d8e2313a-0de4-499b-990a-a559e5a853f2",
+        "title": "[MEDIUM] auth-surface — /",
+        "description": "OAuth-only entry with no visible password or magic-link fallback.",
+        "targetPath": "/",
+        "steps": [
+          {
+            "action": "navigate",
+            "target": "/",
+            "description": "Navigate to /"
+          },
+          {
+            "action": "assert-visible",
+            "description": "Verify sign-in surface accessibility and SSO affordances"
+          }
+        ],
+        "tags": [
+          "auth-surface",
+          "medium"
+        ],
+        "recommendations": [
+          {
+            "adapter": "accessibility",
+            "reason": "Generated from template",
+            "confidence": "low"
+          }
+        ],
+        "sourceGapIds": [
+          "87106f51-e3b9-4fd9-bf28-da634b1eb955"
+        ]
+      },
+      {
+        "id": "55cd93a8-7878-427d-9416-1e59c38ac637",
+        "title": "[LOW] auth-surface — /",
+        "description": "No visible “forgot password” or help path detected near OAuth controls.",
+        "targetPath": "/",
+        "steps": [
+          {
+            "action": "navigate",
+            "target": "/",
+            "description": "Navigate to /"
+          },
+          {
+            "action": "assert-visible",
+            "description": "Verify sign-in surface accessibility and SSO affordances"
+          }
+        ],
+        "tags": [
+          "auth-surface",
+          "low"
+        ],
+        "recommendations": [
+          {
+            "adapter": "accessibility",
+            "reason": "Generated from template",
+            "confidence": "low"
+          }
+        ],
+        "sourceGapIds": [
+          "3e4da1ef-c13a-490e-ade2-02d5c5cd3d7b"
+        ]
+      },
+      {
+        "id": "4a2a516b-68ba-4187-a8f6-22be09291c9e",
+        "title": "[CRITICAL] coverage — /",
+        "description": "Scan blocked by authentication. No authenticated pages were evaluated for notquality.com.",
+        "targetPath": "/",
+        "steps": [
+          {
+            "action": "navigate",
+            "target": "/",
+            "description": "Navigate to /"
+          },
+          {
+            "action": "assert-visible",
+            "description": "Resolve authentication and re-run full deployment scan"
+          }
+        ],
+        "tags": [
+          "coverage",
+          "critical"
+        ],
+        "recommendations": [
+          {
+            "adapter": "playwright",
+            "reason": "Generated from template",
+            "confidence": "low"
+          }
+        ],
+        "sourceGapIds": [
+          "auth-block"
+        ]
+      }
+    ],
+    "generatedTests": [],
+    "costIntelligence": {
+      "maxOutputTokensPerLlmCall": 4000,
+      "budgetRole": "max-output-tokens-per-llm-call",
+      "records": [
+        {
+          "provider": "none",
+          "model": "none",
+          "inputTokens": 0,
+          "outputTokens": 0,
+          "operationType": "scenario-generation",
+          "timestamp": "2026-06-10T13:24:41.523Z",
+          "dataQuality": "none",
+          "notes": "No LLM call: ANTHROPIC_API_KEY not set; template scenarios only."
+        }
+      ],
+      "budgetWarnings": [],
+      "usageSummary": {
+        "totalInputTokens": 0,
+        "totalOutputTokens": 0,
+        "dataQuality": "none"
+      },
+      "repeatedOperations": [],
+      "deterministicMaturity": {
+        "level": 1,
+        "label": "L1 — deterministic scan inventory",
+        "rationale": "Structured gaps came from deterministic crawling and checks (links, console, a11y, coverage). This is the baseline Qulib release-confidence story.",
+        "ceilingNote": "L4 (reviewed self-healing) and L5 (adaptive quality intelligence) are not inferred from a snapshot scan. They require documented review, ownership, and sustained automation feedback."
+      },
+      "conversionRecommendations": [
+        "Scenarios were generated from built-in templates (no LLM). This is the lowest-cost path; keep expanding template coverage for recurring gap categories."
+      ]
+    }
+  },
+  "discoveredRoutes": {
+    "scannedAt": "2026-06-10T13:24:41.523Z",
+    "baseUrl": "https://notquality.com",
+    "routes": [],
+    "pagesSkipped": 0,
+    "budgetExceeded": false
+  },
+  "publicSurface": {
+    "pages": [
+      {
+        "path": "/",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [
+          "https://www.notquality.com/challenges",
+          "https://www.notquality.com/",
+          "https://www.notquality.com/login"
+        ],
+        "formCount": 0,
+        "buttonLabels": [
+          "Launch playground\n→",
+          "Launch playground\n→",
+          "Launch playground\n→",
+          "Launch playground\n→"
+        ],
+        "consoleErrors": [],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [
+          "https://www.notquality.com/",
+          "https://www.notquality.com/playgrounds",
+          "https://www.notquality.com/challenges/stale-cart-count",
+          "https://www.notquality.com/challenges/invalid-auth-credentials",
+          "https://www.notquality.com/challenges/order-history-sorting",
+          "https://www.notquality.com/challenges/modal-focus-trap",
+          "https://www.notquality.com/challenges/negative-cart-quantity",
+          "https://www.notquality.com/challenges/product-viewed-missing-id",
+          "https://www.notquality.com/challenges/price-mismatch",
+          "https://www.notquality.com/challenges/products-leaks-inactive",
+          "https://www.notquality.com/challenges/cart-race-condition",
+          "https://www.notquality.com/challenges/lcp-products-page",
+          "https://www.notquality.com/challenges/tone-drift-7b-model",
+          "https://www.notquality.com/challenges/touch-target-stepper",
+          "https://www.notquality.com/challenges/filter-state-mismatch",
+          "https://www.notquality.com/challenges/order-submitted-on-failure",
+          "https://www.notquality.com/challenges/grid-collapse-tablet",
+          "https://www.notquality.com/challenges/aggregate-ship-no-ship"
+        ],
+        "formCount": 0,
+        "buttonLabels": [
+          "All",
+          "Legacy",
+          "API",
+          "Events",
+          "A11Y",
+          "Mobile",
+          "Perf",
+          "Flaky",
+          "AI",
+          "Release",
+          "All",
+          "Easy",
+          "Medium",
+          "Hard",
+          "Capstone"
+        ],
+        "consoleErrors": [],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [
+          "https://www.notquality.com/challenges",
+          "https://www.notquality.com/",
+          "https://www.notquality.com/login"
+        ],
+        "formCount": 0,
+        "buttonLabels": [
+          "Launch playground\n→",
+          "Launch playground\n→",
+          "Launch playground\n→",
+          "Launch playground\n→"
+        ],
+        "consoleErrors": [],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/login",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [],
+        "brokenLinks": [],
+        "a11yViolations": [
+          {
+            "id": "color-contrast",
+            "impact": "serious",
+            "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=playwright",
+            "nodeCount": 3
+          }
+        ],
+        "statusCode": 200
+      },
+      {
+        "path": "/playgrounds",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [
+          "https://www.notquality.com/",
+          "https://www.notquality.com/challenges",
+          "https://www.notquality.com/login"
+        ],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/stale-cart-count",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [
+          "https://www.notquality.com/challenges",
+          "https://www.notquality.com/login"
+        ],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/invalid-auth-credentials",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/order-history-sorting",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/modal-focus-trap",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/negative-cart-quantity",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/product-viewed-missing-id",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/price-mismatch",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/products-leaks-inactive",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/cart-race-condition",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/lcp-products-page",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/tone-drift-7b-model",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/touch-target-stepper",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/filter-state-mismatch",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/order-submitted-on-failure",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      },
+      {
+        "path": "/challenges/grid-collapse-tablet",
+        "pageTitle": "notquality.com — deliberately imperfect apps for QA practice",
+        "links": [],
+        "formCount": 0,
+        "buttonLabels": [],
+        "consoleErrors": [
+          "Failed to load resource: the server responded with a status of 404 ()"
+        ],
+        "brokenLinks": [],
+        "a11yViolations": [],
+        "statusCode": 200
+      }
+    ],
+    "gaps": [
+      {
+        "id": "4bdd8c37-0a6e-4468-89d3-9af865cf7fc6",
+        "path": "/login",
+        "severity": "high",
+        "reason": "A11y violation color-contrast (serious): https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=playwright",
+        "category": "a11y"
+      },
+      {
+        "id": "36179415-555c-4b87-aefb-b6f24933a065",
+        "path": "/challenges/stale-cart-count",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "1102d4ff-0bb5-4995-84c2-4328f4ece71f",
+        "path": "/challenges/invalid-auth-credentials",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "6dab91b7-279f-4b3e-b526-0d536db13999",
+        "path": "/challenges/order-history-sorting",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "1e1c1c90-636c-4196-b760-e92ee3656169",
+        "path": "/challenges/modal-focus-trap",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "c9a6349d-b565-4623-b067-21af4fc85558",
+        "path": "/challenges/negative-cart-quantity",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "aba683be-d658-4b89-a8f4-a9923610684e",
+        "path": "/challenges/product-viewed-missing-id",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "f99ff40b-075a-4c5e-a540-0079bca307be",
+        "path": "/challenges/price-mismatch",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "2056dc62-c18b-41ea-994d-47bde5c08b93",
+        "path": "/challenges/products-leaks-inactive",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "f21adeda-1a60-4315-abb5-ba2e15fa651b",
+        "path": "/challenges/cart-race-condition",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "5bb470c1-5615-44ca-9a8b-002a461bd747",
+        "path": "/challenges/lcp-products-page",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "a44cac87-7cb6-4d39-8e75-9d99a56a2d3e",
+        "path": "/challenges/tone-drift-7b-model",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "0b253e55-3113-489f-95e8-a12305993332",
+        "path": "/challenges/touch-target-stepper",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "b4a7bc21-b109-4e5a-89bb-f2fd1f6d1331",
+        "path": "/challenges/filter-state-mismatch",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "4f1d55eb-c008-4edc-aa11-0517816945f5",
+        "path": "/challenges/order-submitted-on-failure",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      },
+      {
+        "id": "1dfbf0a4-3c3a-4229-9e89-8ed1106a4663",
+        "path": "/challenges/grid-collapse-tablet",
+        "severity": "high",
+        "reason": "Console errors detected (1)",
+        "category": "console-error"
+      }
+    ],
+    "accessibilityViolations": [
+      {
+        "id": "color-contrast",
+        "impact": "serious",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=playwright",
+        "nodeCount": 3,
+        "path": "/login"
+      }
+    ],
+    "brokenLinks": []
+  },
+  "repoInventory": null,
+  "decisionLog": [
+    {
+      "timestamp": "2026-06-10T13:24:40.485Z",
+      "phase": "observe",
+      "decision": "exploration-complete",
+      "reason": "Discovered 20 routes; budgetExceeded=true",
+      "metadata": {
+        "baseUrl": "https://notquality.com/",
+        "scannedRoutes": 20,
+        "budgetExceeded": true,
+        "pagesSkipped": 1
+      }
+    },
+    {
+      "timestamp": "2026-06-10T13:24:40.486Z",
+      "phase": "observe",
+      "decision": "auth-required",
+      "reason": "OAuth detected (github). OAuth cannot be automated. Run \"qulib auth init --base-url https://notquality.com\" to log in manually once and save a reusable storage state file.",
+      "metadata": {
+        "detection": {
+          "hasAuth": true,
+          "type": "oauth",
+          "provider": "github",
+          "loginUrl": "https://notquality.com",
+          "observedSelectors": null,
+          "oauthButtons": [
+            {
+              "provider": "github",
+              "text": "Sign in with GitHub"
+            }
+          ],
+          "authOptions": [
+            {
+              "id": "github",
+              "label": "Sign in with GitHub",
+              "type": "oauth",
+              "provider": "github",
+              "source": "built-in",
+              "automatable": false,
+              "confidence": "high",
+              "requirements": {
+                "method": "storage-state",
+                "instruction": "Run qulib auth init --base-url https://notquality.com"
+              }
+            }
+          ],
+          "recommendation": "OAuth detected (github). OAuth cannot be automated. Run \"qulib auth init --base-url https://notquality.com\" to log in manually once and save a reusable storage state file."
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-10T13:24:41.522Z",
+      "phase": "think",
+      "decision": "llm-scenarios-skipped",
+      "reason": "Skipped LLM scenario generation because ANTHROPIC_API_KEY is not set"
+    },
+    {
+      "timestamp": "2026-06-10T13:24:41.523Z",
+      "phase": "think",
+      "decision": "scenario-generation-complete",
+      "reason": "Generated 3 scenarios via template",
+      "metadata": {
+        "source": "template",
+        "scenarioCount": 3
+      }
+    },
+    {
+      "timestamp": "2026-06-10T13:24:41.523Z",
+      "phase": "act",
+      "decision": "reports-written",
+      "reason": "Skipped writing reports (ephemeral run)",
+      "metadata": {
+        "gapCount": 3,
+        "scenarioCount": 3,
+        "releaseConfidence": 0,
+        "requireHumanReview": true
+      }
+    }
+  ],
+  "detectedAuth": {
+    "hasAuth": true,
+    "type": "oauth",
+    "provider": "github",
+    "loginUrl": "https://notquality.com",
+    "observedSelectors": null,
+    "oauthButtons": [
+      {
+        "provider": "github",
+        "text": "Sign in with GitHub"
+      }
+    ],
+    "authOptions": [
+      {
+        "id": "github",
+        "label": "Sign in with GitHub",
+        "type": "oauth",
+        "provider": "github",
+        "source": "built-in",
+        "automatable": false,
+        "confidence": "high",
+        "requirements": {
+          "method": "storage-state",
+          "instruction": "Run qulib auth init --base-url https://notquality.com"
+        }
+      }
+    ],
+    "recommendation": "OAuth detected (github). OAuth cannot be automated. Run \"qulib auth init --base-url https://notquality.com\" to log in manually once and save a reusable storage state file."
+  }
+}

--- a/docs/demo/confidence-notquality.json
+++ b/docs/demo/confidence-notquality.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": 1,
+  "computedAt": "2026-06-10T13:25:48.433Z",
+  "subject": {
+    "kind": "release",
+    "ref": "https://notquality.com",
+    "tenantId": "default"
+  },
+  "confidenceScore": 92,
+  "verdict": "block",
+  "level": 5,
+  "label": "L5 — advanced QA automation",
+  "contributions": [
+    {
+      "source": "live-app-quality",
+      "score": null,
+      "weight": 0.3,
+      "effectiveWeight": 0,
+      "applicability": "unknown",
+      "blocking": true
+    },
+    {
+      "source": "accessibility",
+      "score": null,
+      "weight": 0.13,
+      "effectiveWeight": 0,
+      "applicability": "unknown",
+      "blocking": false
+    },
+    {
+      "source": "crawl-coverage",
+      "score": null,
+      "weight": 0.1,
+      "effectiveWeight": 0,
+      "applicability": "unknown",
+      "blocking": false
+    },
+    {
+      "source": "test-automation",
+      "score": 86,
+      "weight": 0.22,
+      "effectiveWeight": 0.5945945945945946,
+      "applicability": "applicable",
+      "blocking": false
+    },
+    {
+      "source": "api-coverage",
+      "score": 100,
+      "weight": 0.15,
+      "effectiveWeight": 0.4054054054054054,
+      "applicability": "applicable",
+      "blocking": false
+    }
+  ],
+  "topRisks": [
+    "Auth wall prevented scanning the protected surface.",
+    "Automation maturity: L5 — advanced QA automation (score 86)",
+    "20/20 API endpoints appear covered by test files.",
+    "POST /api/events — found in app/api/events/route.ts, covered by e2e/specs/crud/events.crud.spec.ts",
+    "GET /api/events — found in app/api/events/route.ts, covered by e2e/specs/crud/events.crud.spec.ts"
+  ],
+  "recommendedNextChecks": [
+    "Provide auth credentials (form login or storage state) and re-run to evaluate the protected surface.",
+    "Fix 1 critical gap(s) before shipping.",
+    "Add route-level smoke tests that assert critical paths referenced in production URLs."
+  ],
+  "honestyNotes": [
+    "'live-app-quality' source could not produce a reliable score: Auth wall prevented scanning — confidence score would be dishonest without the protected surface..",
+    "'accessibility' source could not produce a reliable score: Auth wall prevented a11y evaluation..",
+    "'crawl-coverage' source could not produce a reliable score: Auth-required scan; coverage limited to pre-auth pages.."
+  ],
+  "blockers": [
+    "'live-app-quality' is a hard blocker: Auth wall prevented scanning — confidence score would be dishonest without the protected surface.."
+  ],
+  "scoreFormula": "confidenceScore = round( Σ (score * weight) / Σ weight ) for applicable, non-null, non-blocking evidence only. not_applicable, unknown, and null-score items are excluded from the denominator but reported in contributions and honestyNotes."
+}


### PR DESCRIPTION
## Files added under docs/demo/

| File | Description | Timing |
|------|-------------|--------|
| `analyze-notquality.json` | `qulib analyze --url https://notquality.com --ephemeral` | 22s |
| `analyze-example.json` | `qulib analyze --url https://example.com --ephemeral` | 3s |
| `confidence-notquality.json` | `qulib confidence --url https://notquality.com --repo /path/to/notquality --json` | 18s |
| `CRIB-SHEET.md` | 1-page demo script with exact commands, expected outputs, timings, and per-beat failure drills | — |

## Validation

All three JSONs pass `jq .` (exit 0) and contain `status`/`verdict` fields:
- `analyze-notquality.json`: `status: partial`, `detectedAuth.type: oauth`, 3 gaps (critical/medium/low), `releaseConfidence: 0`
- `analyze-example.json`: `status: complete`, `releaseConfidence: 100`
- `confidence-notquality.json`: `verdict: block`, `confidenceScore: 92`, `level: 5`, 5 contributions with scores

Captured from locally built current main (same code as 0.9.0 — LANE-1 dist-based shim is already in place).

## Actions run

`qulib-action selftest` triggered manually and passed green:
https://github.com/TapeshN/qulib/actions/runs/27279569823

Job `gate.mjs end-to-end (offline fixture)` completed in 52s. This is the run to show in the Actions tab on stage.

Note: `qulib-analyze.yml` is `workflow_call` only (cannot be triggered manually per the Friday plan).

## Crib sheet covers

- Exact `npx -y @qulib/core@0.9.0` commands for each beat (note: requires Thursday's publish; local runs witness identical code)
- MCP registration one-liner: `claude mcp add qulib -- npx -y @qulib/mcp`
- Claude Code ask for the agent beat: "Should we ship notquality.com? Use qulib."
- Per-beat failure drills pointing to the captured fallback JSONs
- Pre-stage checklist and Friday morning verification steps

DO NOT MERGE — awaiting operator review per FLOORS.