### PR TITLE
[task-20260623-0521-qulib-confidence-honesty-cursor-dispatch] fix(core): honest release-confidence — disclose uncollected sources, fix topRisks semantics, populate next-checks

### DIFF
--- a/packages/core/src/cli/__tests__/confidence.test.ts
+++ b/packages/core/src/cli/__tests__/confidence.test.ts
@@ -96,6 +96,35 @@ test('runConfidence --repo: api-coverage contribution present (may be not_applic
   assert.ok(apiContrib, 'api-coverage contribution should be present for repo input');
 });
 
+test('runConfidence --repo: partial run discloses uncollected sources in honestyNotes', async () => {
+  const { rc } = await confidence({ repo: MATURITY_REPO });
+  assert.ok(rc.honestyNotes.length > 0, 'repo-only partial runs must populate honestyNotes');
+  assert.ok(
+    rc.honestyNotes.some((n) => /Partial evidence:/i.test(n)),
+    'honestyNotes must include partial-evidence summary'
+  );
+  assert.ok(
+    rc.honestyNotes.some((n) => /live-app-quality/i.test(n)),
+    'honestyNotes must name uncollected app-runtime source'
+  );
+});
+
+test('runConfidence --repo: topRisks excludes automation maturity success strings', async () => {
+  const { rc } = await confidence({ repo: MATURITY_REPO });
+  assert.ok(
+    !rc.topRisks.some((r) => /Automation maturity: L\d/i.test(r)),
+    'topRisks must not list automation maturity achievements as risks'
+  );
+});
+
+test('runConfidence --repo: recommendedNextChecks suggests gathering skipped evidence', async () => {
+  const { rc } = await confidence({ repo: MATURITY_REPO });
+  assert.ok(
+    rc.recommendedNextChecks.some((r) => /analyze_app/i.test(r)),
+    'recommendedNextChecks must suggest analyze_app when app-runtime sources were skipped'
+  );
+});
+
 test('runConfidence --repo human report includes verdict and score', async () => {
   const { out } = await confidence({ repo: MATURITY_REPO });
   assert.match(out, /Release confidence for/i);

--- a/packages/core/src/cli/confidence-run.ts
+++ b/packages/core/src/cli/confidence-run.ts
@@ -58,6 +58,11 @@ export function formatConfidenceReport(rc: ReleaseConfidence, subjectRef: string
     for (const b of rc.blockers) lines.push(`    • ${b}`);
   }
 
+  if (rc.honestyNotes.length > 0) {
+    lines.push('  honesty notes:');
+    for (const n of rc.honestyNotes) lines.push(`    • ${n}`);
+  }
+
   lines.push('  contributions:');
   for (const c of rc.contributions) {
     const scoreLabel = c.score !== null ? `${c.score}/100` : 'n/a';
@@ -78,11 +83,6 @@ export function formatConfidenceReport(rc: ReleaseConfidence, subjectRef: string
   if (rc.recommendedNextChecks.length > 0) {
     lines.push('  recommended next checks:');
     for (const r of rc.recommendedNextChecks) lines.push(`    • ${r}`);
-  }
-
-  if (rc.honestyNotes.length > 0) {
-    lines.push('  honesty notes:');
-    for (const n of rc.honestyNotes) lines.push(`    • ${n}`);
   }
 
   return lines.join('\n');

--- a/packages/core/src/tools/scoring/__tests__/confidence.test.ts
+++ b/packages/core/src/tools/scoring/__tests__/confidence.test.ts
@@ -240,3 +240,83 @@ test('scoreFormula is documented on the result', () => {
   assert.ok(rc.scoreFormula, 'scoreFormula present');
   assert.match(rc.scoreFormula, /applicable/i);
 });
+
+// ---------------------------------------------------------------------------
+// G. Partial-run honesty (repoPath-only / subset of model sources)
+// ---------------------------------------------------------------------------
+
+function repoOnlyPartialInput(): ConfidenceInput {
+  const items = [
+    makeItem('test-automation', 96, 0.22, {
+      evidence: ['Automation maturity: L5 — advanced QA automation (score 96)'],
+      recommendations: ['Balance component vs E2E Cypress tests so critical flows stay fast in CI.'],
+      collector: { tool: 'qulib_score_automation', inputRef: '/repo/example' },
+    }),
+    makeItem('api-coverage', 100, 0.15, {
+      evidence: ['32/32 API endpoints appear covered by test files.'],
+      recommendations: [],
+      collector: { tool: 'qulib_score_api' },
+    }),
+  ];
+  return { subject: { kind: 'repo', ref: '/repo/example', tenantId: 'test' }, evidence: items };
+}
+
+test('partial model coverage: score/verdict/contributions unchanged (honesty-only projection)', () => {
+  const rc = computeReleaseConfidence(repoOnlyPartialInput());
+  const weightSum = 0.22 + 0.15;
+  const expectedScore = Math.round((96 * 0.22 + 100 * 0.15) / weightSum);
+  assert.equal(rc.confidenceScore, expectedScore);
+  assert.equal(rc.verdict, 'ship');
+  assert.equal(rc.contributions.length, 2);
+  const testAuto = rc.contributions.find((c) => c.source === 'test-automation');
+  assert.ok(testAuto);
+  assert.equal(testAuto!.score, 96);
+  assert.ok(Math.abs(testAuto!.effectiveWeight - 0.22 / weightSum) < 0.001);
+  const api = rc.contributions.find((c) => c.source === 'api-coverage');
+  assert.ok(api);
+  assert.equal(api!.score, 100);
+  assert.ok(Math.abs(api!.effectiveWeight - 0.15 / weightSum) < 0.001);
+});
+
+test('partial model coverage: honestyNotes discloses uncollected sources and coverage fraction', () => {
+  const rc = computeReleaseConfidence(repoOnlyPartialInput());
+  assert.ok(rc.honestyNotes.length > 0, 'honestyNotes must not be empty on partial runs');
+  assert.ok(
+    rc.honestyNotes.some((n) => /Partial evidence:/i.test(n) && /of 6 model sources/i.test(n)),
+    'honestyNotes must state N-of-M source coverage'
+  );
+  assert.ok(
+    rc.honestyNotes.some((n) => /live-app-quality/i.test(n) && /not collected/i.test(n)),
+    'honestyNotes must name an uncollected source'
+  );
+  assert.ok(
+    rc.honestyNotes.some((n) => /raw model weight/i.test(n)),
+    'honestyNotes must disclose raw weight coverage'
+  );
+});
+
+test('partial model coverage: topRisks excludes coverage successes and surfaces gaps', () => {
+  const rc = computeReleaseConfidence(repoOnlyPartialInput());
+  assert.ok(rc.topRisks.length > 0, 'topRisks should list partial-run risks');
+  assert.ok(
+    !rc.topRisks.some((r) => /appear covered/i.test(r)),
+    'topRisks must not treat endpoint coverage success as a risk'
+  );
+  assert.ok(
+    !rc.topRisks.some((r) => /Automation maturity: L5/i.test(r)),
+    'topRisks must not treat automation maturity success as a risk'
+  );
+  assert.ok(
+    rc.topRisks.some((r) => /Uncollected high-weight evidence/i.test(r)),
+    'topRisks must flag uncollected high-weight sources'
+  );
+});
+
+test('partial model coverage: recommendedNextChecks populated when sources skipped', () => {
+  const rc = computeReleaseConfidence(repoOnlyPartialInput());
+  assert.ok(rc.recommendedNextChecks.length > 0, 'recommendedNextChecks must not be empty');
+  assert.ok(
+    rc.recommendedNextChecks.some((r) => /analyze_app/i.test(r)),
+    'recommendedNextChecks must suggest running analyze_app for uncollected app-runtime sources'
+  );
+});

--- a/packages/core/src/tools/scoring/confidence.ts
+++ b/packages/core/src/tools/scoring/confidence.ts
@@ -27,6 +27,7 @@ import type {
   ConfidenceInput,
   ConfidencePolicy,
   EvidenceItem,
+  EvidenceSourceKind,
   ReleaseConfidence,
   ConfidenceVerdict,
 } from '../../schemas/confidence.schema.js';
@@ -52,6 +53,22 @@ const DEFAULT_WEIGHTS: Record<string, number> = {
   'doc-health': 0.0,
   'human-approval': 0.0,
   'agent-evidence': 0.0,
+};
+
+/** Model sources with non-zero default weight — the full evidence model for partial-run disclosure. */
+const MODEL_SOURCES: EvidenceSourceKind[] = (
+  Object.entries(DEFAULT_WEIGHTS)
+    .filter(([, weight]) => weight > 0)
+    .map(([source]) => source) as EvidenceSourceKind[]
+);
+
+const UNCOLLECTED_NEXT_CHECKS: Record<string, string> = {
+  'live-app-quality': 'Run analyze_app against the deployed URL to collect live-app quality evidence.',
+  'accessibility': 'Run analyze_app against the deployed URL to evaluate accessibility.',
+  'crawl-coverage': 'Run analyze_app against the deployed URL to measure crawl coverage.',
+  'test-automation': 'Run qulib score-automation against the repo to score test automation maturity.',
+  'api-coverage': 'Run qulib score-api against the repo to measure API test coverage.',
+  'ci-results': 'Ingest CI status from your pipeline (ci-results source not yet wired).',
 };
 
 interface ResolvedPolicy {
@@ -92,6 +109,115 @@ function buildHonestyNote(item: EvidenceItem): string {
     return `${base} ran but returned a null score${item.reason ? ': ' + item.reason : ''}.`;
   }
   return `${base} has partial or degraded signal.`;
+}
+
+function resolveModelWeight(source: string, policyWeights: Record<string, number> | undefined): number {
+  if (policyWeights && source in policyWeights) {
+    return policyWeights[source]!;
+  }
+  return DEFAULT_WEIGHTS[source] ?? 0;
+}
+
+function inferUncollectedReason(
+  source: string,
+  presentSources: Set<string>
+): string {
+  const hasAnalyzeEvidence =
+    presentSources.has('live-app-quality') ||
+    presentSources.has('accessibility') ||
+    presentSources.has('crawl-coverage');
+  const hasRepoEvidence =
+    presentSources.has('test-automation') || presentSources.has('api-coverage');
+
+  switch (source) {
+    case 'live-app-quality':
+    case 'accessibility':
+    case 'crawl-coverage':
+      return hasAnalyzeEvidence
+        ? 'not collected in this confidence run'
+        : 'app-runtime analysis not run — no url provided';
+    case 'test-automation':
+    case 'api-coverage':
+      return hasRepoEvidence
+        ? 'not collected in this confidence run'
+        : 'repo scoring not run — no repo provided';
+    case 'ci-results':
+      return 'CI status not ingested — no ci-results source wired';
+    default:
+      return 'not collected';
+  }
+}
+
+function buildUncollectedHonestyNote(source: string, reason: string, rawWeight: number): string {
+  const pct = Math.round(rawWeight * 100);
+  return `'${source}' not collected (${pct}% raw model weight): ${reason}.`;
+}
+
+function buildCoverageSummaryNote(
+  scoredSourceCount: number,
+  modelSourceCount: number,
+  rawWeightScored: number,
+  rawWeightModel: number
+): string {
+  const coveragePct = rawWeightModel > 0 ? Math.round((rawWeightScored / rawWeightModel) * 100) : 0;
+  return (
+    `Partial evidence: verdict computed on ${scoredSourceCount} of ${modelSourceCount} model sources ` +
+    `(~${coveragePct}% of raw model weight). Collected weights were renormalized to 100% for the score.`
+  );
+}
+
+function isPositiveEvidence(text: string): boolean {
+  if (/appear covered/i.test(text)) return true;
+  if (/Automation maturity: L\d/i.test(text)) return true;
+  if (/No a11y gaps/i.test(text)) return true;
+  if (/^L\d —/i.test(text)) return true;
+  if (/^releaseConfidence=/i.test(text)) return true;
+  if (/^coverageScore=/i.test(text)) return true;
+  if (/^No .* gaps detected/i.test(text)) return true;
+  return false;
+}
+
+function extractItemRisks(item: EvidenceItem, passThreshold: number): string[] {
+  const risks: string[] = [];
+
+  if (item.blocking) {
+    if (item.reason) risks.push(item.reason);
+    risks.push(...item.evidence.filter((entry) => !isPositiveEvidence(entry)));
+    return risks;
+  }
+
+  const applicability = item.applicability ?? 'applicable';
+  if (applicability === 'unknown' || item.score === null) {
+    if (item.reason) risks.push(`${item.source}: ${item.reason}`);
+    risks.push(
+      ...item.evidence.filter(
+        (entry) => !isPositiveEvidence(entry) && /(gap|critical|high|untested|uncovered|missing|block|fail|warning|auth|blocked)/i.test(entry)
+      )
+    );
+    return risks;
+  }
+
+  if (applicability === 'not_applicable') {
+    if (item.reason) risks.push(`${item.source}: ${item.reason}`);
+    return risks;
+  }
+
+  if (item.score !== null && item.score < passThreshold) {
+    risks.push(...item.evidence.filter((entry) => !isPositiveEvidence(entry)));
+    if (item.score < passThreshold) {
+      risks.push(`${item.source} scored ${item.score}/100 — below pass threshold (${passThreshold}).`);
+    }
+  } else {
+    risks.push(
+      ...item.evidence.filter(
+        (entry) =>
+          !isPositiveEvidence(entry) &&
+          /(gap|critical|high|untested|uncovered|missing|block|fail|warning|penalty|below)/i.test(entry)
+      )
+    );
+  }
+
+  return risks;
 }
 
 /**
@@ -178,12 +304,28 @@ export function computeReleaseConfidence(input: ConfidenceInput): ReleaseConfide
   // Level / label from shared ladder.
   const { level, label } = scoreLevel(confidenceScore ?? 0);
 
-  // Honesty notes — one per degraded/excluded source.
+  const presentSources = new Set(input.evidence.map((item) => item.source));
+  const uncollectedSources = MODEL_SOURCES.filter((source) => !presentSources.has(source));
+  const modelWeightSum = MODEL_SOURCES.reduce(
+    (sum, source) => sum + resolveModelWeight(source, policy.weights),
+    0
+  );
+
+  // Honesty notes — partial-run summary first, then uncollected, then degraded/excluded collected sources.
   const honestyNotes: string[] = [];
+  if (uncollectedSources.length > 0 || (weightSum > 0 && weightSum < modelWeightSum - 0.001)) {
+    honestyNotes.push(
+      buildCoverageSummaryNote(applicable.length, MODEL_SOURCES.length, weightSum, modelWeightSum)
+    );
+  }
+  for (const source of uncollectedSources) {
+    const rawWeight = resolveModelWeight(source, policy.weights);
+    const reason = inferUncollectedReason(source, presentSources);
+    honestyNotes.push(buildUncollectedHonestyNote(source, reason, rawWeight));
+  }
   for (const item of excluded) {
     honestyNotes.push(buildHonestyNote(item));
   }
-  // Also note any blocking items that aren't in the excluded set.
   for (const item of blockingItems) {
     if ((item.applicability ?? 'applicable') === 'applicable' && item.score !== null) {
       honestyNotes.push(
@@ -192,19 +334,36 @@ export function computeReleaseConfidence(input: ConfidenceInput): ReleaseConfide
     }
   }
 
-  // Top risks — merge evidence across sources, severity-sorted by position.
-  const allRisks: string[] = [
-    ...blockingItems.flatMap((item) => item.evidence),
-    ...input.evidence
-      .filter((item) => (item.applicability ?? 'applicable') === 'applicable')
-      .sort((a, b) => (a.score ?? 0) - (b.score ?? 0))
-      .flatMap((item) => item.evidence),
-  ];
-  const topRisks = [...new Set(allRisks)].slice(0, limit);
+  // Top risks — gaps and blockers only; never surface coverage successes as risks.
+  const allRisks: string[] = [];
+  for (const source of uncollectedSources) {
+    const rawWeight = resolveModelWeight(source, policy.weights);
+    if (rawWeight >= 0.10) {
+      const reason = inferUncollectedReason(source, presentSources);
+      allRisks.push(
+        `Uncollected high-weight evidence: ${source} (${Math.round(rawWeight * 100)}% raw weight) — ${reason}.`
+      );
+    }
+  }
+  for (const item of blockingItems) {
+    allRisks.push(...extractItemRisks(item, policy.passThreshold));
+  }
+  for (const item of [...excluded].sort((a, b) => resolveWeight(a, policy.weights) - resolveWeight(b, policy.weights))) {
+    allRisks.push(...extractItemRisks(item, policy.passThreshold));
+  }
+  for (const item of [...applicable].sort((a, b) => (a.score ?? 0) - (b.score ?? 0))) {
+    allRisks.push(...extractItemRisks(item, policy.passThreshold));
+  }
+  const topRisks = [...new Set(allRisks.filter(Boolean))].slice(0, limit);
 
-  // Recommended next checks — merge and deduplicate.
-  const allRecs: string[] = input.evidence.flatMap((item) => item.recommendations ?? []);
-  const recommendedNextChecks = [...new Set(allRecs)].slice(0, limit);
+  // Recommended next checks — concrete actions for uncollected sources plus per-item recommendations.
+  const allRecs: string[] = [];
+  for (const source of uncollectedSources) {
+    const rec = UNCOLLECTED_NEXT_CHECKS[source];
+    if (rec) allRecs.push(rec);
+  }
+  allRecs.push(...input.evidence.flatMap((item) => item.recommendations ?? []));
+  const recommendedNextChecks = [...new Set(allRecs.filter(Boolean))].slice(0, limit);
 
   const result = {
     schemaVersion: 1 as const,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this PR does

Fixes three release-confidence honesty/labeling gaps in `computeReleaseConfidence` when only a subset of model evidence sources are collected (e.g. repoPath-only runs). Scoring math, verdict ladder, and `contributions[]` numbers are unchanged — this is projection/honesty only.

## Why

Dogfooding `qulib_score_confidence` with repoPath-only input produced a clean `ship`/high-score verdict from ~37% of raw model weight with empty `honestyNotes`, success strings in `topRisks`, and empty `recommendedNextChecks`. That violates qulib's honest "should we ship?" intent.

## Changes

1. **honestyNotes (P1):** Detect uncollected model sources, prepend a partial-evidence summary (`N of M sources`, raw weight %), and name each missing source with context-aware reasons (e.g. "no url provided").
2. **topRisks (P2):** Filter positive coverage/maturity success strings; surface uncollected high-weight sources, excluded/degraded signals, and low-scoring dimensions instead.
3. **recommendedNextChecks (P3):** Add concrete next-evidence actions for uncollected sources (analyze_app, score-automation, CI ingestion) alongside existing per-item recommendations.
4. **CLI report:** Move honesty notes above contributions so partial-evidence disclosure is harder to miss.

## Type

- [x] Bug fix

## Checklist

- [x] Branched from `main`
- [x] `npm run build` passes
- [x] `npm test` passes
- [x] Commit messages follow `type: short description`
- [x] No new dependencies added
- [x] Output remains honest

## Related issues

QULIB-confidence-honesty-dogfood (TapeshN/projects/3)

## Test plan

- Added unit tests in `confidence.test.ts` for partial model coverage.
- Added CLI integration tests for `--repo` partial runs.
- `npm run build && npm test` green.

Branch: `tap/sor-dispatch` (also pushed as `cursor/qulib-confidence-honesty-labeling-1043`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05ace5a8-5aa7-42d5-a24e-941a703248a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05ace5a8-5aa7-42d5-a24e-941a703248a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

