### PR TITLE
Refresh public roadmap and README status for v0.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ datasets/*
 !datasets/golden/
 datasets/golden/*
 !datasets/golden/manifest.json
-roadmap.json

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ On npm: **`@qulib/core`** (engine + CLI `qulib`) and **`@qulib/mcp`** (MCP serve
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![CI](https://github.com/TapeshN/qulib/actions/workflows/ci.yml/badge.svg)](https://github.com/TapeshN/qulib/actions/workflows/ci.yml)
 
+**Status:** [`@qulib/core`](https://www.npmjs.com/package/@qulib/core) and [`@qulib/mcp`](https://www.npmjs.com/package/@qulib/mcp) **v0.10.0** are published on npm. See [`roadmap.json`](./roadmap.json) for shipped capabilities and the trust / release-confidence path to v1.0.0.
+
 ---
 
 ## What Qulib does
@@ -143,6 +145,7 @@ The agent will call **`qulib_score_confidence`** for the fused release verdict, 
 | `qulib_score_api` | API endpoint discovery + test coverage: are your routes exercised? |
 | `qulib_scaffold_tests` | Ready-to-run Cypress spec + config, generated from a live crawl. |
 | **`qulib_diff`** | Structured diff between two analyze outputs — added findings, resolved findings, severity changes, and a confidence delta. |
+| **`qulib_detect_prompt_leakage`** | Scan a page surface for signals that AI system prompts or agent instructions are inadvertently exposed publicly. |
 | `qulib_explore_auth` | All sign-in paths (OAuth, SSO, forms, magic link) and what to collect before scanning. |
 | `qulib_detect_auth` | Single-pass auth pattern guess with a recommendation. Lighter than `explore_auth`. |
 
@@ -259,11 +262,15 @@ qulib confidence --url https://example.com [--repo /path/to/repo] [--json]
 
 ### The 5 views (data model)
 
-1. **Release Confidence** — the fused score + verdict (available now; the `computeReleaseConfidence` output)
-2. **Delivery Traffic** — time-series of verdicts per subject (schema + `diffConfidence` helper; persistence P4)
-3. **Inbox** — human-judgment items: blockers, unknown signals, approvals needed (schema + `deriveInbox`; queue P4)
-4. **Replay** — provenance trace: how each score was computed and by which tool (`buildReplay`)
-5. **Audit Trail** — tamper-evident append-only ledger entry per verdict (`toAuditEntry`; sink P4)
+| View | Status | Notes |
+|---|---|---|
+| **Release Confidence** | **Shipped** | Fused score + verdict via `computeReleaseConfidence` / `qulib_score_confidence` |
+| **Replay** | **Shipped** | Provenance trace — how each score was computed and by which tool (`buildReplay`) |
+| **Delivery Traffic** | Planned | Time-series of verdicts per subject (`diffConfidence` helper exists; persistence planned for 1.0) |
+| **Inbox** | Planned | Human-judgment queue for blockers and approvals (`deriveInbox` helper exists; workflow planned for 1.0) |
+| **Audit Trail** | Planned | Tamper-evident ledger entry per verdict (`toAuditEntry` helper exists; sink planned for 1.0) |
+
+The forward roadmap centers on **trust**: witnessed delivery state, durable provenance, and later **agent-action / skill gating** so orchestrators can safely act on ship verdicts. Details: [`roadmap.json`](./roadmap.json).
 
 **Honesty over fake confidence:** sources that are `not_applicable`, `unknown`, or `null` are excluded from the denominator but reported in `contributions` and `honestyNotes`. An auth wall or empty corpus forces `verdict=block` — qulib never silently passes an unevaluated surface.
 
@@ -349,6 +356,7 @@ A more complete dogfood example using real notquality.com signals is at [`packag
 
 - [Core (CLI, API, Cost Intelligence)](./packages/core/README.md)
 - [MCP server](./packages/mcp/README.md)
+- [Public roadmap](./roadmap.json) — shipped tools and planned trust / release-confidence milestones
 - [Source map](./docs/source-map.md) — new contributors: start here to navigate the codebase
 - [Contributing](./CONTRIBUTING.md)
 - [Security](./SECURITY.md)

--- a/roadmap.json
+++ b/roadmap.json
@@ -1,0 +1,137 @@
+{
+  "schemaVersion": 1,
+  "lastUpdated": "2026-06-22",
+  "positioning": "Release confidence for deployed web apps — the one question: should this ship?",
+  "version": {
+    "current": "0.10.0",
+    "published": "0.10.0",
+    "target": "1.0.0"
+  },
+  "direction": {
+    "summary": "Ship honest release-confidence evidence today; deepen trust with provenance, witnessed state, and later agent-action gating.",
+    "northStar": "Every ship verdict should be explainable, replayable, and safe to act on in CI and agent workflows."
+  },
+  "shipped": [
+    {
+      "id": "live-app-analysis",
+      "title": "Live-app gap analysis",
+      "summary": "Crawl a deployed URL, run deterministic checks (a11y, links, console, coverage), and emit structured gap reports.",
+      "tools": ["qulib_analyze_app", "analyze_app"],
+      "shippedIn": "0.3.0"
+    },
+    {
+      "id": "auth-intelligence",
+      "title": "Auth detection and exploration",
+      "summary": "Detect sign-in patterns and enumerate auth paths before scanning authenticated surfaces.",
+      "tools": ["qulib_detect_auth", "detect_auth", "qulib_explore_auth", "explore_auth"],
+      "shippedIn": "0.5.0"
+    },
+    {
+      "id": "automation-maturity",
+      "title": "Repo automation maturity scoring",
+      "summary": "Score test-automation maturity from a local checkout without a live crawl.",
+      "tools": ["qulib_score_automation"],
+      "shippedIn": "0.9.0"
+    },
+    {
+      "id": "api-coverage",
+      "title": "API endpoint coverage scoring",
+      "summary": "Discover API routes in a repo and score how well they are exercised by tests.",
+      "tools": ["qulib_score_api"],
+      "shippedIn": "0.8.0"
+    },
+    {
+      "id": "release-confidence",
+      "title": "Fused release-confidence verdict",
+      "summary": "Combine live-app, automation, and API evidence into one ship / caution / hold / block verdict with honesty notes.",
+      "tools": ["qulib_score_confidence"],
+      "shippedIn": "0.9.0"
+    },
+    {
+      "id": "test-scaffolding",
+      "title": "Crawl-driven test scaffolding",
+      "summary": "Generate ready-to-run Cypress specs and config from a live URL crawl.",
+      "tools": ["qulib_scaffold_tests"],
+      "shippedIn": "0.9.0"
+    },
+    {
+      "id": "analyze-diff",
+      "title": "Structured analyze diff and baseline drift",
+      "summary": "Diff two analyze outputs for added/resolved gaps, severity changes, and confidence delta. CLI baseline save/list/compare plus MCP diff.",
+      "tools": ["qulib_diff"],
+      "shippedIn": "0.10.0"
+    },
+    {
+      "id": "prompt-leakage",
+      "title": "Prompt and instruction exposure detection",
+      "summary": "Scan page surfaces for signals that AI system prompts or agent instructions are publicly exposed.",
+      "tools": ["qulib_detect_prompt_leakage"],
+      "shippedIn": "0.10.0"
+    },
+    {
+      "id": "ci-gate",
+      "title": "GitHub Actions release gate",
+      "summary": "Composite action and reusable workflow that map agent-summary gate verdicts to CI pass/fail with artifact upload.",
+      "tools": [],
+      "shippedIn": "0.9.0"
+    },
+    {
+      "id": "confidence-views-core",
+      "title": "Confidence data model — release verdict and replay",
+      "summary": "Release-confidence output and provenance replay trace are available programmatically; delivery traffic, inbox, and audit sinks are planned.",
+      "tools": [],
+      "shippedIn": "0.9.0"
+    }
+  ],
+  "planned": [
+    {
+      "id": "witnessed-delivery-traffic",
+      "title": "Witnessed delivery traffic",
+      "summary": "Persist a time-series of release-confidence verdicts per subject so drift and regressions are visible across deploys.",
+      "targetRelease": "1.0.0",
+      "theme": "trust"
+    },
+    {
+      "id": "human-inbox",
+      "title": "Human judgment inbox",
+      "summary": "Queue blockers, unknown signals, and approval items derived from confidence output for operator review.",
+      "targetRelease": "1.0.0",
+      "theme": "trust"
+    },
+    {
+      "id": "audit-trail-sink",
+      "title": "Tamper-evident audit trail",
+      "summary": "Append-only ledger entries for each verdict so ship decisions carry durable provenance.",
+      "targetRelease": "1.0.0",
+      "theme": "trust"
+    },
+    {
+      "id": "agent-evidence",
+      "title": "Agent evidence ingestion",
+      "summary": "Let external agentic decisions feed the same confidence aggregator as first-class evidence without changing the math.",
+      "targetRelease": "1.0.0",
+      "theme": "trust"
+    },
+    {
+      "id": "agent-action-gating",
+      "title": "Agent-action and skill gating",
+      "summary": "Trust tiers for MCP tools — read-only discovery vs write-capable actions — so orchestrators can gate risky agent steps.",
+      "targetRelease": "post-1.0.0",
+      "theme": "trust"
+    },
+    {
+      "id": "golden-dataset-gate",
+      "title": "Golden dataset regression gate",
+      "summary": "15+ public sites across coverage tags with zero regressions in the final pre-1.0 sweep.",
+      "targetRelease": "1.0.0",
+      "theme": "release-confidence"
+    },
+    {
+      "id": "auth-intelligence-v1",
+      "title": "Full auth intelligence for 1.0",
+      "summary": "Harden auth exploration, login automation, and storage-state flows for production agent and CI use.",
+      "targetRelease": "1.0.0",
+      "theme": "release-confidence"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The public story was stale — roadmap metadata implied ~0.6.0 while **v0.10.0** is published on npm with additional shipped MCP tools. This PR adds a tracked `roadmap.json` and aligns the root README with reality.

## Changes

### `roadmap.json` (new, now tracked)

- **current / published:** `0.10.0` (read from `packages/core` and `packages/mcp`)
- **target:** `1.0.0`
- **Shipped capabilities** documented with MCP tool names:
  - `qulib_analyze_app` / `analyze_app`
  - `qulib_detect_auth` / `detect_auth`, `qulib_explore_auth` / `explore_auth`
  - `qulib_score_automation`, `qulib_score_api`, `qulib_score_confidence`
  - `qulib_scaffold_tests`, `qulib_diff`, `qulib_detect_prompt_leakage`
  - CI gate + core confidence/replay primitives
- **Planned** items framed toward **trust / release-confidence**: witnessed delivery traffic, human inbox, audit trail sink, agent evidence ingestion, and later agent-action/skill gating

Removed `roadmap.json` from `.gitignore` so the file is part of the public repo.

### `README.md`

- Added a **Status** line calling out v0.10.0 on npm and linking to `roadmap.json`
- Added `qulib_detect_prompt_leakage` to the MCP tool catalog
- Replaced vague phase labels on the 5 confidence views with explicit **Shipped / Planned** table
- Linked `roadmap.json` from the Documentation section

## Not in scope

- No version bump (docs/metadata only)
- No CHANGELOG entry required

## Verification

- `roadmap.json` validates as JSON
- Version strings match `packages/core/package.json` and `packages/mcp/package.json` (`0.10.0`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fa3b66f-1407-5c3e-8945-8d10caef5280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fa3b66f-1407-5c3e-8945-8d10caef5280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

