### PR TITLE
docs: fix stale version strings, dead references, and accuracy gaps ahead of v0.9.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,13 +28,9 @@ packages/mcp/src/    — MCP tool wrappers over core
 
 ## Roadmap
 
-The release plan lives in `roadmap.json` at the repo root. Any agent planning work reads it first.
-
-**Current:** v0.8.2 on main and npm registry.
+**Current:** v0.9.0 on main and npm registry.
 
 **Target:** v1.0.0 — full auth intelligence, composable audit tools, CI integration.
-
-Before starting new feature work, read `roadmap.json` to understand where the feature fits in the release sequence and what its dependencies are.
 
 ---
 
@@ -56,8 +52,8 @@ You talk to one agent. That agent auto-scales based on what you ask. Slash comma
 
 | You say | Agent does |
 |---|---|
-| "what's next?" | Reads roadmap.json + initiatives.json, recommends next task |
-| "ship 0.7.0" | Plans the train, spawns parallel subagents if safe, handles release + publish prompt |
+| "what's next?" | Reads initiatives.json, recommends next task |
+| "ship X.Y.Z" | Plans the train, spawns parallel subagents if safe, handles release + publish prompt |
 | "fix this bug" | Solo work — branch, fix, test, PR. Suggests a patch release after. |
 | "find test sites" | Spawns research agent in background |
 | "run QA sweep" | Spawns sweep agent, presents findings |
@@ -148,7 +144,6 @@ Every agent — parent or subagent — runs this before touching code:
 3. Read this file — know the rules
 4. Read `.cursor/state/initiatives.json` — know what's in flight
 5. Read `.cursor/state/sessions.json` — is the user clocked in?
-6. If planning work: read `roadmap.json` — know what ships when
 
 ### Autonomy levels
 
@@ -172,7 +167,6 @@ Set by the user at session start. Default is **standard**.
 | What it is | Where it goes |
 |---|---|
 | Workflow rule, agent behavior | This file (`CLAUDE.md`) |
-| Release plan, feature scope | `roadmap.json` |
 | File-specific coding pattern | `.cursor/rules/<name>.mdc` |
 | One-off session context | Chat memory (do not persist) |
 
@@ -208,11 +202,11 @@ When spawning subagents, include:
 When shipping multiple dependent changes:
 
 ```
-main (v0.8.2)
+main (v0.9.0)
   └── fix/thing           → PR, CI green, merge
-        └── chore/release-0.8.x  → PR, CI green, merge, PUBLISH
+        └── chore/release-X.Y.Z  → PR, CI green, merge, PUBLISH
               └── feature/next   → PR, CI green, merge
-                    └── chore/release-0.6.0  → PR, CI green, merge, PUBLISH
+                    └── chore/release-X.Y.Z  → PR, CI green, merge, PUBLISH
 ```
 
 Each branch is created from the **updated main** after the previous PR merges. Gate: `npm run build && npm test` green before each PR opens.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,10 @@ npm install
 npm run build
 ```
 
-Run the CLI against any URL to verify the build works (from `packages/core` so the default `qulib.config.ts` is found):
+Run the CLI against any URL to verify the build works:
 
 ```bash
-cd packages/core
-node bin/qulib.js analyze --url https://example.com --ephemeral
+node packages/core/bin/qulib.js analyze --url https://example.com --ephemeral
 ```
 
 You should see a JSON report on stdout with a `releaseConfidence` score.
@@ -24,7 +23,7 @@ You should see a JSON report on stdout with a `releaseConfidence` score.
 
 1. Open an issue first if the change is non-trivial — saves wasted effort if the direction needs discussion.
 2. Read `CLAUDE.md` — it documents the project's rules, branch conventions, and design principles.
-3. Run `npm run build` and confirm it passes before submitting.
+3. Run `npm run build && npm test` and confirm both pass before submitting.
 
 ## Branch and commit conventions
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,6 @@ npm run smoke
 npx @qulib/core cost doctor
 ```
 
-> **Note:** the config-fallback improvement is landing in a parallel PR. Until it merges, run
-> these commands from `packages/core` (where a default `qulib.config.ts` exists) or pass
-> `--config <path>` explicitly.
-
 ---
 
 ## Quick start (MCP)
@@ -127,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Qulib analyze gate
-        uses: TapeshN/qulib/.github/actions/qulib-analyze@v0.9.0
+        uses: TapeshN/qulib/.github/actions/qulib-analyze@v1
         with:
           url: https://your-app.example.com
           fail-on: fail        # fail (default) | warn | never
@@ -140,7 +136,7 @@ jobs:
 # .github/workflows/qa.yml
 jobs:
   qa:
