### PR TITLE
Add prompt-leakage coverage tag to golden manifest and eval gate

### DIFF
--- a/datasets/golden/manifest.json
+++ b/datasets/golden/manifest.json
@@ -144,17 +144,6 @@
       }
     },
     {
-      "id": "gemini-google",
-      "url": "https://gemini.google.com/",
-      "name": "Google Gemini",
-      "rationale": "Public Google AI assistant entry point; no auth wall on first paint; clean prompt-leakage negative control.",
-      "coverage_tags": ["prompt-leakage", "none"],
-      "expected": {
-        "hasAuth": false,
-        "leaksPrompt": false
-      }
-    },
-    {
       "id": "you-com",
       "url": "https://you.com/",
       "name": "You.com",

--- a/datasets/golden/manifest.json
+++ b/datasets/golden/manifest.json
@@ -9,7 +9,8 @@
     "none",
     "public",
     "click-reveal",
-    "spa"
+    "spa",
+    "prompt-leakage"
   ],
   "sites": [
     {
@@ -129,6 +130,39 @@
       "coverage_tags": ["spa"],
       "expected": {
         "hasAuth": true
+      }
+    },
+    {
+      "id": "huggingface-chat",
+      "url": "https://huggingface.co/chat/",
+      "name": "Hugging Face Chat",
+      "rationale": "Public AI chat landing page; exercises prompt-leakage detection on a consumer assistant surface with no login wall.",
+      "coverage_tags": ["prompt-leakage", "none"],
+      "expected": {
+        "hasAuth": false,
+        "leaksPrompt": false
+      }
+    },
+    {
+      "id": "gemini-google",
+      "url": "https://gemini.google.com/",
+      "name": "Google Gemini",
+      "rationale": "Public Google AI assistant entry point; no auth wall on first paint; clean prompt-leakage negative control.",
+      "coverage_tags": ["prompt-leakage", "none"],
+      "expected": {
+        "hasAuth": false,
+        "leaksPrompt": false
+      }
+    },
+    {
+      "id": "you-com",
+      "url": "https://you.com/",
+      "name": "You.com",
+      "rationale": "Public AI search assistant homepage; readable without credentials; expected to pass prompt-leakage scan.",
+      "coverage_tags": ["prompt-leakage", "none"],
+      "expected": {
+        "hasAuth": false,
+        "leaksPrompt": false
       }
     }
   ]

--- a/packages/core/evals/runner/__tests__/golden-manifest.test.ts
+++ b/packages/core/evals/runner/__tests__/golden-manifest.test.ts
@@ -5,14 +5,14 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { loadGoldenManifest, goldenManifestPath } from '../load-golden-manifest.js';
 
-test('loadGoldenManifest: tracked manifest parses and has 8-12 diverse sites', () => {
+test('loadGoldenManifest: tracked manifest parses and has 8-14 diverse sites', () => {
   const manifest = loadGoldenManifest();
 
   assert.equal(manifest.schemaVersion, 1);
   assert.ok(manifest.coverage_tags.length >= 5, 'manifest must declare coverage_tags');
   assert.ok(
-    manifest.sites.length >= 8 && manifest.sites.length <= 12,
-    `expected 8-12 sites, got ${manifest.sites.length}`
+    manifest.sites.length >= 8 && manifest.sites.length <= 14,
+    `expected 8-14 sites, got ${manifest.sites.length}`
   );
 
   const siteTags = new Set<string>();
@@ -24,7 +24,7 @@ test('loadGoldenManifest: tracked manifest parses and has 8-12 diverse sites', (
     }
   }
 
-  for (const required of ['form-login', 'oauth', 'magic-link', 'none'] as const) {
+  for (const required of ['form-login', 'oauth', 'magic-link', 'none', 'prompt-leakage'] as const) {
     assert.ok(siteTags.has(required), `coverage must include at least one "${required}" site`);
   }
 });

--- a/packages/core/src/schemas/golden-manifest.schema.ts
+++ b/packages/core/src/schemas/golden-manifest.schema.ts
@@ -5,6 +5,7 @@ export const GoldenSiteExpectedSchema = z
   .object({
     hasAuth: z.boolean().optional(),
     type: z.enum(['none', 'form-login', 'oauth', 'magic-link', 'unknown']).optional(),
+    leaksPrompt: z.boolean().optional(),
   })
   .strict();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this PR does

Wires the `detectPromptLeakage()` scorer into the golden dataset manifest and eval gate by declaring `prompt-leakage` as a first-class coverage tag, adding three public AI-assistant negative-control sites, and extending the golden expected schema with an optional `leaksPrompt` boolean.

## Why

The prompt-leakage scorer shipped in v0.10.0 but had no representation in `datasets/golden/manifest.json`, so QA sweeps and the eval gate could not assert coverage for this dimension.

## Type

- [x] New feature

## Checklist

- [x] Branched from `main`
- [x] `npm run build` passes
- [x] `npm run test` passes (including `golden-manifest.test.ts` prompt-leakage assertion and existing `prompt-leakage.test.ts` unit tests)
- [x] Commit messages follow `type: short description`
- [x] No new dependencies added
- [x] Output remains honest

## Changes

- **`datasets/golden/manifest.json`**: Added `prompt-leakage` to top-level `coverage_tags`; added three public, no-login AI assistant pages (`huggingface-chat`, `gemini-google`, `you-com`) tagged `['prompt-leakage','none']` with `expected { hasAuth: false, leaksPrompt: false }`.
- **`packages/core/src/schemas/golden-manifest.schema.ts`**: Additive optional `leaksPrompt` field on `GoldenSiteExpected`.
- **`packages/core/evals/runner/__tests__/golden-manifest.test.ts`**: Assert `prompt-leakage` appears in site tags; bump site-count upper bound from 12 to 14.

## Gate output

```
npm run build && npm run test
# build: PASS (core + mcp tsc)
# test: PASS — zero failures
# golden-manifest: ok 30-33 (prompt-leakage assertion GREEN)
# prompt-leakage unit tests: ok 483-489
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d5f400a-4098-54a8-91f0-1fda657f84fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d5f400a-4098-54a8-91f0-1fda657f84fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

