### PR TITLE
ci: move GitHub-owned actions off Node 20 before the June 16 forced Node-24 cutover

### DIFF
--- a/.github/actions/qulib-analyze/action.yml
+++ b/.github/actions/qulib-analyze/action.yml
@@ -81,9 +81,13 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
+        # v5+ auto-caches when a packageManager field is present; this action
+        # does no `npm ci`, so keep v4's no-cache behavior to avoid a
+        # "lockfile not found" failure in consumer repos without a lockfile.
+        package-manager-cache: false
 
     - name: Install Playwright Chromium
       if: ${{ inputs.install-browser == 'true' }}
@@ -124,7 +128,7 @@ runs:
 
     - name: Upload agent-summary artifact
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: qulib-agent-summary
         path: ${{ inputs.output-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     name: Build & type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -53,10 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -77,8 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -94,10 +94,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,10 @@ jobs:
     name: Publish (core then mcp, with provenance)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/qulib-action-selftest.yml
+++ b/.github/workflows/qulib-action-selftest.yml
@@ -24,9 +24,9 @@ jobs:
     name: gate.mjs end-to-end (offline fixture)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/qulib-analyze.yml
+++ b/.github/workflows/qulib-analyze.yml
@@ -86,14 +86,14 @@ jobs:
     steps:
       - name: Check out caller repo
         if: ${{ inputs.checkout }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # The composite action lives in this repo, so check it out to a subdir
       # to reference it by local path. (When the action is published, callers
       # use `uses: TapeshN/qulib/.github/actions/qulib-analyze@v1` directly and
       # do not need this step.)
       - name: Check out qulib (for the composite action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: TapeshN/qulib
           ref: ${{ inputs.qulib-version != 'latest' && format('v{0}', inputs.qulib-version) || 'main' }}


### PR DESCRIPTION
## Why

GitHub Actions **forces Node.js 24 on June 16, 2026** and **removes Node 20 from runners on Sept 16, 2026**. Our workflows pinned `actions/checkout`, `actions/setup-node`, and `actions/upload-artifact` to majors that still run on Node 20 — the **v0.10.0 publish run (2026-06-13) emitted the Node-20 deprecation annotation**. The next release after June 16 could otherwise fail to publish.

## What

Bumped every GitHub-owned action across `.github/` to its **current latest major** (Node 24 runtime). The original task referenced `@v5`, but latest-major has since moved on, so this targets the true latest:

| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/checkout` | v4 | **v6** | Node 24 |
| `actions/setup-node` | v4 | **v6** | Node 24 |
| `actions/upload-artifact` | v4 | **v7** | Node 24 |

Files touched: `publish.yml`, `ci.yml` (5 jobs), `qulib-action-selftest.yml`, `qulib-analyze.yml`, and the composite action `.github/actions/qulib-analyze/action.yml` (same Node-20 deprecation in our public reusable surface).

## Compatibility verified against each action's release notes

- **checkout v4→v6** — v5 is the Node-24 move; v6 only changes internal credential-file handling. No inputs removed. We use bare checkout plus `repository`/`ref`/`path` (all stable). Drop-in.
- **setup-node v4→v6** — `node-version` / `registry-url` / `cache` all preserved. v5+ added auto-caching (v6 narrows it to npm); our workflow steps set `cache: "npm"` explicitly so behavior is unchanged. The composite action does no `npm ci`, so it sets `package-manager-cache: false` to keep v4's no-cache behavior and avoid a "lockfile not found" failure in consumer repos.
- **upload-artifact v4→v7** — `name` / `path` / `if-no-files-found` preserved; v7 adds an opt-in `archive` param (default `true` = old zip behavior) and moves internals to ESM. Compatible.

## Scope guardrails

- **Config-only.** No package version bump, no publish.
- **OIDC trusted publishing left exactly as-is** — `id-token: write`, `--provenance`, `release: [published]` trigger, `registry-url`, and the build/publish `node-version: "20"` are unchanged (that's the Node the package builds/publishes *on*, distinct from the action runtime this PR fixes).
- All five files re-validated as parseable YAML.

Closes #127