-    uses: TapeshN/qulib/.github/workflows/qulib-analyze.yml@v0.9.0
+    uses: TapeshN/qulib/.github/workflows/qulib-analyze.yml@v1
     with:
       url: https://your-app.example.com
       fail-on: warn
@@ -187,7 +183,7 @@ Every run **uploads the agent-summary JSON as an artifact** (`qulib-agent-summar
 | `blocked` | `true` if the gate violated the `fail-on` policy (the job was failed). |
 | `summary-path` | Path to the written agent-summary JSON artifact. |
 
-> The composite action lives at [`.github/actions/qulib-analyze`](./.github/actions/qulib-analyze) and the reusable workflow at [`.github/workflows/qulib-analyze.yml`](./.github/workflows/qulib-analyze.yml). Reference them at a tag (e.g. `@v0.9.0`) for reproducible CI.
+> The composite action lives at [`.github/actions/qulib-analyze`](./.github/actions/qulib-analyze) and the reusable workflow at [`.github/workflows/qulib-analyze.yml`](./.github/workflows/qulib-analyze.yml). Reference them at a stable tag (e.g. `@v1`) for reproducible CI.
 
 ---
 

--- a/docs/manual-testing-checklist.md
+++ b/docs/manual-testing-checklist.md
@@ -58,27 +58,27 @@ node packages/core/bin/qulib.js detect-auth --url "<URL>" --timeout 30000
 | Amazon | `https://www.amazon.com/ap/signin` | Often `unknown`; storage-state path should stay honest |
 | Wikipedia | `https://en.wikipedia.org/wiki/Main_Page` | May follow login link → `form-login` on `Special:UserLogin` |
 
-## Scaffold CLI (`qulib scaffold` — shipped v0.7.0)
+## Scaffold CLI (`qulib scaffold`)
 
 - [ ] Dry-run: `node packages/core/bin/qulib.js scaffold --url https://notquality.com --dry-run` exits 0 and prints `[qulib scaffold] Dry-run` without writing files
 - [ ] Write mode: `node packages/core/bin/qulib.js scaffold --url https://notquality.com --out /tmp/qulib-scaffold-test` exits 0, writes `projectConfig.json` + at least one spec file
 - [ ] `--json` flag: output is valid JSON with a `specs` array
-- [ ] Framework flag: `--framework playwright` produces `.spec.ts` files; `--framework cypress` produces `.cy.ts` files
+- [ ] Framework flag: `--framework cypress-e2e` produces `.cy.ts` files; `--framework playwright` currently errors with an actionable message (adapter not yet implemented)
 
-## Score-automation CLI (`qulib score-automation` — shipped v0.7.0)
+## Score-automation CLI (`qulib score-automation`)
 
 - [ ] `node packages/core/bin/qulib.js score-automation --repo .` exits 0 and prints an automation maturity score
 - [ ] `--json` flag: output is valid JSON with `automationMaturity.score` and `automationMaturity.level`
 - [ ] Missing `--repo` exits non-zero with a clear error message
 
-## Confidence CLI (`qulib confidence` — shipped v0.8.x)
+## Confidence CLI (`qulib confidence`)
 
 - [ ] `node packages/core/bin/qulib.js confidence --url https://notquality.com` exits 0, prints a `ship | caution | hold | block` verdict and score
 - [ ] `--json` flag: output is valid JSON with `verdict` and `confidenceScore` fields
 - [ ] `--repo .` combined with `--url` merges automation maturity into the confidence input
 - [ ] Missing both `--url` and `--repo` exits non-zero with a clear error
 
-## Cost doctor (`qulib cost doctor` — shipped v0.6.0)
+## Cost doctor (`qulib cost doctor`)
 
 - [ ] Run `node packages/core/bin/qulib.js analyze --url https://notquality.com` (non-ephemeral) to generate `output/report.json`
 - [ ] `node packages/core/bin/qulib.js cost doctor` (from `packages/core`) prints `maxOutputTokensPerLlmCall`, `usageSummary`, and `deterministicMaturity`

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -109,4 +109,5 @@ When adding a test file: append its path to `packages/core/package.json "test"` 
 | Q3 | Baseline monitor (`saveBaseline`, `loadBaseline`, `compareBaselines`) | SHIPPED |
 | Q4 | Recipe toolshed (`auth`, `a11y`, `nav`, `seed`) | SHIPPED |
 | Q5 | API coverage scoring (`computeApiCoverage`, `qulib_score_api`) | SHIPPED |
+| Q6 | *(reserved — not assigned; Q7 follows Q5 in the shipping sequence)* | N/A |
 | Q7 | **Confidence Aggregator** — fused release confidence verdict | SHIPPED |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -345,22 +345,19 @@ qulib analyze --url https://yourapp.com --auth-storage-state ./qulib-storage-sta
 
 ## Sample report (fixture baseline)
 
-From the local fixture baseline used in v0.5.0 PR 1/2:
+The fixture tests in `packages/core/src/__tests__/analyze.fixtures.test.ts` assert structural shape — that `releaseConfidence` is a number, `gaps` is an array, and coverage scores are non-negative. Exact scores vary with each scoring version; re-run the fixture suite for current reference values.
+
+A minimal structural snapshot looks like:
 
 ```json
 {
   "status": "complete",
   "releaseConfidence": 68,
   "gaps": [
-    "... 4 total gap items ..."
+    "... gap items ..."
   ]
 }
 ```
-
-Use these as conservative reference numbers:
-- public fixture (`/`): `releaseConfidence: 68/100`, `gaps: 4`
-- auth-wall fixture (`/auth`): `releaseConfidence: 24/100`, `gaps: 2`
-- broken fixture (`/broken`): `releaseConfidence: 0/100`, `gaps: 6`
 
 ## MCP tools quick map
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -136,8 +136,6 @@ When the model sees **`unrecognizedButtons`**, it can ask the user to register a
 | Size | Small: top gaps, cost summary, next checks, `repoInventorySummary` (counts only) | Full `gapAnalysis` (all scenarios) and full `repoInventory` (test files, missing test IDs) |
 | When to use | Routine agent turns, chat context limits | Deep dives, exporting full scenario JSON |
 
-> **0.4.2 note:** The compact response now ships `repoInventorySummary` (route/test/missing-id counts plus framework verdict) instead of the full `repoInventory`. Agents that need the raw `testFiles` or `missingTestIds` arrays should pass `includeFullReport: true`.
-
 Example (full):
 
 ```json


### PR DESCRIPTION
## Summary

Pre-release doc maintenance sweep ahead of v0.9.0. Surgical fixes only — no voice changes, no restructuring. No package.json / CHANGELOG / VERSION / lockfiles / .github/ touched.

## Fixes applied

**CLAUDE.md**
- Current version updated v0.8.2 → v0.9.0 (evidence: `packages/core/package.json` and `packages/mcp/package.json` both at 0.9.0; HEAD is the release-0.9.0 merge)
- Removed dead `roadmap.json` read directives — the file does not exist in the repo; the PR-train workflow and release ritual are the operative procedures
- PR-train diagram example updated: `main (v0.8.2)` → `main (v0.9.0)`, `chore/release-0.6.0` → `chore/release-X.Y.Z` (generic)
- "ship 0.7.0" example command changed to "ship X.Y.Z" (v0.7.0 shipped long ago)

**README.md**
- Removed the stale config-fallback Note block (lines 90-93): PR #113 (`fix(cli): fall back to built-in defaults when no config file is present`) is merged; commands work from repo root without `--config`
- CI integration examples: changed all three `@v0.9.0` references to `@v1` to match what `.github/workflows/qulib-analyze.yml` itself recommends to consumers (lines 9 and 15 of that file show `@v1`); no `v0.9.0` git tag exists

**CONTRIBUTING.md**
- "Before opening a PR" step 3: added `npm test` — `npm run build && npm test` matches the hard stop documented in CLAUDE.md line 84
- Quick local setup: removed the `cd packages/core` workaround (also stale now that config-fallback PR is merged); path adjusted to `node packages/core/bin/qulib.js` from repo root

**docs/manual-testing-checklist.md**
- Scaffold framework flag check: `--framework cypress` does not exist (accepted values are `cypress-e2e` and `playwright`); `--framework playwright` errors with an actionable message (evidence: `packages/core/src/cli/scaffold-run.ts` line 34 `FRAMEWORKS = ['cypress-e2e', 'playwright']`, line 163 error message)
- Removed `— shipped vX.Y.Z` annotations from all four section headers (Scaffold, Score-automation, Confidence, Cost doctor) — with v0.9.0 about to publish these are all stale

**docs/source-map.md**
- Added Q6 N/A row to explain the skip from Q5 to Q7 in the feature phases table

**packages/core/README.md**
- Replaced the unverifiable v0.5.0 fixture numbers (releaseConfidence: 68/24/0) with a note pointing to the fixture test for structural guarantees — `analyze.fixtures.test.ts` asserts shape only, never exact numbers, so the pinned values were misleading

**packages/mcp/README.md**
- Removed the `0.4.2 note` callout — six versions old; the stable compact-vs-full table directly above it already documents the distinction accurately without a stale version attribution

## Floors confirmed

- Docs/markdown only — zero source, config, or workflow files modified
- No merge (floor)
- No force-push (floor)
- CHANGELOG / VERSION / package.json / lockfiles untouched (no-touch list)
- IP boundary: the only blocklist match in modified files is a pre-existing `GitLab` URL in the Known tricky URLs regression table of manual-testing-checklist.md (present since commit c32d493, not introduced by this PR)