### PR TITLE
ci: add report-only security scan workflow (gitleaks + semgrep + npm audit)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,100 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    # Report-only: findings are surfaced but do not fail the PR.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+  semgrep:
+    name: OWASP + TS static analysis (semgrep)
+    runs-on: ubuntu-latest
+    # Report-only: findings surface as job summary / artifact; no --error flag.
+    continue-on-error: true
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run semgrep
+        run: |
+          semgrep \
+            --config p/owasp-top-ten \
+            --config p/typescript \
+            --config p/react \
+            --sarif \
+            --output semgrep-results.sarif \
+            --no-rewrite-rule-ids \
+            . || true
+
+      - name: Write job summary
+        if: always()
+        run: |
+          echo "## Semgrep findings" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f semgrep-results.sarif ]; then
+            TOTAL=$(python3 -c "
+          import json, sys
+          data = json.load(open('semgrep-results.sarif'))
+          results = []
+          for run in data.get('runs', []):
+              results.extend(run.get('results', []))
+          print(len(results))
+          " 2>/dev/null || echo "unknown")
+            echo "Total findings: **${TOTAL}** (report-only — not blocking merge)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No SARIF output found." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload SARIF as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: semgrep-sarif
+          path: semgrep-results.sarif
+          if-no-files-found: ignore
+
+  npm-audit:
+    name: Dependency audit (informational)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: npm audit (high+)
+        run: |
+          npm audit --audit-level=high --json | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          meta = data.get('metadata', {})
+          vulns = meta.get('vulnerabilities', {})
+          total = meta.get('totalDependencies', '?')
+          print(f'Vulnerabilities: critical={vulns.get(\"critical\",0)}, high={vulns.get(\"high\",0)}, moderate={vulns.get(\"moderate\",0)}, low={vulns.get(\"low\",0)}')
+          print(f'Total dependencies scanned: {total}')
+          " 2>/dev/null || true
+          npm audit --audit-level=high || true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/security.yml` — a new, additive CI workflow (does not touch `publish.yml` or any existing workflow)
- Three report-only jobs, all with `continue-on-error: true`:
  - **gitleaks** — scans full git history for committed secrets (official `gitleaks/gitleaks-action@v2`)
  - **semgrep** — runs `p/owasp-top-ten`, `p/typescript`, `p/react` rulesets; SARIF uploaded as artifact; finding count written to job summary
  - **npm-audit** — `npm audit --audit-level=high` informational summary
- No findings block merge in this round. Promote to blocking after the initial triage pass.

## Local baseline (2026-06-16)

| Scanner | Critical | High | Medium | Low |
|---|---|---|---|---|
| semgrep (owasp-top-ten) | 0 | 0 | 0 | 1 finding (shell-injection pattern in existing `qulib-analyze/action.yml`) |
| semgrep (typescript) | 0 | 0 | 0 | 0 |
| semgrep (react) | 0 | 0 | 0 | 0 |
| npm audit | 0 | 0 | 0 | 0 |

The one OWASP finding is in an existing workflow file, not new code — tracked for a follow-up triage.

## Test plan

- [ ] PR CI triggers the new `Security Scan` workflow on this PR itself (pull_request trigger)
- [ ] All three jobs show `continue-on-error` — any finding surfaces in the summary without blocking merge
- [ ] No existing workflows (`ci.yml`, `publish.yml`, `pr-state-sync.yml`) are modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)