### PR TITLE
docs: fix post-publish accuracy and disable broken PR State Sync workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Entries for **0.3.1 and earlier** were reconstructed from git tags (`v0.1.1` … `v0.2.2`) and release commits on `main`.
 
-## [0.9.0] — 2026-06-11
+## [0.9.0] — 2026-06-10
 
 This release promotes all work merged since v0.8.2 (PRs #92–#113). The headline fix is a broken installed CLI (any `npx @qulib/core` quickstart failed on published v0.8.2); the headline feature is the Release Confidence Layer — qulib can now answer "should we ship?" with a fused, multi-signal verdict.
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,6 @@ npm run smoke
 npx @qulib/core cost doctor
 ```
 
-> **Note:** the config-fallback improvement is landing in a parallel PR. Until it merges, run
-> these commands from `packages/core` (where a default `qulib.config.ts` exists) or pass
-> `--config <path>` explicitly.
-
 ---
 
 ## Quick start (MCP)

--- a/docs/demo/CRIB-SHEET.md
+++ b/docs/demo/CRIB-SHEET.md
@@ -1,6 +1,11 @@
 # qulib Friday Demo — Crib Sheet
 ## "Should We Ship?" — 5-minute script
 
+> **Working directory assumption:** all commands and asset paths below are relative to the repo root
+> (`TapeshN/qulib`). Absolute paths where the file is referenced outside a `cd` context:
+> `<repo-root>/docs/demo/analyze-notquality.json`, `<repo-root>/docs/demo/confidence-notquality.json`,
+> `<repo-root>/docs/demo/analyze-example.json`.
+
 > Everything runs from `@qulib/core@0.9.0` and `@qulib/mcp@0.9.0` (published Thursday).
 > MCP pre-registered in Claude Code before taking the stage.
 > Fallback JSONs in this directory — narrate one if a live step fails twice, never debug on stage.
@@ -20,7 +25,7 @@ claude mcp add qulib -- npx -y @qulib/mcp
 Pre-stage checklist:
 - `notquality` repo checked out at `~/demo/notquality`
 - Claude Code open, qulib MCP registered (7 tools visible)
-- Browser tab with Thursday's green Actions run open (NOT a live run)
+- Browser tab with Thursday's green `qulib-action selftest` Actions run open (NOT a live run)
 - Fallback JSONs staged in a terminal: `cat ~/path/to/analyze-notquality.json`
 - Hotspot active, terminal font size 20+
 
@@ -41,7 +46,7 @@ npx -y @qulib/core@0.9.0 --version
 
 **Failure drill:** If `npx` fails or hangs — say "let me show you what 0.9.0 outputs" and run:
 ```
-cat docs/demo/analyze-notquality.json | jq '.status, .detectedAuth.type'
+cat <repo-root>/docs/demo/analyze-notquality.json | jq '.status, .detectedAuth.type'
 ```
 
 ---
@@ -60,10 +65,12 @@ npx -y @qulib/core@0.9.0 analyze --url https://notquality.com
 status: partial
 detectedAuth: { type: "oauth", provider: "github" }
 gaps: [
-  { severity: "critical", category: "coverage",
-    reason: "Scan blocked by authentication…" },
   { severity: "medium", category: "auth-surface",
-    reason: "OAuth-only entry with no password fallback…" }
+    reason: "OAuth-only entry with no password fallback…" },
+  { severity: "low", category: "auth-surface",
+    reason: "No visible "forgot password" or help path detected…" },
+  { severity: "critical", category: "coverage",
+    reason: "Scan blocked by authentication…" }
 ]
 decisionLog: [ "exploration-complete", "auth-required", … ]
 ```
@@ -76,7 +83,7 @@ decisionLog: [ "exploration-complete", "auth-required", … ]
 **Failure drill (if live command fails twice):** Open `docs/demo/analyze-notquality.json` and narrate:
 - `status: partial` — partial scan
 - `detectedAuth.type: oauth` — caught the GitHub OAuth wall
-- Three gaps: `critical` auth-block, `medium` no-fallback-login, `low` no-recovery-link
+- Three gaps (JSON order): `medium` no-fallback-login, `low` no-recovery-link, `critical` auth-block
 - `releaseConfidence: 0` — honestly zero because the protected surface was not seen
 
 ---
@@ -101,8 +108,8 @@ npx -y @qulib/core@0.9.0 confidence --url https://notquality.com --repo .
     - live-app-quality [unknown] [BLOCKER]: n/a  excluded
     - accessibility [unknown]: n/a  excluded
     - crawl-coverage [unknown]: n/a  excluded
-    - test-automation [applicable]: 86/100  ew=50.0%
-    - api-coverage [applicable]: 100/100  ew=50.0%
+    - test-automation [applicable]: 86/100  ew=59.5%
+    - api-coverage [applicable]: 100/100  ew=40.5%
   honesty notes:
     • 'live-app-quality' source could not produce a reliable score: Auth wall…
 ```


### PR DESCRIPTION
## Summary

- **CHANGELOG.md:** correct `[0.9.0]` date from `2026-06-11` to `2026-06-10` (actual publish date tonight)
- **README.md:** remove stale note telling users to run from `packages/core` until the config-fallback PR merges — that shipped in PR #113
- **docs/demo/CRIB-SHEET.md** (four corrections):
  - **3a — asset paths:** add working-directory assumption block at top of sheet; failure-drill command now uses absolute-from-repo-root path (`<repo-root>/docs/demo/…`)
  - **3b — Beat 3 weights:** expected output changed from `ew=50.0%` / `ew=50.0%` to `ew=59.5%` / `ew=40.5%` — matches the actual `effectiveWeight` values in `confidence-notquality.json` (`0.5946` / `0.4054`)
  - **3c — Beat 2 gap order:** expected output shape and failure-drill narration reordered from critical-first to `medium → low → critical`, matching the real JSON array order in `analyze-notquality.json`
  - **3d — Actions workflow name:** standardized pre-stage checklist (was vague "Actions run") to `qulib-action selftest` — consistent with Beat 4 narration and the Friday-morning checklist
- **PR State Sync workflow disabled** via `gh workflow disable` (37 consecutive red runs; reads as repo rot when the Actions tab is open on stage; re-enable post- is a one-liner: `gh workflow enable "PR State Sync" --repo TapeshN/qulib`)

## Witness log

- `npm run build` — clean (no TypeScript errors)
- `PLAYWRIGHT_SKIP=1 npm test` — 17/17 pass, 0 fail
- `gh workflow list --repo TapeshN/qulib` — PR State Sync absent from active list (confirmed disabled)
- `jq` sanity on both demo JSONs — parse valid; gap order and effective weights match corrections in sheet

## Floors

No version bumps, no npm publish, no merge.
